### PR TITLE
Cache SERVFAIL responses (#91)

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -167,6 +167,13 @@ func (r *Cache) storeInCache(query, answer *dns.Msg) {
 		} else {
 			item.expiry = now.Add(time.Duration(r.NegativeTTL) * time.Second)
 		}
+	case dns.RcodeServerFailure:
+		// According to RFC2308, a SERVFAIL response must not be cached for longer than 5 minutes.
+		if r.NegativeTTL < 300 {
+			item.expiry = now.Add(time.Duration(r.NegativeTTL) * time.Second)
+		} else {
+			item.expiry = now.Add(300 * time.Second)
+		}
 	default:
 		return
 	}


### PR DESCRIPTION
Cache server failure responses for `cache-negative-ttl` seconds,
but not longer than 5 minutes.