### PR TITLE
Restore the original query ID when DoQ fails

### DIFF
--- a/dnslistener.go
+++ b/dnslistener.go
@@ -72,8 +72,7 @@ func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNe
 			if err != nil {
 				metrics.err.Add("resolve", 1)
 				log.WithError(err).Error("failed to resolve")
-				a = new(dns.Msg)
-				a.SetRcode(req, dns.RcodeServerFailure)
+				a = servfail(req)
 			}
 		} else {
 			metrics.err.Add("acl", 1)

--- a/doqclient.go
+++ b/doqclient.go
@@ -33,7 +33,7 @@ type DoQClient struct {
 
 // DoQClientOptions contains options used by the DNS-over-QUIC resolver.
 type DoQClientOptions struct {
-	// Bootstrap address - IP to use for the serivce instead of looking up
+	// Bootstrap address - IP to use for the service instead of looking up
 	// the service's hostname with potentially plain DNS.
 	BootstrapAddr string
 
@@ -110,9 +110,12 @@ func (d *DoQClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		edns0.Option = newOpt
 	}
 
-	// When sending queries over a DoQ, the DNS Message ID MUST be set to zero.
+	// When sending queries over a DoQ, the DNS Message ID MUST be set to zero. Don't forget
+	// to restore the ID in the original query, it could be needed for error responses further
+	// up
 	id := q.Id
 	q.Id = 0
+	defer func() { q.Id = id }()
 
 	// Encode the query
 	b, err := q.Pack()

--- a/doqclient_test.go
+++ b/doqclient_test.go
@@ -1,0 +1,31 @@
+package rdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDOQSimple(t *testing.T) {
+	d, err := NewDoQClient("test-doq", "dns-unfiltered.adguard.com:784", DoQClientOptions{})
+	require.NoError(t, err)
+	q := new(dns.Msg)
+	q.SetQuestion("google.com.", dns.TypeA)
+	id := q.Id
+	r, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.NotEmpty(t, r.Answer)
+	require.Equal(t, id, r.Id)
+}
+
+func TestDOQError(t *testing.T) {
+	d, err := NewDoQClient("test-doq", "127.0.0.1:0", DoQClientOptions{})
+	require.NoError(t, err)
+	q := new(dns.Msg)
+	q.SetQuestion("google.com.", dns.TypeA)
+	id := q.Id
+	_, err = d.Resolve(q, ClientInfo{})
+	require.Error(t, err)
+	require.Equal(t, id, q.Id) // Shouldn't touch the ID in the query
+}

--- a/message.go
+++ b/message.go
@@ -27,6 +27,11 @@ func nxdomain(q *dns.Msg) *dns.Msg {
 	return responseWithCode(q, dns.RcodeNameError)
 }
 
+// Returns a SERVFAIL answer for a query.
+func servfail(q *dns.Msg) *dns.Msg {
+	return responseWithCode(q, dns.RcodeServerFailure)
+}
+
 // Returns a REFUSED answer for a query.
 func refused(q *dns.Msg) *dns.Msg {
 	return responseWithCode(q, dns.RcodeRefused)


### PR DESCRIPTION
Fixes #119 