### PR TITLE
New 'fastest' group

### DIFF
--- a/cmd/routedns/example-config/fastest.toml
+++ b/cmd/routedns/example-config/fastest.toml
@@ -1,0 +1,25 @@
+# Example of how to use a Fastest group of resolvers. Queries are routed
+# to all upstream resolvers concurrently and only the fastest (non-error)
+# response is used. Consider that this increases the overall query load.
+
+[listeners.local-udp]
+address = "127.0.0.1:53"
+protocol = "udp"
+resolver = "fastest"
+
+[groups.fastest]
+type   = "fastest"
+resolvers = ["cloudflare-dot-1", "cloudflare-dot-2", "google-dot"]
+
+[resolvers.cloudflare-dot-1]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[resolvers.cloudflare-dot-2]
+address = "1.0.0.1:853"
+protocol = "dot"
+
+[resolvers.google-dot]
+address = "8.8.8.8:853"
+protocol = "dot"
+

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -270,6 +270,8 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 		resolvers[id] = rdns.NewFailRotate(id, gr...)
 	case "fail-back":
 		resolvers[id] = rdns.NewFailBack(id, rdns.FailBackOptions{ResetAfter: time.Minute}, gr...)
+	case "fastest":
+		resolvers[id] = rdns.NewFastest(id, gr...)
 	case "random":
 		resolvers[id] = rdns.NewRandom(id, rdns.RandomOptions{ResetAfter: time.Minute}, gr...)
 	case "blocklist":

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -18,6 +18,7 @@
   - [Fail-Rotate group](#Fail-Rotate-group)
   - [Fail-Back group](#Fail-Back-group)
   - [Random group](#Random-group)
+  - [Fastest group](#Fastest-group)
   - [Replace](#Replace)
   - [Query Blocklist](#Query-Blocklist)
   - [Response Blocklist](#Response-Blocklist)
@@ -425,6 +426,28 @@ resolvers = ["cloudflare-dot-1", "cloudflare-dot-2", "google-dot"]
 ```
 
 Example config files: [random-resolver.toml](../cmd/routedns/example-config/random-resolver.toml)
+
+### Fastest group
+
+This group will send every query to all configured resolvers but only use the fastest (successful) response. Slower responses are discarded. Use sparingly as this increases the overall query load on upstream resolvers.
+
+#### Configuration
+
+Fastest groups are instantiated with `type = "fastest"` in the groups section of the configuration.
+
+Options:
+
+- `resolvers` - An array of upstream resolvers or modifiers.
+
+#### Examples
+
+```toml
+[groups.fastest]
+type   = "fastest"
+resolvers = ["cloudflare-dot-1", "cloudflare-dot-2", "google-dot"]
+```
+
+Example config files: [fastest.toml](../cmd/routedns/example-config/fastest.toml)
 
 ### Replace
 

--- a/fastest.go
+++ b/fastest.go
@@ -1,0 +1,68 @@
+package rdns
+
+import (
+	"github.com/miekg/dns"
+)
+
+// Fastest is a resolver group that queries all resolvers concurrently for
+// the same query, then returns the fastest response only.
+type Fastest struct {
+	id        string
+	resolvers []Resolver
+}
+
+var _ Resolver = &FailRotate{}
+
+// NewFastest returns a new instance of a resolver group that returns the fastest
+// response from all its resolvers.
+func NewFastest(id string, resolvers ...Resolver) *Fastest {
+	return &Fastest{
+		id:        id,
+		resolvers: resolvers,
+	}
+}
+
+// Resolve a DNS query by sending it to all resolvers and returning the fastest
+// non-error response
+func (r *Fastest) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+	log := logger(r.id, q, ci)
+
+	type response struct {
+		r   Resolver
+		a   *dns.Msg
+		err error
+	}
+
+	responseCh := make(chan response, len(r.resolvers))
+
+	// Send the query to all resolvers. The responses are collected in a buffered channel
+	for _, resolver := range r.resolvers {
+		resolver := resolver
+		go func() {
+			a, err := resolver.Resolve(q, ci)
+			responseCh <- response{resolver, a, err}
+		}()
+	}
+
+	// Wait for responses, the first one that is successful is returned while the remaining open requests
+	// are abandoned.
+	var i int
+	for resolverResponse := range responseCh {
+		resolver, a, err := resolverResponse.r, resolverResponse.a, resolverResponse.err
+		if err == nil && (a == nil || a.Rcode != dns.RcodeServerFailure) { // Return immediately if successful
+			log.WithField("resolver", resolver.String()).Trace("using response from resolver")
+			return a, err
+		}
+		log.WithField("resolver", resolver.String()).WithError(err).Debug("resolver returned failure, waiting for next response")
+
+		// If all responses were bad, return the last one
+		if i++; i >= len(r.resolvers) {
+			return a, err
+		}
+	}
+	return nil, nil // should never be reached
+}
+
+func (r *Fastest) String() string {
+	return r.id
+}

--- a/fastest_test.go
+++ b/fastest_test.go
@@ -1,0 +1,126 @@
+package rdns
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFastest(t *testing.T) {
+	// Build 2 resolvers that count the number of invocations
+	var ci ClientInfo
+	r1 := &TestResolver{ // slow resolver, with one A record in the response
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			time.Sleep(10 * time.Millisecond)
+			a := new(dns.Msg)
+			a.SetReply(q)
+			a.Answer = []dns.RR{
+				&dns.A{
+					Hdr: dns.RR_Header{
+						Name:   q.Question[0].Name,
+						Rrtype: dns.TypeA,
+						Class:  dns.ClassINET,
+					},
+					A: net.IP{127, 0, 0, 1},
+				},
+			}
+			return a, nil
+
+		},
+	}
+	r2 := new(TestResolver) // fast resolver
+
+	g := NewFastest("fastest", r1, r2)
+	q := new(dns.Msg)
+	q.SetQuestion("test.com.", dns.TypeA)
+
+	// Send the first query, it should go to both and the fast response (with A record) should come back.
+	a, err := g.Resolve(q, ci)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond) // Wait to make sure both resolvers are actually hit before checking the hit-count
+
+	require.Equal(t, 1, r1.HitCount())
+	require.Equal(t, 1, r2.HitCount())
+	require.Equal(t, 0, len(a.Answer))
+}
+
+func TestFastestFail(t *testing.T) {
+	var ci ClientInfo
+
+	// Fast resolver that fails
+	opt := StaticResolverOptions{
+		RCode: dns.RcodeServerFailure,
+	}
+	r1, err := NewStaticResolver("test-static", opt)
+	require.NoError(t, err)
+
+	// Slow resolver that succeeds
+	r2 := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			time.Sleep(10 * time.Millisecond)
+			a := new(dns.Msg)
+			a.SetReply(q)
+			a.Answer = []dns.RR{
+				&dns.A{
+					Hdr: dns.RR_Header{
+						Name:   q.Question[0].Name,
+						Rrtype: dns.TypeA,
+						Class:  dns.ClassINET,
+					},
+					A: net.IP{127, 0, 0, 1},
+				},
+			}
+			return a, nil
+
+		},
+	}
+
+	g := NewFastest("fastest", r1, r2)
+	q := new(dns.Msg)
+	q.SetQuestion("test.com.", dns.TypeA)
+
+	// We have a fast failing, and a slow succeeding one. Expect success
+	a, err := g.Resolve(q, ci)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, r2.HitCount())
+	require.Equal(t, 1, len(a.Answer))
+
+}
+func TestFastestFailAll(t *testing.T) {
+	var ci ClientInfo
+
+	// Fast resolver that fails with an error
+	r1 := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			return nil, errors.New("failed")
+		},
+	}
+
+	// Slow resolver that fails with SERVFAIL
+	r2 := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			time.Sleep(10 * time.Millisecond)
+			a := new(dns.Msg)
+			a.SetRcode(q, dns.RcodeServerFailure)
+			return a, nil
+		},
+	}
+
+	g := NewFastest("fastest", r1, r2)
+	q := new(dns.Msg)
+	q.SetQuestion("test.com.", dns.TypeA)
+
+	// Expect the response to be from the slow SERVFAIL
+	a, err := g.Resolve(q, ci)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, r1.HitCount())
+	require.Equal(t, 1, r2.HitCount())
+	require.Equal(t, dns.RcodeServerFailure, a.Rcode)
+}


### PR DESCRIPTION
The new element sends every query to all upstream resolvers and picks the fastest response. Implements #110 