### PR TITLE
Support X-Forwarded-For when it comes from a trusted proxy

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -28,6 +28,12 @@ type listener struct {
 	ServerCrt  string   `toml:"server-crt"`
 	MutualTLS  bool     `toml:"mutual-tls"`
 	AllowedNet []string `toml:"allowed-net"`
+	DoH        dohListener
+}
+
+// DoH-specific resolver options
+type dohListener struct {
+	ProxyAddr  string   `toml:"trusted-proxy"`
 }
 
 type resolver struct {

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -33,7 +33,7 @@ type listener struct {
 
 // DoH-specific resolver options
 type dohListener struct {
-	ProxyAddr  string   `toml:"trusted-proxy"`
+	HTTPProxyAddr string `toml:"trusted-proxy"`
 }
 
 type resolver struct {

--- a/cmd/routedns/example-config/doh-behind-proxy.toml
+++ b/cmd/routedns/example-config/doh-behind-proxy.toml
@@ -1,0 +1,15 @@
+# Server-side of a simple DNS-over-HTTPS proxy that is behind a reverse proxy.
+# The X-Forwarded-For header from the reverse proxy (trusted-proxy: 192.168.1.2)
+# will be used to determine the client address.
+
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[listeners.local-doh-quic]
+address = ":443"
+protocol = "doh"
+resolver = "cloudflare-dot"
+server-crt = "example-config/server.crt"
+server-key = "example-config/server.key"
+trusted-proxy = "192.168.1.2"

--- a/cmd/routedns/example-config/doh-behind-proxy.toml
+++ b/cmd/routedns/example-config/doh-behind-proxy.toml
@@ -1,12 +1,12 @@
-# Server-side of a simple DNS-over-HTTPS proxy that is behind a reverse proxy.
-# The X-Forwarded-For header from the reverse proxy (trusted-proxy: 192.168.1.2)
+# Server-side of a DNS-over-HTTPS proxy that is behind an HTTP reverse proxy.
+# The X-Forwarded-For header provided by the trusted-proxy (on 192.168.1.2)
 # will be used to determine the client address.
 
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"
 
-[listeners.local-doh-quic]
+[listeners.local-doh-behind-proxy]
 address = ":443"
 protocol = "doh"
 resolver = "cloudflare-dot"

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -244,15 +244,15 @@ func start(opt options, args []string) error {
 			if err != nil {
 				return err
 			}
-			proxyAddr := net.ParseIP(l.DoH.ProxyAddr)
-			if l.DoH.ProxyAddr != "" && proxyAddr == nil {
-				return fmt.Errorf("listener '%s' proxy-address '%s' is not an IPv4 or IPv6 address", id, l.DoH.ProxyAddr)
+			httpProxyAddr := net.ParseIP(l.DoH.HTTPProxyAddr)
+			if l.DoH.HTTPProxyAddr != "" && httpProxyAddr == nil {
+				return fmt.Errorf("listener '%s' proxy-address '%s' is not an IPv4 or IPv6 address", id, l.DoH.HTTPProxyAddr)
 			}
 			opt := rdns.DoHListenerOptions{
 				TLSConfig:     tlsConfig,
 				ListenOptions: opt,
 				Transport:     l.Transport,
-				ProxyAddr:     &proxyAddr,
+				HTTPProxyAddr: httpProxyAddr,
 			}
 			ln, err := rdns.NewDoHListener(id, l.Address, opt, resolver)
 			if err != nil {

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -244,7 +244,17 @@ func start(opt options, args []string) error {
 			if err != nil {
 				return err
 			}
-			ln, err := rdns.NewDoHListener(id, l.Address, rdns.DoHListenerOptions{TLSConfig: tlsConfig, ListenOptions: opt, Transport: l.Transport}, resolver)
+			proxyAddr := net.ParseIP(l.DoH.ProxyAddr)
+			if l.DoH.ProxyAddr != "" && proxyAddr == nil {
+				return fmt.Errorf("listener '%s' proxy-address '%s' is not an IPv4 or IPv6 address", id, l.DoH.ProxyAddr)
+			}
+			opt := rdns.DoHListenerOptions{
+				TLSConfig:     tlsConfig,
+				ListenOptions: opt,
+				Transport:     l.Transport,
+				ProxyAddr:     &proxyAddr,
+			}
+			ln, err := rdns.NewDoHListener(id, l.Address, opt, resolver)
 			if err != nil {
 				return err
 			}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -118,6 +118,10 @@ Secure listeners, such as DNS-over-TLS, DNS-over-HTTPS, DNS-over-DTLS, DNS-over-
 - `ca` - CA to validate client certificated. Optional. Uses the operating system's CA store by default.
 - `mutual-tls` - Requires clients to send valid (as per `ca` option) certificates before establishing a connection. Optional.
 
+The DNS-over-HTTPS listener also accepts the client IP address from a trusted reverse proxy. X-Forwarded-For headers are only used if they are provided from this address
+
+- `trusted-proxy` - IP address of trusted reverse proxy. Optional.
+
 ### Plain DNS
 
 Regular (insecure) DNS protocol over port 53, UDP and TCP. Setting `protocol` to `udp` will start a UDP listener, and `tcp` starts a TCP listener. In many cases both are present in a configuration if RouteDNS is used to provide DNS to local services over the loopback device.
@@ -197,7 +201,19 @@ server-crt = "example-config/server.crt"
 server-key = "example-config/server.key"
 ```
 
-Example config files: [mutual-tls-doh-server.toml](../cmd/routedns/example-config/mutual-tls-doh-server.toml), [doh-quic-server.toml](../cmd/routedns/example-config/doh-quic-server.toml)
+DoH behind a reverse proxy. Clients are expected to connect to the reverse proxy, which will provide their IP address in the X-Forwarded-For header. RouteDNS will trust this header from the proxy listed in `trusted-proxy`
+
+```toml
+[listeners.local-doh]
+address = ":443"
+protocol = "doh"
+resolver = "cloudflare-dot"
+server-crt = "/path/to/server.crt"
+server-key = "/path/to/server.key"
+trusted-proxy = "192.168.1.2"
+```
+
+Example config files: [mutual-tls-doh-server.toml](../cmd/routedns/example-config/mutual-tls-doh-server.toml), [doh-quic-server.toml](../cmd/routedns/example-config/doh-quic-server.toml), [doh-behind-proxy.toml](../cmd/routedns/example-config/doh-behind-proxy.toml)
 
 ### DNS-over-DTLS
 

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -45,7 +45,7 @@ type DoHListenerOptions struct {
 	TLSConfig *tls.Config
 
 	// IP(v4/v6) of a known reverse proxy in front of this server.
-	ProxyAddr *net.IP
+	HTTPProxyAddr net.IP
 }
 
 // NewDoHListener returns an instance of a DNS-over-HTTPS listener.
@@ -174,13 +174,13 @@ func (s *DoHListener) extractClientAddress(r *http.Request) net.IP {
 	xForwardedFor := r.Header.Get("X-Forwarded-For")
 
 	// Simple case: No proxy (or empty/long X-Forwarded-For).
-	if s.opt.ProxyAddr == nil || xForwardedFor == "" || len(xForwardedFor) >= 1024 {
+	if s.opt.HTTPProxyAddr == nil || xForwardedFor == "" || len(xForwardedFor) >= 1024 {
 		return clientIP
 	}
 
 	// If our client is a reverse proxy then use the last entry in X-Forwarded-For.
 	chain := strings.Split(xForwardedFor, ", ")
-	if clientIP != nil && s.opt.ProxyAddr.Equal(clientIP) {
+	if clientIP != nil && s.opt.HTTPProxyAddr.Equal(clientIP) {
 		if ip := net.ParseIP(chain[len(chain)-1]); ip != nil {
 			// Ignore XFF whe the client is local to the proxy.
 			if !ip.IsLoopback() {

--- a/dohlistener_test.go
+++ b/dohlistener_test.go
@@ -204,6 +204,14 @@ func TestClientBehindProxy(t *testing.T) {
 	r.Header.Add("X-Forwarded-For", "192.168.1.2, 10.0.1.6")
 	client = s.extractClientAddress(r)
 	require.Equal(t, "10.0.1.6", client.String())
+
+	// Our proxy is behind an untrusted proxy (10.0.1.6), ignore XFF.
+	// In the future we might parse XFF to determine the client is 192.168.1.2.
+	r, _ = http.NewRequest("GET", "https://www.example.com", nil)
+	r.RemoteAddr = "10.0.1.6:1234"
+	r.Header.Add("X-Forwarded-For", "192.168.1.2, 10.0.0.2")
+	client = s.extractClientAddress(r)
+	require.Equal(t, "10.0.1.6", client.String())
 }
 
 func TestIPv6Proxy(t *testing.T) {

--- a/dohlistener_test.go
+++ b/dohlistener_test.go
@@ -227,9 +227,9 @@ func TestIPv6Proxy(t *testing.T) {
 
 	// There is no proxy.
 	r, _ := http.NewRequest("GET", "https://www.example.com", nil)
-	r.RemoteAddr = "[2001:4860:4860::8]:1234"
+	r.RemoteAddr = "[2001:4860:4860::1]:1234"
 	client := s.extractClientAddress(r)
-	require.Equal(t, "2001:4860:4860::8", client.String())
+	require.Equal(t, "2001:4860:4860::1", client.String())
 
 	// The client is our proxy.
 	r, _ = http.NewRequest("GET", "https://www.example.com", nil)

--- a/dohlistener_test.go
+++ b/dohlistener_test.go
@@ -55,8 +55,8 @@ func TestDoHListenerSimple(t *testing.T) {
 	// The upstream resolver should have seen the query
 	require.Equal(t, 2, upstream.HitCount())
 
-	// The listener should not use X-Forwarded-For if ProxyAddr is not set.
-	require.Nil(t, s.opt.ProxyAddr)
+	// The listener should not use X-Forwarded-For if HTTPProxyAddr is not set.
+	require.Nil(t, s.opt.HTTPProxyAddr)
 	r, _ := http.NewRequest("GET", "https://www.example.com", nil)
 	r.RemoteAddr = "10.0.0.2:1234"
 	r.Header.Add("X-Forwarded-For", "10.0.1.3")
@@ -145,11 +145,11 @@ func TestClientBehindProxy(t *testing.T) {
 
 	expectedProxyAddr := "10.0.0.2"
 	proxyAddr := net.ParseIP(expectedProxyAddr)
-	s, err := NewDoHListener("test-doh", addr, DoHListenerOptions{TLSConfig: tlsServerConfig, ProxyAddr: &proxyAddr}, upstream)
+	s, err := NewDoHListener("test-doh", addr, DoHListenerOptions{TLSConfig: tlsServerConfig, HTTPProxyAddr: proxyAddr}, upstream)
 	require.NoError(t, err)
 
 	// Verify that the ProxyAddr has been set.
-	require.Equal(t, expectedProxyAddr, s.opt.ProxyAddr.String())
+	require.Equal(t, expectedProxyAddr, s.opt.HTTPProxyAddr.String())
 
 	// There is no proxy.
 	r, _ := http.NewRequest("GET", "https://www.example.com", nil)
@@ -227,11 +227,11 @@ func TestIPv6Proxy(t *testing.T) {
 
 	expectedProxyAddr := "2001:4860:4860::8"
 	proxyAddr := net.ParseIP(expectedProxyAddr)
-	s, err := NewDoHListener("test-doh", addr, DoHListenerOptions{TLSConfig: tlsServerConfig, ProxyAddr: &proxyAddr}, upstream)
+	s, err := NewDoHListener("test-doh", addr, DoHListenerOptions{TLSConfig: tlsServerConfig, HTTPProxyAddr: proxyAddr}, upstream)
 	require.NoError(t, err)
 
 	// Verify that the ProxyAddr has been set.
-	require.Equal(t, expectedProxyAddr, s.opt.ProxyAddr.String())
+	require.Equal(t, expectedProxyAddr, s.opt.HTTPProxyAddr.String())
 
 	// There is no proxy.
 	r, _ := http.NewRequest("GET", "https://www.example.com", nil)


### PR DESCRIPTION
I find this useful for running routedns behind nginx.