### PR TITLE
Expvar

### DIFF
--- a/adminlistener.go
+++ b/adminlistener.go
@@ -1,0 +1,119 @@
+package rdns
+
+import (
+	"context"
+	"crypto/tls"
+	"expvar"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go/http3"
+	"github.com/sirupsen/logrus"
+)
+
+// Read/Write timeout in the admin server
+const adminServerTimeout = 10 * time.Second
+
+// AdminListener is a DNS listener/server for admin services.
+type AdminListener struct {
+	httpServer *http.Server
+	quicServer *http3.Server
+
+	id   string
+	addr string
+	opt  AdminListenerOptions
+
+	mux *http.ServeMux
+}
+
+var _ Listener = &AdminListener{}
+
+// AdminListenerOptions contains options used by the admin service.
+type AdminListenerOptions struct {
+	ListenOptions
+
+	// Transport protocol to run HTTPS over. "quic" or "tcp", defaults to "tcp".
+	Transport string
+
+	TLSConfig *tls.Config
+}
+
+// NewAdminListener returns an instance of an admin service listener.
+func NewAdminListener(id, addr string, opt AdminListenerOptions) (*AdminListener, error) {
+	switch opt.Transport {
+	case "tcp", "":
+		opt.Transport = "tcp"
+	case "quic":
+		opt.Transport = "quic"
+	default:
+		return nil, fmt.Errorf("unknown protocol: '%s'", opt.Transport)
+	}
+
+	l := &AdminListener{
+		id:   id,
+		addr: addr,
+		opt:  opt,
+		mux:  http.NewServeMux(),
+	}
+	// Serve metrics.
+	l.mux.Handle("/routedns/vars", expvar.Handler())
+	return l, nil
+}
+
+// Start the admin server.
+func (s *AdminListener) Start() error {
+	Log.WithFields(logrus.Fields{"id": s.id, "protocol": s.opt.Transport, "addr": s.addr}).Info("starting listener")
+	if s.opt.Transport == "quic" {
+		return s.startQUIC()
+	}
+	return s.startTCP()
+}
+
+// Start the admin server with TCP transport.
+func (s *AdminListener) startTCP() error {
+	s.httpServer = &http.Server{
+		Addr:         s.addr,
+		TLSConfig:    s.opt.TLSConfig,
+		Handler:      s.mux,
+		ReadTimeout:  adminServerTimeout,
+		WriteTimeout: adminServerTimeout,
+	}
+
+	ln, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+	return s.httpServer.ServeTLS(ln, "", "")
+}
+
+// Start the admin server with QUIC transport.
+func (s *AdminListener) startQUIC() error {
+	s.quicServer = &http3.Server{
+		Server: &http.Server{
+			Addr:         s.addr,
+			TLSConfig:    s.opt.TLSConfig,
+			Handler:      s.mux,
+			ReadTimeout:  adminServerTimeout,
+			WriteTimeout: adminServerTimeout,
+		},
+		QuicConfig: &quic.Config{},
+	}
+	return s.quicServer.ListenAndServe()
+}
+
+// Stop the server.
+func (s *AdminListener) Stop() error {
+	Log.WithFields(logrus.Fields{"id": s.id, "protocol": s.opt.Transport, "addr": s.addr}).Info("stopping listener")
+	if s.opt.Transport == "quic" {
+		return s.quicServer.Close()
+	}
+	return s.httpServer.Shutdown(context.Background())
+}
+
+func (s *AdminListener) String() string {
+	return s.id
+}

--- a/cmd/routedns/example-config/admin.toml
+++ b/cmd/routedns/example-config/admin.toml
@@ -1,0 +1,22 @@
+# Simple proxy using a cache with metrics at https://127.0.0.2/routedns/vars/.
+
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[groups.cloudflare-cached]
+type = "cache"
+resolvers = ["cloudflare-dot"]
+cache-size = 1000
+cache-negative-ttl = 10
+
+[listeners.local-udp]
+address = "127.0.0.1:53"
+protocol = "udp"
+resolver = "cloudflare-cached"
+
+[listeners.local-admin]
+address = "127.0.0.2:443"
+protocol = "admin"
+server-crt = "/path/to/server.crt"
+server-key = "/path/to/server.key"

--- a/dnsclient.go
+++ b/dnsclient.go
@@ -14,7 +14,7 @@ type DNSClient struct {
 	endpoint string
 	net      string
 	pipeline *Pipeline
-	// Pipeline also provides operation counters.
+	// Pipeline also provides operation metrics.
 }
 
 type DNSClientOptions struct {

--- a/dnsclient.go
+++ b/dnsclient.go
@@ -14,6 +14,7 @@ type DNSClient struct {
 	endpoint string
 	net      string
 	pipeline *Pipeline
+	// Pipeline also provides operation counters.
 }
 
 type DNSClientOptions struct {
@@ -46,7 +47,7 @@ func NewDNSClient(id, endpoint, network string, opt DNSClientOptions) *DNSClient
 		id:       id,
 		net:      network,
 		endpoint: endpoint,
-		pipeline: NewPipeline(endpoint, client),
+		pipeline: NewPipeline(id, endpoint, client),
 	}
 }
 

--- a/dnslistener.go
+++ b/dnslistener.go
@@ -47,6 +47,11 @@ func (s DNSListener) String() string {
 
 // DNS handler to forward all incoming requests to a given resolver.
 func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNet) dns.HandlerFunc {
+	expSession := getVarMap("listener", id, "session")
+	expQuery := getVarInt("listener", id, "query")
+	expResponse := getVarMap("listener", id, "response")
+	expDrop := getVarInt("listener", id, "drop")
+	expError := getVarMap("listener", id, "header")
 	return func(w dns.ResponseWriter, req *dns.Msg) {
 		var (
 			ci  ClientInfo
@@ -56,23 +61,28 @@ func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNe
 		switch addr := w.RemoteAddr().(type) {
 		case *net.TCPAddr:
 			ci.SourceIP = addr.IP
+			expSession.Add("tcp", 1)
 		case *net.UDPAddr:
 			ci.SourceIP = addr.IP
+			expSession.Add("udp", 1)
 		}
 
 		log := Log.WithFields(logrus.Fields{"id": id, "client": ci.SourceIP, "qname": qName(req), "protocol": protocol, "addr": addr})
 		log.Debug("received query")
+		expQuery.Add(1)
 
 		a := new(dns.Msg)
 		if isAllowed(allowedNet, ci.SourceIP) {
 			log.WithField("resolver", r.String()).Trace("forwarding query to resolver")
 			a, err = r.Resolve(req, ci)
 			if err != nil {
+				expError.Add("resolve", 1)
 				log.WithError(err).Error("failed to resolve")
 				a = new(dns.Msg)
 				a.SetRcode(req, dns.RcodeServerFailure)
 			}
 		} else {
+			expError.Add("acl", 1)
 			log.Debug("refusing client ip")
 			a.SetRcode(req, dns.RcodeRefused)
 		}
@@ -80,6 +90,7 @@ func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNe
 		// A nil response from the resolvers means "drop", close the connection
 		if a == nil {
 			w.Close()
+			expDrop.Add(1)
 			return
 		}
 
@@ -90,6 +101,7 @@ func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNe
 		} else {
 			stripPadding(a)
 		}
+		expResponse.Add(dns.RcodeToString[a.Rcode], 1)
 		_ = w.WriteMsg(a)
 	}
 }

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -10,6 +10,7 @@
   - [DNS-over-HTTPS](#DNS-over-HTTPS)
   - [DNS-over-DTLS](#DNS-over-DTLS)
   - [DNS-over-QUIC](#DNS-over-QUIC)
+  - [Admin](#Admin)
 - [Modifiers, Groups and Routers](#Modifiers-Groups-and-Routers)
   - [Cache](#Cache)
   - [TTL Modifier](#TTL-modifier)
@@ -111,7 +112,7 @@ Common options for all listeners:
 - `resolver` - Name/identifier of the next element in the pipeline. Can be a router, group, modifier or resolver.
 - `allowed-net` - Array of network addresses that are allowed to send queries to this listener, in CIDR notation, such as `["192.167.1.0/24", "::1/128"]`. If not set, no filter is applied, all clients can send queries.
 
-Secure listeners, such as DNS-over-TLS, DNS-over-HTTPS, DNS-over-DTLS, DNS-over-QUIC support additional options to configure certificate, keys and peer validation
+Secure listeners, such as DNS-over-TLS, DNS-over-HTTPS, DNS-over-DTLS, DNS-over-QUIC and Admin support additional options to configure certificate, keys and peer validation
 
 - `server-crt` - Server certificate file. Required.
 - `server-key` - Server key file. Required.
@@ -254,6 +255,22 @@ server-key = "example-config/server.key"
 ```
 
 Example config files: [doq-listener.toml](../cmd/routedns/example-config/doq-listener.toml)
+
+### Admin
+
+The Admin listener provides metrics on RouteDNS usage and performance at https://{address}/routedns/vars/.
+
+Examples:
+
+```toml
+[listeners.local-admin]
+address = "127.0.0.7:443"
+protocol = "admin"
+server-crt = "example-config/server.crt"
+server-key = "example-config/server.key"
+```
+
+Example config files: [admin.toml](../cmd/routedns/example-config/admin.toml)
 
 ## Modifiers, Groups and Routers
 

--- a/dohclient.go
+++ b/dohclient.go
@@ -41,11 +41,14 @@ type DoHClientOptions struct {
 
 // DoHClient is a DNS-over-HTTP resolver with support fot HTTP/2.
 type DoHClient struct {
-	id       string
-	endpoint string
-	template *uritemplates.UriTemplate
-	client   *http.Client
-	opt      DoHClientOptions
+	id          string
+	endpoint    string
+	template    *uritemplates.UriTemplate
+	client      *http.Client
+	opt         DoHClientOptions
+	expQuery    *varInt // Query count
+	expResponse *varMap // DNS Response codes
+	expError    *varMap // RouteDNS failure reasons
 }
 
 var _ Resolver = &DoHClient{}
@@ -82,11 +85,14 @@ func NewDoHClient(id, endpoint string, opt DoHClientOptions) (*DoHClient, error)
 	}
 
 	return &DoHClient{
-		id:       id,
-		endpoint: endpoint,
-		template: template,
-		client:   client,
-		opt:      opt,
+		id:          id,
+		endpoint:    endpoint,
+		template:    template,
+		client:      client,
+		opt:         opt,
+		expQuery:    getVarInt("client", id, "query"),
+		expResponse: getVarMap("client", id, "response"),
+		expError:    getVarMap("client", id, "error"),
 	}, nil
 }
 
@@ -101,6 +107,7 @@ func (d *DoHClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	// Add padding before sending the query over HTTPS
 	padQuery(q)
 
+	d.expQuery.Add(1)
 	switch d.opt.Method {
 	case "POST":
 		return d.ResolvePOST(q)
@@ -115,25 +122,29 @@ func (d *DoHClient) ResolvePOST(q *dns.Msg) (*dns.Msg, error) {
 	// Pack the DNS query into wire format
 	b, err := q.Pack()
 	if err != nil {
+		d.expError.Add("pack", 1)
 		return nil, err
 	}
 	// The URL could be a template. Process it without values since POST doesn't use variables in the URL.
 	u, err := d.template.Expand(map[string]interface{}{})
 	if err != nil {
+		d.expError.Add("template", 1)
 		return nil, err
 	}
 	req, err := http.NewRequest("POST", u, bytes.NewReader(b))
 	if err != nil {
+		d.expError.Add("http", 1)
 		return nil, err
 	}
 	req.Header.Add("accept", "application/dns-message")
 	req.Header.Add("content-type", "application/dns-message")
 	resp, err := d.client.Do(req)
 	if err != nil {
+		d.expError.Add("post", 1)
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return responseFromHTTP(resp)
+	return d.responseFromHTTP(resp)
 }
 
 // ResolveGET resolves a DNS query via DNS-over-HTTP using the GET method.
@@ -141,6 +152,7 @@ func (d *DoHClient) ResolveGET(q *dns.Msg) (*dns.Msg, error) {
 	// Pack the DNS query into wire format
 	b, err := q.Pack()
 	if err != nil {
+		d.expError.Add("pack", 1)
 		return nil, err
 	}
 	// Encode the query as base64url without padding
@@ -149,19 +161,22 @@ func (d *DoHClient) ResolveGET(q *dns.Msg) (*dns.Msg, error) {
 	// The URL must be a template. Process it with the "dns" param containing the encoded query.
 	u, err := d.template.Expand(map[string]interface{}{"dns": b64})
 	if err != nil {
+		d.expError.Add("template", 1)
 		return nil, err
 	}
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
+		d.expError.Add("http", 1)
 		return nil, err
 	}
 	req.Header.Add("accept", "application/dns-message")
 	resp, err := d.client.Do(req)
 	if err != nil {
+		d.expError.Add("get", 1)
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return responseFromHTTP(resp)
+	return d.responseFromHTTP(resp)
 }
 
 func (d *DoHClient) String() string {
@@ -169,16 +184,23 @@ func (d *DoHClient) String() string {
 }
 
 // Check the HTTP response status code and parse out the response DNS message.
-func responseFromHTTP(resp *http.Response) (*dns.Msg, error) {
+func (d *DoHClient) responseFromHTTP(resp *http.Response) (*dns.Msg, error) {
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		d.expError.Add(fmt.Sprintf("http%d", resp.StatusCode), 1)
 		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 	rb, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
+		d.expError.Add("read", 1)
 		return nil, err
 	}
 	a := new(dns.Msg)
 	err = a.Unpack(rb)
+	if err != nil {
+		d.expError.Add("unpack", 1)
+	} else {
+		d.expResponse.Add(dns.RcodeToString[a.Rcode], 1)
+	}
 	return a, err
 }
 

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -33,12 +33,7 @@ type DoHListener struct {
 
 	mux *http.ServeMux
 
-	expSession  *varMap // Transport query was received over.
-	expMethod   *varMap // HTTP method used for query.
-	expQuery    *varInt // DNS query count.
-	expResponse *varMap // DNS response code.
-	expError    *varMap // RouteDNS failure reason.
-	expDrop     *varInt // Number of queries dropped internally.
+	metrics *DoHListenerMetrics
 }
 
 var _ Listener = &DoHListener{}
@@ -56,6 +51,27 @@ type DoHListenerOptions struct {
 	HTTPProxyAddr net.IP
 }
 
+type DoHListenerMetrics struct {
+	ListenerMetrics
+
+	// HTTP method used for query.
+	get  *expvar.Int
+	post *expvar.Int
+}
+
+func NewDoHListenerMetrics(id string) *DoHListenerMetrics {
+	return &DoHListenerMetrics{
+		ListenerMetrics: ListenerMetrics{
+			query:    getVarInt("listener", id, "query"),
+			response: getVarMap("listener", id, "response"),
+			err:      getVarMap("listener", id, "error"),
+			drop:     getVarInt("listener", id, "drop"),
+		},
+		get:  getVarInt("listener", id, "get"),
+		post: getVarInt("listener", id, "post"),
+	}
+}
+
 // NewDoHListener returns an instance of a DNS-over-HTTPS listener.
 func NewDoHListener(id, addr string, opt DoHListenerOptions, resolver Resolver) (*DoHListener, error) {
 	switch opt.Transport {
@@ -68,27 +84,20 @@ func NewDoHListener(id, addr string, opt DoHListenerOptions, resolver Resolver) 
 	}
 
 	l := &DoHListener{
-		id:          id,
-		addr:        addr,
-		r:           resolver,
-		opt:         opt,
-		mux:         http.NewServeMux(),
-		expSession:  getVarMap("listener", id, "session"),
-		expMethod:   getVarMap("listener", id, "method"),
-		expQuery:    getVarInt("listener", id, "query"),
-		expResponse: getVarMap("listener", id, "response"),
-		expError:    getVarMap("listener", id, "error"),
-		expDrop:     getVarInt("listener", id, "drop"),
+		id:      id,
+		addr:    addr,
+		r:       resolver,
+		opt:     opt,
+		mux:     http.NewServeMux(),
+		metrics: NewDoHListenerMetrics(id),
 	}
 	l.mux.Handle("/dns-query", http.HandlerFunc(l.dohHandler))
-	l.mux.Handle("/routedns/vars", expvar.Handler())
 	return l, nil
 }
 
 // Start the DoH server.
 func (s *DoHListener) Start() error {
 	Log.WithFields(logrus.Fields{"id": s.id, "protocol": "doh", "addr": s.addr}).Info("starting listener")
-
 	if s.opt.Transport == "quic" {
 		return s.startQUIC()
 	}
@@ -142,14 +151,15 @@ func (s *DoHListener) String() string {
 }
 
 func (s *DoHListener) dohHandler(w http.ResponseWriter, r *http.Request) {
-	s.expSession.Add(s.opt.Transport, 1)
-	s.expMethod.Add(r.Method, 1)
 	switch r.Method {
 	case "GET":
+		s.metrics.get.Add(1)
 		s.getHandler(w, r)
 	case "POST":
+		s.metrics.post.Add(1)
 		s.postHandler(w, r)
 	default:
+		s.metrics.err.Add("httpmethod", 1)
 		http.Error(w, "only GET and POST allowed", http.StatusMethodNotAllowed)
 	}
 }
@@ -215,17 +225,17 @@ func (s *DoHListener) extractClientAddress(r *http.Request) net.IP {
 }
 
 func (s *DoHListener) parseAndRespond(b []byte, w http.ResponseWriter, r *http.Request) {
-	s.expQuery.Add(1)
+	s.metrics.query.Add(1)
 	q := new(dns.Msg)
 	if err := q.Unpack(b); err != nil {
-		s.expError.Add("unpack", 1)
+		s.metrics.err.Add("unpack", 1)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	// Extract the remote host address from the HTTP headers.
 	clientIP := s.extractClientAddress(r)
 	if clientIP == nil {
-		s.expError.Add("remoteaddr", 1)
+		s.metrics.err.Add("remoteaddr", 1)
 		http.Error(w, "Invalid RemoteAddr", http.StatusBadRequest)
 		return
 	}
@@ -252,7 +262,7 @@ func (s *DoHListener) parseAndRespond(b []byte, w http.ResponseWriter, r *http.R
 
 	// A nil response from the resolvers means "drop", return blank response
 	if a == nil {
-		s.expDrop.Add(1)
+		s.metrics.drop.Add(1)
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}
@@ -260,10 +270,10 @@ func (s *DoHListener) parseAndRespond(b []byte, w http.ResponseWriter, r *http.R
 	// Pad the packet according to rfc8467 and rfc7830
 	padAnswer(q, a)
 
-	s.expResponse.Add(dns.RcodeToString[a.Rcode], 1)
+	s.metrics.response.Add(rCode(a), 1)
 	out, err := a.Pack()
 	if err != nil {
-		s.expError.Add("pack", 1)
+		s.metrics.err.Add("pack", 1)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/dotclient.go
+++ b/dotclient.go
@@ -14,6 +14,7 @@ type DoTClient struct {
 	id       string
 	endpoint string
 	pipeline *Pipeline
+	// Pipeline also provides operation counters
 }
 
 // DoTClientOptions contains options used by the DNS-over-TLS resolver.
@@ -57,7 +58,7 @@ func NewDoTClient(id, endpoint string, opt DoTClientOptions) (*DoTClient, error)
 	return &DoTClient{
 		id:       id,
 		endpoint: endpoint,
-		pipeline: NewPipeline(endpoint, client),
+		pipeline: NewPipeline(id, endpoint, client),
 	}, nil
 }
 

--- a/dotclient.go
+++ b/dotclient.go
@@ -14,7 +14,7 @@ type DoTClient struct {
 	id       string
 	endpoint string
 	pipeline *Pipeline
-	// Pipeline also provides operation counters
+	// Pipeline also provides operation metrics.
 }
 
 // DoTClientOptions contains options used by the DNS-over-TLS resolver.

--- a/dtlsclient.go
+++ b/dtlsclient.go
@@ -15,7 +15,7 @@ type DTLSClient struct {
 	id       string
 	endpoint string
 	pipeline *Pipeline
-	// Pipeline also provides operation counters.
+	// Pipeline also provides operation metrics.
 }
 
 // DTLSClientOptions contains options used by the DNS-over-DTLS resolver.

--- a/dtlsclient.go
+++ b/dtlsclient.go
@@ -15,6 +15,7 @@ type DTLSClient struct {
 	id       string
 	endpoint string
 	pipeline *Pipeline
+	// Pipeline also provides operation counters.
 }
 
 // DTLSClientOptions contains options used by the DNS-over-DTLS resolver.
@@ -75,7 +76,7 @@ func NewDTLSClient(id, endpoint string, opt DTLSClientOptions) (*DTLSClient, err
 	return &DTLSClient{
 		id:       id,
 		endpoint: endpoint,
-		pipeline: NewPipeline(endpoint, client),
+		pipeline: NewPipeline(id, endpoint, client),
 	}, nil
 }
 

--- a/failback.go
+++ b/failback.go
@@ -39,8 +39,6 @@ type FailRouterMetrics struct {
 	RouterMetrics
 	// Failover count
 	failover *expvar.Int
-	// Available router count
-	available *expvar.Int
 }
 
 func NewFailRouterMetrics(id string, available int) *FailRouterMetrics {
@@ -48,11 +46,11 @@ func NewFailRouterMetrics(id string, available int) *FailRouterMetrics {
 	avail.Set(int64(available))
 	return &FailRouterMetrics{
 		RouterMetrics: RouterMetrics{
-			route:   getVarMap("router", id, "route"),
-			failure: getVarMap("router", id, "failure"),
+			route:     getVarMap("router", id, "route"),
+			failure:   getVarMap("router", id, "failure"),
+			available: avail,
 		},
-		failover:  getVarInt("router", id, "failover"),
-		available: avail,
+		failover: getVarInt("router", id, "failover"),
 	}
 }
 

--- a/failback.go
+++ b/failback.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"expvar"
 	"sync"
 	"time"
 
@@ -22,10 +23,7 @@ type FailBack struct {
 	failCh    chan struct{} // signal the timer to reset on failure
 	active    int
 	opt       FailBackOptions
-
-	expRoute    *varMap // Next route chosen
-	expFailure  *varMap // RouteDNS failure reason
-	expFailover *varInt // Failover count
+	metrics   *FailRouterMetrics
 }
 
 // FailBackOptions contain group-specific options.
@@ -37,18 +35,37 @@ type FailBackOptions struct {
 
 var _ Resolver = &FailBack{}
 
+type FailRouterMetrics struct {
+	RouterMetrics
+	// Failover count
+	failover *expvar.Int
+	// Available router count
+	available *expvar.Int
+}
+
+func NewFailRouterMetrics(id string, available int) *FailRouterMetrics {
+	avail := getVarInt("router", id, "available")
+	avail.Set(int64(available))
+	return &FailRouterMetrics{
+		RouterMetrics: RouterMetrics{
+			route:   getVarMap("router", id, "route"),
+			failure: getVarMap("router", id, "failure"),
+		},
+		failover:  getVarInt("router", id, "failover"),
+		available: avail,
+	}
+}
+
 // NewFailBack returns a new instance of a failover resolver group.
 func NewFailBack(id string, opt FailBackOptions, resolvers ...Resolver) *FailBack {
 	if opt.ResetAfter == 0 {
 		opt.ResetAfter = time.Minute
 	}
 	return &FailBack{
-		id:          id,
-		resolvers:   resolvers,
-		opt:         opt,
-		expRoute:    getVarMap("router", id, "route"),
-		expFailure:  getVarMap("router", id, "failure"),
-		expFailover: getVarInt("router", id, "failover"),
+		id:        id,
+		resolvers: resolvers,
+		opt:       opt,
+		metrics:   NewFailRouterMetrics(id, len(resolvers)),
 	}
 }
 
@@ -60,13 +77,13 @@ func (r *FailBack) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	for i := 0; i < len(r.resolvers); i++ {
 		resolver, active := r.current()
 		log.WithField("resolver", resolver.String()).Debug("forwarding query to resolver")
-		r.expRoute.Add(resolver.String(), 1)
+		r.metrics.route.Add(resolver.String(), 1)
 		a, err := resolver.Resolve(q, ci)
 		if err == nil { // Return immediately if successful
 			return a, err
 		}
 		log.WithField("resolver", resolver.String()).WithError(err).Debug("resolver returned failure")
-		r.expFailure.Add(resolver.String(), 1)
+		r.metrics.failure.Add(resolver.String(), 1)
 
 		// Record the error to be returned when all requests fail
 		gErr = err
@@ -97,7 +114,6 @@ func (r *FailBack) errorFrom(i int) {
 	if i != r.active {
 		return
 	}
-	r.expFailover.Add(1)
 	if r.failCh == nil { // lazy start the reset timer
 		r.failCh = r.startResetTimer()
 	}
@@ -106,6 +122,8 @@ func (r *FailBack) errorFrom(i int) {
 		"id":       r.id,
 		"resolver": r.resolvers[r.active].String(),
 	}).Debug("failing over to resolver")
+	r.metrics.failover.Add(1)
+	r.metrics.available.Add(-1)
 	r.failCh <- struct{}{} // signal the timer to wait some more before switching back
 }
 
@@ -126,6 +144,7 @@ func (r *FailBack) startResetTimer() chan struct{} {
 				r.active = 0
 				Log.WithField("resolver", r.resolvers[r.active].String()).Debug("failing back to resolver")
 				r.mu.Unlock()
+				r.metrics.available.Add(1)
 				// we just reset to the first resolver, let's wait for another failure before running again
 				<-failCh
 			}

--- a/listener.go
+++ b/listener.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"expvar"
 	"fmt"
 	"net"
 )
@@ -15,4 +16,28 @@ type Listener interface {
 // can be used to route requests.
 type ClientInfo struct {
 	SourceIP net.IP
+}
+
+// Metrics that are available from listeners and clients.
+type ListenerMetrics struct {
+	// DNS query count.
+	query *expvar.Int
+	// DNS response type counts.
+	response *expvar.Map
+	// Number of queries dropped (denied).
+	drop *expvar.Int
+	// RouteDNS failure reason counts.
+	err *expvar.Map
+	// Maximum number of queries queued (optional).
+	maxQueueLen *expvar.Int
+}
+
+func NewListenerMetrics(base string, id string) *ListenerMetrics {
+	return &ListenerMetrics{
+		query:       getVarInt(base, id, "query"),
+		response:    getVarMap(base, id, "response"),
+		drop:        getVarInt(base, id, "drop"),
+		err:         getVarMap(base, id, "error"),
+		maxQueueLen: getVarInt(base, id, "maxqueue"),
+	}
 }

--- a/message.go
+++ b/message.go
@@ -1,6 +1,10 @@
 package rdns
 
-import "github.com/miekg/dns"
+import (
+	"strconv"
+
+	"github.com/miekg/dns"
+)
 
 // Return the query name from a DNS query.
 func qName(q *dns.Msg) string {
@@ -8,6 +12,14 @@ func qName(q *dns.Msg) string {
 		return ""
 	}
 	return q.Question[0].Name
+}
+
+// Return the result code name from a DNS response.
+func rCode(r *dns.Msg) string {
+	if result, ok := dns.RcodeToString[r.Rcode]; ok {
+		return result
+	}
+	return strconv.Itoa(r.Rcode)
 }
 
 // Returns a NXDOMAIN answer for a query.

--- a/pipeline.go
+++ b/pipeline.go
@@ -24,11 +24,7 @@ type Pipeline struct {
 	addr     string
 	client   DNSDialer
 	requests chan *request
-
-	expQuery       *varInt
-	expResponse    *varMap
-	expError       *varMap
-	expMaxQueueLen *varInt
+	metrics  *ListenerMetrics
 }
 
 // DNSDialer is an abstraction for a dns.Client that returns a *dns.Conn.
@@ -39,13 +35,10 @@ type DNSDialer interface {
 // NewPipeline returns an initialized (and running) DNS connection manager.
 func NewPipeline(id string, addr string, client DNSDialer) *Pipeline {
 	c := &Pipeline{
-		addr:           addr,
-		client:         client,
-		requests:       make(chan *request),
-		expQuery:       getVarInt("pipeline", id, "query"),
-		expResponse:    getVarMap("pipeline", id, "response"),
-		expError:       getVarMap("pipeline", id, "error"),
-		expMaxQueueLen: getVarInt("pipeline", id, "maxqlen"),
+		addr:     addr,
+		client:   client,
+		requests: make(chan *request),
+		metrics:  NewListenerMetrics("client", id),
 	}
 	go c.start()
 	return c
@@ -63,7 +56,7 @@ func (c *Pipeline) Resolve(q *dns.Msg) (*dns.Msg, error) {
 	select {
 	case <-r.done:
 	case <-timeout.C:
-		c.expError.Add("querytimeout", 1)
+		c.metrics.err.Add("querytimeout", 1)
 		return nil, QueryTimeoutError{q}
 	}
 
@@ -84,7 +77,7 @@ func (c *Pipeline) start() {
 		log.Trace("opening connection")
 		conn, err := c.client.Dial(c.addr)
 		if err != nil {
-			c.expError.Add("open", 1)
+			c.metrics.err.Add("open", 1)
 			log.WithError(err).Error("failed to open connection")
 			req.markDone(nil, err)
 			continue
@@ -99,17 +92,13 @@ func (c *Pipeline) start() {
 				case req := <-c.requests:
 					query := inFlight.add(req)
 					log.WithField("qname", qName(query)).Trace("sending query")
-					c.expQuery.Add(1)
-					ql := (int64)(inFlight.maxLen)
-					if ql > c.expMaxQueueLen.Value() {
-						c.expMaxQueueLen.Set(ql)
-					}
+					c.metrics.query.Add(1)
 					if err := conn.WriteMsg(query); err != nil {
 						req.markDone(nil, err) // fail the request
 						inFlight.get(query)    // clean up the in-flight queue so it doesn't keep growing
 						conn.Close()           // throw away this connection, should wake up the reader as well
 						wg.Done()
-						c.expError.Add("send_query", 1)
+						c.metrics.err.Add("send_query", 1)
 						log.WithField("qname", qName(query)).WithError(err).Trace("failed sending query")
 						return
 					}
@@ -131,10 +120,9 @@ func (c *Pipeline) start() {
 					switch e := err.(type) {
 					case net.Error:
 						if e.Timeout() {
-							c.expError.Add("idle_timeout", 1)
 							log.Trace("connection terminated by idle timeout")
 						} else {
-							c.expError.Add("server_term", 1)
+							c.metrics.err.Add("server_term", 1)
 							log.Trace("connection terminated by server")
 						}
 						close(done) // tell the writer to not use this connection anymore
@@ -142,7 +130,7 @@ func (c *Pipeline) start() {
 						return
 					default:
 						if err == io.EOF {
-							c.expError.Add("server_eof", 1)
+							c.metrics.err.Add("server_eof", 1)
 							log.Trace("connection terminated by server")
 							close(done) // tell the writer to not use this connection anymore
 							wg.Done()
@@ -152,7 +140,7 @@ func (c *Pipeline) start() {
 						// In this case, return it and carry on, don't terminate the connection because we
 						// got a bad packet (like a truncated one for example).
 						if a == nil {
-							c.expError.Add("read", 1)
+							c.metrics.err.Add("read", 1)
 							log.WithError(err).Error("read failed")
 							close(done) // tell the writer to not use this connection anymore
 							wg.Done()
@@ -163,12 +151,16 @@ func (c *Pipeline) start() {
 				}
 				req := inFlight.get(a) // match the answer to an in-flight query
 				if req == nil {
-					c.expError.Add("unexpected_a", 1)
+					c.metrics.err.Add("unexpected_a", 1)
 					log.WithField("qname", qName(a)).Warn("unexpected answer received, ignoring")
 					continue
 				}
-				c.expResponse.Add(dns.RcodeToString[a.Rcode], 1)
+				c.metrics.response.Add(rCode(a), 1)
 				req.markDone(a, nil)
+				ql := (int64)(inFlight.maxLen)
+				if ql > c.metrics.maxQueueLen.Value() {
+					c.metrics.maxQueueLen.Set(ql)
+				}
 			}
 		}()
 

--- a/roundrobin.go
+++ b/roundrobin.go
@@ -23,7 +23,7 @@ func NewRoundRobin(id string, resolvers ...Resolver) *RoundRobin {
 	return &RoundRobin{
 		id:        id,
 		resolvers: resolvers,
-		metrics:   NewRouterMetrics(id),
+		metrics:   NewRouterMetrics(id, len(resolvers)),
 	}
 }
 

--- a/vars.go
+++ b/vars.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 )
 
-type varInt = expvar.Int
-type varMap = expvar.Map
-
-func getVarInt(base string, id string, name string) *varInt {
+// Get an *expvar.Int with the given path.
+func getVarInt(base string, id string, name string) *expvar.Int {
 	fullname := fmt.Sprintf("routedns.%s.%s.%s", base, id, name)
 	if v := expvar.Get(fullname); v != nil {
 		return v.(*expvar.Int)
@@ -16,7 +14,8 @@ func getVarInt(base string, id string, name string) *varInt {
 	return expvar.NewInt(fullname)
 }
 
-func getVarMap(base string, id string, name string) *varMap {
+// Get an *expvar.Map with the given path.
+func getVarMap(base string, id string, name string) *expvar.Map {
 	fullname := fmt.Sprintf("routedns.%s.%s.%s", base, id, name)
 	if v := expvar.Get(fullname); v != nil {
 		return v.(*expvar.Map)

--- a/vars.go
+++ b/vars.go
@@ -1,0 +1,25 @@
+package rdns
+
+import (
+	"expvar"
+	"fmt"
+)
+
+type varInt = expvar.Int
+type varMap = expvar.Map
+
+func getVarInt(base string, id string, name string) *varInt {
+	fullname := fmt.Sprintf("routedns.%s.%s.%s", base, id, name)
+	if v := expvar.Get(fullname); v != nil {
+		return v.(*expvar.Int)
+	}
+	return expvar.NewInt(fullname)
+}
+
+func getVarMap(base string, id string, name string) *varMap {
+	fullname := fmt.Sprintf("routedns.%s.%s.%s", base, id, name)
+	if v := expvar.Get(fullname); v != nil {
+		return v.(*expvar.Map)
+	}
+	return expvar.NewMap(fullname)
+}


### PR DESCRIPTION
Add metrics (including a new "admin" listener).

Add expvar metrics to listeners, routers and clients.  Variables are kept in structs which are reused where possible (eg. routers use or subclass RouterMetrics).

Metrics examples:
"routedns.listener.local-udp.query": 8,
"routedns.listener.local-udp.response": {"NOERROR": 8},
"routedns.router.cloudflare.available": 9,
"routedns.router.cloudflare.route": {"cloudflare-dot-1-0-0-1": 1, "cloudflare-dot-1-1-1-1": 1},
"routedns.client.cloudflare-dot-1-0-0-1.maxqueue": 1,
"routedns.client.cloudflare-dot-1-0-0-1.query": 1,
"routedns.client.cloudflare-dot-1-0-0-1.response": {"NOERROR": 1},

AdminListener is a new listener based on the DoH listener, including accepting the same config options.  This listener is a bit special because it's the only listener that doesn't route requests.  The config for AdminListener has been added to the docs and examples.