### PR TITLE
Add cache-dir option to HTTP blocklists

### DIFF
--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -3,27 +3,50 @@ package rdns
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 )
 
 // HTTPLoader reads blocklist rules from a server via HTTP(S).
 type HTTPLoader struct {
-	url string
+	url      string
+	opt      HTTPLoaderOptions
+	fromDisk bool
+}
+
+// HTTPLoaderOptions holds options for HTTP blocklist loaders.
+type HTTPLoaderOptions struct {
+	CacheDir string
 }
 
 var _ BlocklistLoader = &HTTPLoader{}
 
 const httpTimeout = 30 * time.Minute
 
-func NewHTTPLoader(url string) *HTTPLoader {
-	return &HTTPLoader{url}
+func NewHTTPLoader(url string, opt HTTPLoaderOptions) *HTTPLoader {
+	return &HTTPLoader{url, opt, opt.CacheDir != ""}
 }
 
 func (l *HTTPLoader) Load() ([]string, error) {
 	log := Log.WithField("url", l.url)
 	log.Trace("loading blocklist")
+
+	// If a cache-dir was given, try to load the list from disk on first load
+	if l.fromDisk {
+		start := time.Now()
+		l.fromDisk = false
+		rules, err := l.loadFromDisk()
+		if err == nil {
+			log.WithField("load-time", time.Since(start)).Trace("loaded blocklist from cache-dir")
+			return rules, err
+		}
+		log.WithError(err).Warn("unable to load cached list from disk, loading from upstream")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 
@@ -42,11 +65,61 @@ func (l *HTTPLoader) Load() ([]string, error) {
 		return nil, fmt.Errorf("got unexpected status code %d from %s", resp.StatusCode, l.url)
 	}
 
+	start := time.Now()
 	var rules []string
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
 		rules = append(rules, scanner.Text())
 	}
-	log.Trace("completed loading blocklist")
+	log.WithField("load-time", time.Since(start)).Trace("completed loading blocklist")
+
+	// Cache the content to disk if the read from the remote server was successful
+	if scanner.Err() == nil && l.opt.CacheDir != "" {
+		log.Trace("writing rules to cache-dir")
+		if err := l.writeToDisk(rules); err != nil {
+			log.WithError(err).Error("failed to write rules to cache")
+		}
+	}
 	return rules, scanner.Err()
+}
+
+// Loads a cached version of the list from disk. The filename is made by hashing the URL with SHA256
+// and the file is expect to be in cache-dir.
+func (l *HTTPLoader) loadFromDisk() ([]string, error) {
+	f, err := os.Open(l.cacheFilename())
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var rules []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		rules = append(rules, scanner.Text())
+	}
+	return rules, scanner.Err()
+}
+
+func (l *HTTPLoader) writeToDisk(rules []string) error {
+	// log.Tracef("writing list to cache file %q", filename)
+	f, err := os.Create(l.cacheFilename())
+	if err != nil {
+		// log.WithError(err).Error("failed to write to cache-dir")
+		return err
+	}
+	defer f.Close()
+	fb := bufio.NewWriter(f)
+	defer fb.Flush()
+	for _, r := range rules {
+		if _, err := fb.WriteString(r + "\n"); err != nil {
+			// log.WithError(err).Error("failed to write cache file")
+			return err
+		}
+	}
+	return nil
+}
+
+// Returns the name of the list cache file, which is the SHA265 of url in the cache-dir.
+func (l *HTTPLoader) cacheFilename() string {
+	name := fmt.Sprintf("%x", sha256.Sum256([]byte(l.url)))
+	return filepath.Join(l.opt.CacheDir, name)
 }

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -102,8 +102,9 @@ type group struct {
 
 // Block/Allowlist items for blocklist-v2
 type list struct {
-	Format string
-	Source string
+	Format   string
+	Source   string
+	CacheDir string `toml:"cache-dir"` // Where to store copies of remote blocklists for faster startup
 }
 
 type router struct {

--- a/cmd/routedns/example-config/blocklist-remote-cache.toml
+++ b/cmd/routedns/example-config/blocklist-remote-cache.toml
@@ -1,0 +1,21 @@
+# Config with a remote blocklist that is refreshed once a day and caches the list
+# for faster start up. After the list has been downloaded, it is stored on disk and
+# used during the next startup. The local cache is refreshed every time the list
+# is loaded.
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[groups.cloudflare-blocklist]
+type = "blocklist-v2"
+resolvers = ["cloudflare-dot"]
+blocklist-refresh = 86400
+blocklist-source = [
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.domain.list", cache-dir = "/var/tmp"},
+   {format = "regexp", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.regexp.list", cache-dir = "/var/tmp"},
+]
+
+[listeners.local-udp]
+address = ":53"
+protocol = "udp"
+resolver = "cloudflare-blocklist"


### PR DESCRIPTION
As per #67, adds a `cache-dir` option to remote HTTP lists to cache to disk and support faster startup