### PR TITLE
Cache based on query and ECS subnet address

### DIFF
--- a/cmd/routedns/example-config/cache.toml
+++ b/cmd/routedns/example-config/cache.toml
@@ -14,8 +14,3 @@ cache-negative-ttl = 10         # Optional, TTL to apply to responses without a 
 address = "127.0.0.1:53"
 protocol = "udp"
 resolver = "cloudflare-cached"
-
-[listeners.local-tcp]
-address = "127.0.0.1:53"
-protocol = "tcp"
-resolver = "cloudflare-cached"

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -242,7 +242,7 @@ Example config files: [doq-listener.toml](../cmd/routedns/example-config/doq-lis
 
 ### Cache
 
-A cache will store the responses to queries in memory and respond to further identical queries with the same response. To determine how long an item is kept in memory, the cache uses the lowest TTL of the RRs in the response. Responses served from the cache have their TTL updated according to the time the records spent in memory.
+A cache will store the responses to queries in memory and respond to further identical queries with the same response. To determine how long an item is kept in memory, the cache uses the lowest TTL of the RRs in the response. Responses served from the cache have their TTL updated according to the time the records spent in memory. If a query has an [ECS Subnet](https://tools.ietf.org/html/rfc7871) option, the subnet address forms part of they key to support subnet-specific answers.
 
 Caches can be combined with a [TTL Modifier](#TTL-Modifier) to avoid too many cache-misses due to excessively low TTL values.
 


### PR DESCRIPTION
Includes the ECS subnet address (if available) in the key when caching responses to allow caching different responses for different locations.

Implements #61 