### PR TITLE
Update QUIC to support RFC9000

### DIFF
--- a/cmd/routedns/example-config/mutual-tls-doq-client.toml
+++ b/cmd/routedns/example-config/mutual-tls-doq-client.toml
@@ -1,0 +1,17 @@
+# This is the client-half of a fully secure DoH-over-QUIC configuration
+# where the server is private and expects the client to present a cert
+# by a CA it trusts. All queries received locally will be forwarded over
+# DOH to the server, which then passes it on to its upstream servers.
+
+[resolvers.myserver-doh]
+address = "https://127.0.0.1:8443/dns-query"
+protocol = "doh"
+transport = "quic"
+ca = "../../testdata/ca.crt"
+client-crt = "../../testdata/client.crt"
+client-key = "../../testdata/client.key"
+
+[listeners.local]
+address = ":53"
+protocol = "udp"
+resolver = "myserver-doh"

--- a/cmd/routedns/example-config/mutual-tls-doq-server.toml
+++ b/cmd/routedns/example-config/mutual-tls-doq-server.toml
@@ -1,0 +1,18 @@
+# This is the server-side of a secure DOH-over-QUIC proxy where the server
+# expects the client to present a signed certificate it trusts (mutual-TLS).
+# Any query received from the client this way, will then be forwarded to
+# Cloudflare via DoT by the server.
+
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[listeners.local-doh]
+address = ":8443"
+protocol = "doh"
+transport = "quic"
+resolver = "cloudflare-dot"
+server-crt = "../../testdata/server.crt"
+server-key = "../../testdata/server.key"
+ca = "../../testdata/ca.crt"
+mutual-tls = true

--- a/doqlistener.go
+++ b/doqlistener.go
@@ -91,7 +91,7 @@ func (s DoQListener) Start() error {
 
 		go func() {
 			s.handleSession(session)
-			_ = session.CloseWithError(quic.ErrorCode(DOQNoError), "")
+			_ = session.CloseWithError(DOQNoError, "")
 			s.log.Trace("closing session")
 		}()
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/heimdalr/dag v1.0.1
 	github.com/jtacoma/uritemplates v1.0.0
-	github.com/lucas-clemente/quic-go v0.20.0
+	github.com/lucas-clemente/quic-go v0.21.0
 	github.com/miekg/dns v1.1.41
 	github.com/oschwald/maxminddb-golang v1.8.0
 	github.com/pion/dtls/v2 v2.0.8

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lucas-clemente/quic-go v0.20.0 h1:FSU3YN5VnLafHR27Ejs1r1CYMS7XMyIVDzRewkDLNBw=
 github.com/lucas-clemente/quic-go v0.20.0/go.mod h1:fZq/HUDIM+mW6X6wtzORjC0E/WDBMKe5Hf9bgjISwLk=
+github.com/lucas-clemente/quic-go v0.21.0 h1:ZdC8UBxUSBdPlEv1+4y4SqIBy54VA8bRxN7DmkQ0URs=
+github.com/lucas-clemente/quic-go v0.21.0/go.mod h1:BWkfkkOSJD1AxFNBqdjBZi6FznZ96bhdcvZiA+LDrY8=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -174,6 +176,7 @@ github.com/marten-seemann/qtls-go1-15 v0.1.4 h1:RehYMOyRW8hPVEja1KBVsFVNSm35Jj9M
 github.com/marten-seemann/qtls-go1-15 v0.1.4/go.mod h1:GyFwywLKkRt+6mfU99csTEY1joMZz5vmB1WNZH3P81I=
 github.com/marten-seemann/qtls-go1-16 v0.1.3 h1:XEZ1xGorVy9u+lJq+WXNE+hiqRYLNvJGYmwfwKQN2gU=
 github.com/marten-seemann/qtls-go1-16 v0.1.3/go.mod h1:gNpI2Ol+lRS3WwSOtIUUtRwZEQMXjYK+dQSBFbethAk=
+github.com/marten-seemann/qtls-go1-17 v0.1.0-alpha.1/go.mod h1:lQDiKZDfPagLmg1zMtEgoBMSTAORq6M08lBogD5FtBY=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=


### PR DESCRIPTION
- Updates the QUIC library to support RFC9000
- Reworks/clean up the QUIC usage 
- Fix https://github.com/folbricht/routedns/issues/160