### PR TITLE
Allow filtering of responses in addition to blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Rather than filtering queries, response blocklists evaluate the response to a qu
 - `response-blocklist-cidr` blocks backed on IP networks (in CIDR notation) on A or AAAA responses.
 - `response-blocklist-name` filters based on domain names in CNAME, MX, NS, PRT and SRV records.
 
-The configuration options of response blocklists are very similar to that of [query blocklists](#Queryblocklists) with the exception of the allowlists options which are not currently supported. If the `filter` option is set to `true`, matching records will be removed from responses rather than the whole response.
+The configuration options of response blocklists are very similar to that of [query blocklists](#Queryblocklists) with the exception of the allowlists options which are not currently supported. If the `filter` option is set to `true` in `response-blocklist-cidr`, matching records will be removed from responses rather than the whole response. If there is no answer record left after applying the filter, NXDOMAIN will be returned.
 
 Examples of simple response blocklists with static rules in the configuration file.
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Rather than filtering queries, response blocklists evaluate the response to a qu
 - `response-blocklist-cidr` blocks backed on IP networks (in CIDR notation) on A or AAAA responses.
 - `response-blocklist-name` filters based on domain names in CNAME, MX, NS, PRT and SRV records.
 
-The configuration options of response blocklists are very similar to that of [query blocklists](#Queryblocklists) with the exception of the allowlists options which are not currently supported.
+The configuration options of response blocklists are very similar to that of [query blocklists](#Queryblocklists) with the exception of the allowlists options which are not currently supported. If the `filter` option is set to `true`, matching records will be removed from responses rather than the whole response.
 
 Examples of simple response blocklists with static rules in the configuration file.
 

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -61,6 +61,7 @@ type group struct {
 	Refresh   int      // Blocklist refresh when using an external source, in seconds
 
 	// Blocklist-v2 options
+	Filter            bool     // Filter response records rather than return NXDOMAIN
 	BlockListResolver string   `toml:"blocklist-resolver"`
 	AllowListResolver string   `toml:"allowlist-resolver"`
 	BlocklistFormat   string   `toml:"blocklist-format"` // only used for static blocklists in the config

--- a/cmd/routedns/example-config/response-blocklist-cidr-resolver.toml
+++ b/cmd/routedns/example-config/response-blocklist-cidr-resolver.toml
@@ -1,0 +1,32 @@
+# Shows how to use an alternative blocklist-resolver with a response blocklist.
+# 1) the query is sent to the default resolver ("default-do")
+# 2) if the response contains an item on the blocklist and a blocklist-resolver
+#    is configured, the query will be sent there instead. Note, the response from
+#    blocklist-resolver is not re-evaluated.
+
+[resolvers.default-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[resolvers.alternate-dot]
+address = "8.8.8.8:853"
+protocol = "dot"
+
+[groups.cloudflare-blocklist]
+type               = "response-blocklist-cidr"
+resolvers          = ["default-dot"] # Default resolver, all queries are sent here first
+blocklist-resolver = "alternate-dot" # Use this resolver when a response matches the blocklist
+blocklist          = [
+  '127.0.0.0/24',
+  '157.240.0.0/16',
+]
+
+[listeners.local-udp]
+address = ":53"
+protocol = "udp"
+resolver = "cloudflare-blocklist"
+
+[listeners.local-tcp]
+address = ":53"
+protocol = "tcp"
+resolver = "cloudflare-blocklist"

--- a/cmd/routedns/example-config/response-blocklist-cidr.toml
+++ b/cmd/routedns/example-config/response-blocklist-cidr.toml
@@ -9,6 +9,7 @@ blocklist           = [
   '127.0.0.0/24',
   '157.240.0.0/16',
 ]
+#filter = true # Set to true if the response RRs should be filtered rather than returning NXDOMAIN (default)
 
 [listeners.local-udp]
 address = ":53"

--- a/cmd/routedns/example-config/response-blocklist-name-resolver.toml
+++ b/cmd/routedns/example-config/response-blocklist-name-resolver.toml
@@ -1,0 +1,33 @@
+# Shows how to use an alternative blocklist-resolver with a response blocklist.
+# 1) the query is sent to the default resolver ("default-do")
+# 2) if the response contains an item on the blocklist and a blocklist-resolver
+#    is configured, the query will be sent there instead. Note, the response from
+#    blocklist-resolver is not re-evaluated.
+
+[resolvers.default-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[resolvers.alternate-dot]
+address = "8.8.8.8:853"
+protocol = "dot"
+
+[groups.cloudflare-blocklist]
+type               = "response-blocklist-name"
+resolvers          = ["default-dot"] # Default resolver, all queries are sent here first
+blocklist-resolver = "alternate-dot" # Use this resolver when a response matches the blocklist
+blocklist-format   = "domain"
+blocklist          = [
+  'ns.evil.com.',
+  '*.acme.test',
+]
+
+[listeners.local-udp]
+address = ":53"
+protocol = "udp"
+resolver = "cloudflare-blocklist"
+
+[listeners.local-tcp]
+address = ":53"
+protocol = "tcp"
+resolver = "cloudflare-blocklist"

--- a/cmd/routedns/example-config/response-blocklist-name.toml
+++ b/cmd/routedns/example-config/response-blocklist-name.toml
@@ -7,9 +7,10 @@ type             = "response-blocklist-name"
 resolvers        = ["cloudflare-dot"]
 blocklist-format = "domain"
 blocklist        = [
-  'ns.evil.com',
+  'controlpanel.evil.com.',
   '*.acme.test',
 ]
+#filter = true # Set to true if the response RRs should be filtered rather than returning NXDOMAIN (default)
 
 [listeners.local-udp]
 address = ":53"

--- a/cmd/routedns/example-config/response-blocklist-name.toml
+++ b/cmd/routedns/example-config/response-blocklist-name.toml
@@ -7,7 +7,7 @@ type             = "response-blocklist-name"
 resolvers        = ["cloudflare-dot"]
 blocklist-format = "domain"
 blocklist        = [
-  'controlpanel.evil.com.',
+  'ns.evil.com.',
   '*.acme.test',
 ]
 #filter = true # Set to true if the response RRs should be filtered rather than returning NXDOMAIN (default)

--- a/cmd/routedns/example-config/response-blocklist-name.toml
+++ b/cmd/routedns/example-config/response-blocklist-name.toml
@@ -10,7 +10,6 @@ blocklist        = [
   'ns.evil.com.',
   '*.acme.test',
 ]
-#filter = true # Set to true if the response RRs should be filtered rather than returning NXDOMAIN (default)
 
 [listeners.local-udp]
 address = ":53"

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -382,6 +382,7 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 		opt := rdns.ResponseBlocklistCIDROptions{
 			BlocklistDB:      blocklistDB,
 			BlocklistRefresh: time.Duration(g.BlocklistRefresh) * time.Second,
+			Filter:           g.Filter,
 		}
 		resolvers[id], err = rdns.NewResponseBlocklistCIDR(gr[0], opt)
 		if err != nil {
@@ -417,6 +418,7 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 		opt := rdns.ResponseBlocklistNameOptions{
 			BlocklistDB:      blocklistDB,
 			BlocklistRefresh: time.Duration(g.BlocklistRefresh) * time.Second,
+			Filter:           g.Filter,
 		}
 		resolvers[id], err = rdns.NewResponseBlocklistName(gr[0], opt)
 		if err != nil {

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -380,9 +380,10 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 			}
 		}
 		opt := rdns.ResponseBlocklistCIDROptions{
-			BlocklistDB:      blocklistDB,
-			BlocklistRefresh: time.Duration(g.BlocklistRefresh) * time.Second,
-			Filter:           g.Filter,
+			BlocklistResolver: resolvers[g.BlockListResolver],
+			BlocklistDB:       blocklistDB,
+			BlocklistRefresh:  time.Duration(g.BlocklistRefresh) * time.Second,
+			Filter:            g.Filter,
 		}
 		resolvers[id], err = rdns.NewResponseBlocklistCIDR(gr[0], opt)
 		if err != nil {
@@ -416,9 +417,9 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 			}
 		}
 		opt := rdns.ResponseBlocklistNameOptions{
-			BlocklistDB:      blocklistDB,
-			BlocklistRefresh: time.Duration(g.BlocklistRefresh) * time.Second,
-			Filter:           g.Filter,
+			BlocklistResolver: resolvers[g.BlockListResolver],
+			BlocklistDB:       blocklistDB,
+			BlocklistRefresh:  time.Duration(g.BlocklistRefresh) * time.Second,
 		}
 		resolvers[id], err = rdns.NewResponseBlocklistName(gr[0], opt)
 		if err != nil {

--- a/message.go
+++ b/message.go
@@ -9,3 +9,11 @@ func qName(q *dns.Msg) string {
 	}
 	return q.Question[0].Name
 }
+
+// Returns a NXDOMAIN answer for a query.
+func nxdomain(q *dns.Msg) *dns.Msg {
+	a := new(dns.Msg)
+	a.SetReply(q)
+	a.SetRcode(q, dns.RcodeNameError)
+	return a
+}


### PR DESCRIPTION
Implements #22. Support filtering response records rather than completely blocking them in `response-blocklist-name` and `response-blocklist-cidr` by setting the `filter` option to true.