### PR TITLE
Return SERVFAIL if all resolvers in a group do

### DIFF
--- a/failback.go
+++ b/failback.go
@@ -71,24 +71,24 @@ func NewFailBack(id string, opt FailBackOptions, resolvers ...Resolver) *FailBac
 // resolver on error.
 func (r *FailBack) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	log := logger(r.id, q, ci)
-	var gErr error
+	var (
+		err error
+		a   *dns.Msg
+	)
 	for i := 0; i < len(r.resolvers); i++ {
 		resolver, active := r.current()
 		log.WithField("resolver", resolver.String()).Debug("forwarding query to resolver")
 		r.metrics.route.Add(resolver.String(), 1)
-		a, err := resolver.Resolve(q, ci)
+		a, err = resolver.Resolve(q, ci)
 		if err == nil && (a == nil || a.Rcode != dns.RcodeServerFailure) { // Return immediately if successful
 			return a, err
 		}
 		log.WithField("resolver", resolver.String()).WithError(err).Debug("resolver returned failure")
 		r.metrics.failure.Add(resolver.String(), 1)
 
-		// Record the error to be returned when all requests fail
-		gErr = err
-
 		r.errorFrom(active)
 	}
-	return nil, gErr
+	return a, err
 }
 
 func (r *FailBack) String() string {

--- a/failback_test.go
+++ b/failback_test.go
@@ -83,3 +83,21 @@ func TestFailBackDrop(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, r2.HitCount())
 }
+
+// Return SERVFAIL if all available resolvers return that
+func TestFailBackSERVFAILAll(t *testing.T) {
+	var ci ClientInfo
+	opt := StaticResolverOptions{
+		RCode: dns.RcodeServerFailure,
+	}
+	r, err := NewStaticResolver("test-static", opt)
+	require.NoError(t, err)
+
+	g := NewFailBack("test-fb", FailBackOptions{ResetAfter: time.Second}, r, r)
+	q := new(dns.Msg)
+	q.SetQuestion("test.com.", dns.TypeA)
+
+	a, err := g.Resolve(q, ci)
+	require.NoError(t, err)
+	require.Equal(t, dns.RcodeServerFailure, a.Rcode)
+}

--- a/failrotate_test.go
+++ b/failrotate_test.go
@@ -63,7 +63,6 @@ func TestFailRotate(t *testing.T) {
 }
 
 func TestFailRotateSERVFAIL(t *testing.T) {
-	// Build 2 resolvers that count the number of invocations
 	var ci ClientInfo
 	opt := StaticResolverOptions{
 		RCode: dns.RcodeServerFailure,
@@ -96,4 +95,22 @@ func TestFailRotateDrop(t *testing.T) {
 	_, err := g.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, 0, r2.HitCount())
+}
+
+// Return SERVFAIL if all available resolvers return that
+func TestFailRotateSERVFAILAll(t *testing.T) {
+	var ci ClientInfo
+	opt := StaticResolverOptions{
+		RCode: dns.RcodeServerFailure,
+	}
+	r, err := NewStaticResolver("test-static", opt)
+	require.NoError(t, err)
+
+	g := NewFailRotate("test-rotate", r, r)
+	q := new(dns.Msg)
+	q.SetQuestion("test.com.", dns.TypeA)
+
+	a, err := g.Resolve(q, ci)
+	require.NoError(t, err)
+	require.Equal(t, dns.RcodeServerFailure, a.Rcode)
 }


### PR DESCRIPTION
Always return the last error when all resolvers in a group fail (with errors or SERVFAIL) as per #99 