### PR TITLE
Subnet

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -28,12 +28,12 @@ type listener struct {
 	ServerCrt  string   `toml:"server-crt"`
 	MutualTLS  bool     `toml:"mutual-tls"`
 	AllowedNet []string `toml:"allowed-net"`
-	DoH        dohListener
+	Frontend   dohFrontend
 }
 
-// DoH-specific resolver options
-type dohListener struct {
-	HTTPProxyAddr string `toml:"trusted-proxy"`
+// DoH listener frontend options
+type dohFrontend struct {
+	HTTPProxyNet string `toml:"trusted-proxy"`
 }
 
 type resolver struct {

--- a/cmd/routedns/example-config/doh-behind-proxy.toml
+++ b/cmd/routedns/example-config/doh-behind-proxy.toml
@@ -1,5 +1,5 @@
 # Server-side of a DNS-over-HTTPS proxy that is behind an HTTP reverse proxy.
-# The X-Forwarded-For header provided by the trusted-proxy (on 192.168.1.2)
+# The X-Forwarded-For header provided by any trusted-proxy in 192.168.1.0/24
 # will be used to determine the client address.
 
 [resolvers.cloudflare-dot]
@@ -12,4 +12,4 @@ protocol = "doh"
 resolver = "cloudflare-dot"
 server-crt = "example-config/server.crt"
 server-key = "example-config/server.key"
-trusted-proxy = "192.168.1.2"
+frontend = { trusted-proxy = "192.168.1.0/24" }

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -244,15 +244,15 @@ func start(opt options, args []string) error {
 			if err != nil {
 				return err
 			}
-			httpProxyAddr := net.ParseIP(l.DoH.HTTPProxyAddr)
-			if l.DoH.HTTPProxyAddr != "" && httpProxyAddr == nil {
-				return fmt.Errorf("listener '%s' proxy-address '%s' is not an IPv4 or IPv6 address", id, l.DoH.HTTPProxyAddr)
+			_, httpProxyNet, err := net.ParseCIDR(l.Frontend.HTTPProxyNet)
+			if l.Frontend.HTTPProxyNet != "" && httpProxyNet == nil {
+				return fmt.Errorf("listener '%s' proxy-address '%s': %v", id, l.Frontend.HTTPProxyNet, err)
 			}
 			opt := rdns.DoHListenerOptions{
 				TLSConfig:     tlsConfig,
 				ListenOptions: opt,
 				Transport:     l.Transport,
-				HTTPProxyAddr: httpProxyAddr,
+				HTTPProxyNet:  httpProxyNet,
 			}
 			ln, err := rdns.NewDoHListener(id, l.Address, opt, resolver)
 			if err != nil {

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -244,9 +244,12 @@ func start(opt options, args []string) error {
 			if err != nil {
 				return err
 			}
-			_, httpProxyNet, err := net.ParseCIDR(l.Frontend.HTTPProxyNet)
-			if l.Frontend.HTTPProxyNet != "" && httpProxyNet == nil {
-				return fmt.Errorf("listener '%s' trusted-proxy '%s': %v", id, l.Frontend.HTTPProxyNet, err)
+			var httpProxyNet *net.IPNet
+			if l.Frontend.HTTPProxyNet != "" {
+				_, httpProxyNet, err = net.ParseCIDR(l.Frontend.HTTPProxyNet)
+				if err != nil {
+					return fmt.Errorf("listener '%s' trusted-proxy '%s': %v", id, l.Frontend.HTTPProxyNet, err)
+				}
 			}
 			opt := rdns.DoHListenerOptions{
 				TLSConfig:     tlsConfig,

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -246,7 +246,7 @@ func start(opt options, args []string) error {
 			}
 			_, httpProxyNet, err := net.ParseCIDR(l.Frontend.HTTPProxyNet)
 			if l.Frontend.HTTPProxyNet != "" && httpProxyNet == nil {
-				return fmt.Errorf("listener '%s' proxy-address '%s': %v", id, l.Frontend.HTTPProxyNet, err)
+				return fmt.Errorf("listener '%s' trusted-proxy '%s': %v", id, l.Frontend.HTTPProxyNet, err)
 			}
 			opt := rdns.DoHListenerOptions{
 				TLSConfig:     tlsConfig,

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -118,9 +118,9 @@ Secure listeners, such as DNS-over-TLS, DNS-over-HTTPS, DNS-over-DTLS, DNS-over-
 - `ca` - CA to validate client certificated. Optional. Uses the operating system's CA store by default.
 - `mutual-tls` - Requires clients to send valid (as per `ca` option) certificates before establishing a connection. Optional.
 
-The DNS-over-HTTPS listener also accepts the client IP address from a trusted reverse proxy. X-Forwarded-For headers are only used if they are provided from this address
+The DNS-over-HTTPS listener also accepts the client IP address from trusted reverse proxies in a particular subnet. X-Forwarded-For headers are only used if they are provided from this subnet
 
-- `trusted-proxy` - IP address of trusted reverse proxy. Optional.
+- `trusted-proxy` - CIDR address of trusted reverse proxy. Optional.
 
 ### Plain DNS
 
@@ -201,7 +201,7 @@ server-crt = "example-config/server.crt"
 server-key = "example-config/server.key"
 ```
 
-DoH behind a reverse proxy. Clients are expected to connect to the reverse proxy, which will provide their IP address in the X-Forwarded-For header. RouteDNS will trust this header from the proxy listed in `trusted-proxy`
+DoH behind a reverse proxy. Clients are expected to connect to a reverse proxy in this subnet, which will provide their IP address in the X-Forwarded-For header. RouteDNS will trust this header from proxies in the subnet listed in `trusted-proxy`
 
 ```toml
 [listeners.local-doh]
@@ -210,7 +210,7 @@ protocol = "doh"
 resolver = "cloudflare-dot"
 server-crt = "/path/to/server.crt"
 server-key = "/path/to/server.key"
-trusted-proxy = "192.168.1.2"
+frontend = { trusted-proxy = "192.168.1.0/24" }
 ```
 
 Example config files: [mutual-tls-doh-server.toml](../cmd/routedns/example-config/mutual-tls-doh-server.toml), [doh-quic-server.toml](../cmd/routedns/example-config/doh-quic-server.toml), [doh-behind-proxy.toml](../cmd/routedns/example-config/doh-behind-proxy.toml)

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -44,8 +44,8 @@ type DoHListenerOptions struct {
 
 	TLSConfig *tls.Config
 
-	// IP(v4/v6) of a known reverse proxy in front of this server.
-	HTTPProxyAddr net.IP
+	// IP(v4/v6) subnet of known reverse proxies in front of this server.
+	HTTPProxyNet *net.IPNet
 }
 
 // NewDoHListener returns an instance of a DNS-over-HTTPS listener.
@@ -174,13 +174,13 @@ func (s *DoHListener) extractClientAddress(r *http.Request) net.IP {
 	xForwardedFor := r.Header.Get("X-Forwarded-For")
 
 	// Simple case: No proxy (or empty/long X-Forwarded-For).
-	if s.opt.HTTPProxyAddr == nil || xForwardedFor == "" || len(xForwardedFor) >= 1024 {
+	if s.opt.HTTPProxyNet == nil || xForwardedFor == "" || len(xForwardedFor) >= 1024 {
 		return clientIP
 	}
 
 	// If our client is a reverse proxy then use the last entry in X-Forwarded-For.
 	chain := strings.Split(xForwardedFor, ", ")
-	if clientIP != nil && s.opt.HTTPProxyAddr.Equal(clientIP) {
+	if clientIP != nil && s.opt.HTTPProxyNet.Contains(clientIP) {
 		if ip := net.ParseIP(chain[len(chain)-1]); ip != nil {
 			// Ignore XFF whe the client is local to the proxy.
 			if !ip.IsLoopback() {


### PR DESCRIPTION
Changes:

- Change from one proxy address to CIDR as previously promised.  
- Fix the docs for the configuration file.
- Change the config section from "doh = { trusted-proxy = ... }" to "frontend = { trusted-proxy = ... }"

This is a breaking change.  Anyone who worked out how to set this up despite the problem with the docs will now fail with the message "invalid CIDR address" because the mask length is now required.  I considered making it optional but decided to go for simplicity (since I'm likely the only user right now).