### PR TITLE
Support alternative resolvers for block/allowlist matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,17 @@ Query blocklists can be added to resolver-chains to prevent further processing a
   - `*.domain.com` matches all subdomains but not domain.com. Only one wildcard (at the start of the string) is allowed.
 - `hosts` - A blocklist in hosts-file format. If a non-zero IP address is provided for a record, the response is spoofed rather than returning NXDOMAIN.
 
+The following options are supported by the `blocklist-v2` type:
+
+- `blocklist-resolver` - Alternative resolver for queries matching the blocklist, rather than responding with NXDOMAIN.
+- `blocklist-format` - The format the blocklist is provided in. Only used if `blocklist-source` is not provided.
+- `blocklist-refresh` - Time interval in which external (remote or local) blocklists are reloaded.
+- `blocklist-soure` - An array of blocklists, each with `format` and `source`.
+- `allowlist-resolver` - Alternative resolver for queries matching the allowlist, rather than forwarding to the default resolver.
+- `allowlist-format` - The format the allowlist is provided in. Only used if `allowlist-source` is not provided.
+- `allowlist-refresh` - Time interval in which external (remote or local) allowlists are reloaded.
+- `allowlist-soure` - An array of allowlists, each with `format` and `source`.
+
 Multiple blocklists of different types can be chained in the same configuration. Example of a regexp-based blocklist:
 
 ```toml
@@ -281,6 +292,7 @@ blocklist-source = [
    {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.domain.list"},
    {format = "regexp", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.regexp.list"},
 ]
+allowlist-resolver = "trusted-resolver" # Send anything on the allowlist to a different upstream resolver (optional)
 allowlist-refresh = 86400
 allowlist-source = [
    {format = "domain", source = "/path/to/trustworthy.list"},

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -60,14 +60,16 @@ type group struct {
 	Source    string   // Location of external blocklist, can be a local path or remote URL
 	Refresh   int      // Blocklist refresh when using an external source, in seconds
 
-	// Advanced blocklist
-	BlocklistFormat  string   `toml:"blocklist-format"` // only used for static blocklists in the config
-	BlocklistSource  []list   `toml:"blocklist-source"`
-	BlocklistRefresh int      `toml:"blocklist-refresh"`
-	Allowlist        []string // Rules to override the blocklist rules
-	AllowlistFormat  string   `toml:"allowlist-format"` // only used for static allowlists in the config
-	AllowlistSource  []list   `toml:"allowlist-source"`
-	AllowlistRefresh int      `toml:"allowlist-refresh"`
+	// Blocklist-v2 options
+	BlockListResolver string   `toml:"blocklist-resolver"`
+	AllowListResolver string   `toml:"allowlist-resolver"`
+	BlocklistFormat   string   `toml:"blocklist-format"` // only used for static blocklists in the config
+	BlocklistSource   []list   `toml:"blocklist-source"`
+	BlocklistRefresh  int      `toml:"blocklist-refresh"`
+	Allowlist         []string // Rules to override the blocklist rules
+	AllowlistFormat   string   `toml:"allowlist-format"` // only used for static allowlists in the config
+	AllowlistSource   []list   `toml:"allowlist-source"`
+	AllowlistRefresh  int      `toml:"allowlist-refresh"`
 }
 
 // Block/Allowlist items for blocklist-v2

--- a/cmd/routedns/example-config/blocklist-resolver.toml
+++ b/cmd/routedns/example-config/blocklist-resolver.toml
@@ -1,0 +1,39 @@
+# Simple configuration for "blocklist-v2" that uses alternative resolvers for
+# queries that match the allowlist or blocklist. The default behavior is to
+# return NXDOMAIN for any item that matches the blocklist but not the allowlist.
+# With resolvers, it's possible to send queries to different resolvers based
+# on them matching the allowlist or blocklist. Similar to a router.
+
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[resolvers.google-dot]
+address = "8.8.8.8:853"
+protocol = "dot"
+
+[groups.cloudflare-blocklist]
+type             = "blocklist-v2"
+resolvers        = ["cloudflare-dot"] # Default upstream resolver for anything not matching either list
+blocklist-resolver = "google-dot" # Resolver used for anything matching the blocklist (and not on the allowlist)
+blocklist-format = "domain"
+blocklist = [
+  'evil.com',
+  '.facebook.com',
+  '*.twitter.com',
+]
+allowlist-resolver = "cloudflare-dot" # Resolver for anything on the allowlist
+allowlist-format = "domain"
+allowlist = [                # Allowlist items override/bypass blocklist items
+  'allowed.facebook.com',
+]
+
+[listeners.local-udp]
+address = ":53"
+protocol = "udp"
+resolver = "cloudflare-blocklist"
+
+[listeners.local-tcp]
+address = ":53"
+protocol = "tcp"
+resolver = "cloudflare-blocklist"

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -119,6 +119,13 @@ func start(opt options, args []string) error {
 			return fmt.Errorf("duplicate name: %s", id)
 		}
 		deps[id] = g.Resolvers
+		// Some groups have additional resolvers, add those here.
+		if g.BlockListResolver != "" {
+			deps[id] = append(deps[id], g.BlockListResolver)
+		}
+		if g.AllowListResolver != "" {
+			deps[id] = append(deps[id], g.AllowListResolver)
+		}
 	}
 	for id, r := range config.Routers {
 		_, ok := deps[id]
@@ -303,10 +310,12 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 			}
 		}
 		opt := rdns.BlocklistOptions{
-			BlocklistDB:      blocklistDB,
-			BlocklistRefresh: time.Duration(g.BlocklistRefresh) * time.Second,
-			AllowlistDB:      allowlistDB,
-			AllowlistRefresh: time.Duration(g.AllowlistRefresh) * time.Second,
+			BlocklistResolver: resolvers[g.BlockListResolver],
+			BlocklistDB:       blocklistDB,
+			BlocklistRefresh:  time.Duration(g.BlocklistRefresh) * time.Second,
+			AllowListResolver: resolvers[g.AllowListResolver],
+			AllowlistDB:       allowlistDB,
+			AllowlistRefresh:  time.Duration(g.AllowlistRefresh) * time.Second,
 		}
 		resolvers[id], err = rdns.NewBlocklist(gr[0], opt)
 		if err != nil {


### PR DESCRIPTION
Implements new blocklist-v2 options `blocklist-resolver` and `allowlist-resolver` as per  https://github.com/folbricht/routedns/issues/21