### PR TITLE
Support retry on truncation

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -112,6 +112,11 @@ func (r *Cache) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		return nil, err
 	}
 
+	// Don't cache truncated responses
+	if a.Truncated {
+		return a, nil
+	}
+
 	// Put the upstream response into the cache and return it. Need to store
 	// a copy since other elements might modify the response, like the replacer.
 	r.storeInCache(q, a.Copy())

--- a/cache_test.go
+++ b/cache_test.go
@@ -38,7 +38,7 @@ func TestCache(t *testing.T) {
 	c := NewCache("test-cache", r, opt)
 
 	// First query should be a cache-miss and be passed on to the upstream resolver
-	q.SetQuestion("test.com.", dns.TypeA)
+	q.SetQuestion("example.com.", dns.TypeA)
 	a, err := c.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, 1, r.HitCount())
@@ -54,7 +54,7 @@ func TestCache(t *testing.T) {
 
 	// Different question should go through to upstream again, low TTL
 	answerTTL = 1
-	q.SetQuestion("test2.com.", dns.TypeA)
+	q.SetQuestion("example2.com.", dns.TypeA)
 	a, err = c.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, 2, r.HitCount())
@@ -63,7 +63,7 @@ func TestCache(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// TTL should have expired now, so this should be a cache-miss and be sent upstream
-	q.SetQuestion("test2.com.", dns.TypeA)
+	q.SetQuestion("example2.com.", dns.TypeA)
 	_, err = c.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, 3, r.HitCount())
@@ -88,7 +88,7 @@ func TestCacheNXDOMAIN(t *testing.T) {
 
 	// First query should be a cache-miss and be passed on to the upstream resolver
 	// Since it's an NXDOMAIN it should end up in the cache as well, with default TTL
-	q.SetQuestion("test.com.", dns.TypeA)
+	q.SetQuestion("example.com.", dns.TypeA)
 	_, err := c.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, 1, r.HitCount())
@@ -118,14 +118,14 @@ func TestCacheHardenBelowNXDOMAIN(t *testing.T) {
 	c := NewCache("test-cache", r, opt)
 
 	// Cache an NXDOMAIN for the parent domain
-	q.SetQuestion("test.com.", dns.TypeA)
+	q.SetQuestion("example.com.", dns.TypeA)
 	_, err := c.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, 1, r.HitCount())
 
 	// A sub-domain query should also return NXDOMAIN based on the cached
 	// record for the parent if HardenBelowNXDOMAIN is enabled.
-	q.SetQuestion("not.exist.test.com.", dns.TypeA)
+	q.SetQuestion("not.exist.example.com.", dns.TypeA)
 	a, err := c.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, 1, r.HitCount())
@@ -190,7 +190,7 @@ func TestCacheNoTruncated(t *testing.T) {
 	c := NewCache("test-cache", r, CacheOptions{})
 
 	// Both queries should hit the upstream resolver
-	q.SetQuestion("test.com.", dns.TypeA)
+	q.SetQuestion("example.com.", dns.TypeA)
 	_, err := c.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, 1, r.HitCount())

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -47,6 +47,7 @@ type resolver struct {
 	ClientCrt     string `toml:"client-crt"`
 	BootstrapAddr string `toml:"bootstrap-address"`
 	LocalAddr     string `toml:"local-address"`
+	EDNS0UDPSize  uint16 `toml:"edns0-udp-size"` // UDP resolver option
 }
 
 // DoH-specific resolver options
@@ -118,6 +119,9 @@ type group struct {
 
 	// Response Collapse options
 	NullRCode int `toml:"null-rcode"` // Response code if after collapsing, no answers are left
+
+	// Truncate-Retry options
+	RetryResolver string `toml:"retry-resolver"`
 }
 
 // Block/Allowlist items for blocklist-v2

--- a/cmd/routedns/example-config/truncate-retry.toml
+++ b/cmd/routedns/example-config/truncate-retry.toml
@@ -1,0 +1,37 @@
+# Example showing how to handle truncated responses that can occur with
+# UDP and DTLS responses. The `truncate-retry` element will always try
+# the primary UDP resolver first, but if the respone is truncated it'll
+# retry using the (slower) TCP resolver. This ensures that only complete
+# responses are cached.
+
+# Primary resolver (UDP)
+[resolvers.cloudflare-udp]
+address = "1.1.1.1:53"
+protocol = "udp"
+edns0-udp-size = 1232
+
+# TCP Fallback resolver if UDP responses are truncated
+[resolvers.cloudflare-tcp]
+address = "1.1.1.1:53"
+protocol = "tcp"
+
+# Try UDP first, if truncated use the alernative
+[groups.retry]
+type = "truncate-retry"
+resolvers = ["cloudflare-udp"]
+retry-resolver = "cloudflare-tcp"
+
+[groups.cache]
+type = "cache"
+resolvers = ["retry"]
+
+[listeners.local-udp]
+address = "127.0.0.1:1153"
+protocol = "udp"
+resolver = "cache"
+
+[listeners.local-tcp]
+address = "127.0.0.1:1153"
+protocol = "tcp"
+resolver = "cache"
+

--- a/cmd/routedns/example-config/truncate-retry.toml
+++ b/cmd/routedns/example-config/truncate-retry.toml
@@ -26,12 +26,12 @@ type = "cache"
 resolvers = ["retry"]
 
 [listeners.local-udp]
-address = "127.0.0.1:1153"
+address = "127.0.0.1:53"
 protocol = "udp"
 resolver = "cache"
 
 [listeners.local-tcp]
-address = "127.0.0.1:1153"
+address = "127.0.0.1:53"
 protocol = "tcp"
 resolver = "cache"
 

--- a/cmd/routedns/example-config/use-case-2.toml
+++ b/cmd/routedns/example-config/use-case-2.toml
@@ -2,14 +2,35 @@
 # is sent to the company DNS servers. All other queries are sent securely via
 # DNS-over-HTTPS.
 
-# Define the two company DNS servers. Both use plain (insecure) DNS over UDP
-[resolvers.mycompany-dns-a]
+# Define the two company DNS servers. Both use plain (insecure) DNS over UDP and
+# TCP when a truncated response is received
+[resolvers.mycompany-dns-a-udp]
 address = "10.0.0.1:53"
 protocol = "udp"
 
-[resolvers.mycompany-dns-b]
+# TCP Fallback resolver if UDP responses are truncated
+[resolvers.mycompany-dns-a-tcp]
+address = "10.0.0.1:53"
+protocol = "tcp"
+
+# Try UDP first, if truncated use the alernative TCP one
+[groups.mycompany-dns-a]
+type = "truncate-retry"
+resolvers = ["mycompany-dns-a-udp"]
+retry-resolver = "mycompany-dns-a-tcp"
+
+[resolvers.mycompany-dns-b-udp]
 address = "10.0.0.2:53"
 protocol = "udp"
+
+[resolvers.mycompany-dns-b-tcp]
+address = "10.0.0.2:53"
+protocol = "tcp"
+
+[groups.mycompany-dns-b]
+type = "truncate-retry"
+resolvers = ["mycompany-dns-b-udp"]
+retry-resolver = "mycompany-dns-b-tcp"
 
 # Define the Cloudflare DNS-over-HTTPS resolver (GET methods) since that is most likely allowed outbound
 [resolvers.cloudflare-doh-1-1-1-1-get]

--- a/cmd/routedns/example-config/use-case-4.toml
+++ b/cmd/routedns/example-config/use-case-4.toml
@@ -2,14 +2,34 @@
 # supports modifying queries for short hostnames such as prod-server1 into
 # queries for server1.prod-domain.com and are routint to the correct DNS server.
 
-# Lab DNS servers
-[resolvers.prod-dns]
+# Lab DNS servers. Define both UDP and TCP, with TCP only used when responses
+# are truncated.
+[resolvers.prod-dns-udp]
 address = "10.1.1.1:53"
 protocol = "udp"
 
-[resolvers.test-dns]
+[resolvers.prod-dns-tcp]
+address = "10.1.1.1:53"
+protocol = "tcp"
+
+[resolvers.test-dns-udp]
 address = "10.2.1.1:53"
 protocol = "udp"
+
+[resolvers.test-dns-tcp]
+address = "10.2.1.1:53"
+protocol = "tcp"
+
+# Try UDP first, if truncated use the alernative TCP one
+[groups.prod-dns]
+type = "truncate-retry"
+resolvers = ["prod-dns-udp"]
+retry-resolver = "prod-dns-tcp"
+
+[groups.test-dns]
+type = "truncate-retry"
+resolvers = ["test-dns-udp"]
+retry-resolver = "test-dns-tcp"
 
 # Standard Cloudflare DoT, used for everything not destined to the lab
 [resolvers.cloudflare-dot]

--- a/cmd/routedns/resolver.go
+++ b/cmd/routedns/resolver.go
@@ -48,6 +48,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			BootstrapAddr: r.BootstrapAddr,
 			LocalAddr:     net.ParseIP(r.LocalAddr),
 			DTLSConfig:    dtlsConfig,
+			UDPSize:       r.EDNS0UDPSize,
 		}
 		resolvers[id], err = rdns.NewDTLSClient(id, r.Address, opt)
 		if err != nil {
@@ -72,6 +73,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 	case "tcp", "udp":
 		opt := rdns.DNSClientOptions{
 			LocalAddr: net.ParseIP(r.LocalAddr),
+			UDPSize:   r.EDNS0UDPSize,
 		}
 		resolvers[id], err = rdns.NewDNSClient(id, r.Address, r.Protocol, opt)
 		if err != nil {

--- a/dnslistener.go
+++ b/dnslistener.go
@@ -101,12 +101,7 @@ func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNe
 			if edns0 := req.IsEdns0(); edns0 != nil {
 				maxSize = int(edns0.UDPSize())
 			}
-			if a.Len() > maxSize {
-				log.WithField("max", maxSize).Trace("response too large, truncating")
-				a = new(dns.Msg)
-				a.SetReply(req)
-				a.Truncated = true
-			}
+			a.Truncate(maxSize)
 		}
 
 		metrics.response.Add(rCode(a), 1)

--- a/dnslistener.go
+++ b/dnslistener.go
@@ -94,6 +94,21 @@ func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNe
 		} else {
 			stripPadding(a)
 		}
+
+		// Check the response actually fits if the query was sent over UDP. If not, respond with TC flag.
+		if protocol == "udp" || protocol == "dtls" {
+			maxSize := dns.MinMsgSize
+			if edns0 := req.IsEdns0(); edns0 != nil {
+				maxSize = int(edns0.UDPSize())
+			}
+			if a.Len() > maxSize {
+				log.WithField("max", maxSize).Trace("response too large, truncating")
+				a = new(dns.Msg)
+				a.SetReply(req)
+				a.Truncated = true
+			}
+		}
+
 		metrics.response.Add(rCode(a), 1)
 		_ = w.WriteMsg(a)
 	}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -32,7 +32,9 @@
   - [Response Collapse](#Response-Collapse)
   - [Router](#Router)
   - [Rate Limiter](#Rate-Limiter)
-  - [Fastest TCP Probe](#Fastest TCP Probe)
+  - [Rate Limiter](#Rate-Limiter)
+  - [Fastest TCP Probe](#Fastest-TCP-Probe)
+  - [Retrying Truncated Responses](#Retrying-Truncated-Responses)
 - [Resolvers](#Resolvers)
   - [Plain DNS](#Plain-DNS-Resolver)
   - [DNS-over-TLS](#DNS-over-TLS-Resolver)
@@ -1158,6 +1160,58 @@ resolvers = ["cloudflare-dot"]
 
 Example config files: [fastest-tcp.toml](../cmd/routedns/example-config/fastest-tcp.toml)
 
+### Retrying Truncated Responses
+
+The `truncated-retry` element will first perform a lookup using its primary resolver. If the response from the primary is truncated, the same query is retried with the secondary `retry-resolver`. This element is only useful if the primary resolver uses either plain UDP or DTLS as those apply limits to the size of the response. In addition, it is typically used behind a [cache](#Cache) which can then store the full response and respond faster to clients which too may have to retry the query if using a UDP or DTLS listener.
+
+#### Configuration
+
+To support switching to streaming resolvers on truncation, add an element with `type = "truncate-retry"` in the groups section of the configuration, right before the resolver.
+
+Options:
+
+- `resolvers` - Array of upstream resolvers, only one is supported.
+- `retry-resolver` - Must be referencing another resolver, typically using a stream-protocol such as TCP, DoH, or DoT.
+
+Examples:
+
+TCP probe for the HTTPS port. Successful probes are cached for 30min.
+
+```toml
+# Primary resolver (UDP)
+[resolvers.cloudflare-udp]
+address = "1.1.1.1:53"
+protocol = "udp"
+edns0-udp-size = 1232
+
+# TCP Fallback resolver if UDP responses are truncated
+[resolvers.cloudflare-tcp]
+address = "1.1.1.1:53"
+protocol = "tcp"
+
+# Try UDP first, if truncated use the alernative (TCP)
+[groups.retry]
+type = "truncate-retry"
+resolvers = ["cloudflare-udp"]
+retry-resolver = "cloudflare-tcp"
+
+[groups.cache]
+type = "cache"
+resolvers = ["retry"]
+
+[listeners.local-udp]
+address = "127.0.0.1:1153"
+protocol = "udp"
+resolver = "cache"
+
+[listeners.local-tcp]
+address = "127.0.0.1:1153"
+protocol = "tcp"
+resolver = "cache"
+```
+
+Example config files: [truncate-retry.toml](../cmd/routedns/example-config/truncate-retry.toml)
+
 ## Resolvers
 
 Resolvers forward queries to other DNS servers over the network and typically represent the end of one or many processing pipelines. Resolvers encode every query that is passed from listeners, modifiers, routers etc and send them to a DNS server without further processing. Like with other elements in the pipeline, resolvers requires a unique identifier to reference them from other elements. The following protocols are supported:
@@ -1174,6 +1228,7 @@ Resolvers are defined in the configuration like so `[resolvers.NAME]` and have t
 - `protocol` - The DNS protocol used to send queries, can be `udp`, `tcp`, `dot`, `doh`, `doq`.
 - `bootstrap-address` - Use this IP address if the name in `address` can't be resolved. Using the IP in `address` directly may not work when TLS/certificates are used by the server.
 - `local-address` - IP of the local interface to use for outgoing connections. The address is automatically chosen if this option is left blank.
+- `edns0-udp-size` - If set, modifies the EDNS0 UDP size option in all queries sent upstream. Only meaningful when using UDP or DTLS resolvers. Upstream resolvers may not respect this value and apply their own limits.
 
 Secure resolvers such as DoT, DoH, or DoQ offer additional options to configure the TLS connections.
 
@@ -1222,7 +1277,7 @@ bootstrap-address = "8.8.8.8"
 
 ### Plain DNS Resolver
 
-Plain, un-encrypted DNS protocol clients for UDP or TCP. Use `protocol = "udp"` or `protocol = "tcp"`.
+Plain, un-encrypted DNS protocol clients for UDP or TCP. Use `protocol = "udp"` or `protocol = "tcp"`. Note that UDP responses can be truncated so it is common to use use it in combination with a [truncate-retry](#Retrying-Truncated-Responses) group to define a fallback.
 
 Examples:
 
@@ -1236,7 +1291,7 @@ address = "1.1.1.1:53"
 protocol = "tcp"
 ```
 
-Example config files: [well-known.toml](../cmd/routedns/example-config/well-known.toml)
+Example config files: [well-known.toml](../cmd/routedns/example-config/well-known.toml), [truncate-retry.toml](../cmd/routedns/example-config/truncate-retry.toml)
 
 ### DNS-over-TLS Resolver
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1200,12 +1200,12 @@ type = "cache"
 resolvers = ["retry"]
 
 [listeners.local-udp]
-address = "127.0.0.1:1153"
+address = "127.0.0.1:53"
 protocol = "udp"
 resolver = "cache"
 
 [listeners.local-tcp]
-address = "127.0.0.1:1153"
+address = "127.0.0.1:53"
 protocol = "tcp"
 resolver = "cache"
 ```

--- a/message.go
+++ b/message.go
@@ -61,3 +61,22 @@ func ptr(q *dns.Msg, name string) *dns.Msg {
 	}
 	return a
 }
+
+// Changes the UDP size in the EDNS0 record and returns a
+// copy of the query. Adds an OPT record if there isn't one
+// already. If size is 0, the original query is returned.
+func setUDPSize(q *dns.Msg, size uint16) *dns.Msg {
+	if size == 0 {
+		return q
+	}
+	copy := q.Copy()
+	// Set the EDNS0 size. Adds an OPT record if there isn't
+	// one already
+	edns0 := copy.IsEdns0()
+	if edns0 != nil {
+		edns0.SetUDPSize(size)
+	} else {
+		q.SetEdns0(size, false)
+	}
+	return copy
+}

--- a/truncate-retry.go
+++ b/truncate-retry.go
@@ -1,0 +1,50 @@
+package rdns
+
+import (
+	"github.com/miekg/dns"
+)
+
+// TruncateRetry retries truncated responses with an alternative resolver. This
+// is typically used when using UDP/DTLS transports, to fail over to a stream-
+// based protocol.
+type TruncateRetry struct {
+	id string
+	TruncateRetryOptions
+	resolver      Resolver
+	retryResolver Resolver
+}
+
+var _ Resolver = &TruncateRetry{}
+
+type TruncateRetryOptions struct {
+}
+
+// NewTruncateRetry returns a new instance of a truncate-retry router.
+func NewTruncateRetry(id string, resolver, retryResolver Resolver, opt TruncateRetryOptions) *TruncateRetry {
+	return &TruncateRetry{
+		id:                   id,
+		TruncateRetryOptions: opt,
+		retryResolver:        retryResolver,
+		resolver:             resolver,
+	}
+}
+
+// Resolve a DNS query by first resoling it upstream, if the response is truncated, the
+// retry resolver is used to resolve the same query again.
+func (r *TruncateRetry) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+	a, err := r.resolver.Resolve(q, ci)
+	if err != nil || a == nil {
+		return a, err
+	}
+
+	// Retry the same query on the other resolver if the first one returned a truncated response.
+	if a.Truncated {
+		logger(r.id, q, ci).WithField("resolver", r.retryResolver).Debug("truncated response, forwarding to retry-resolver")
+		a, err = r.retryResolver.Resolve(q, ci)
+	}
+	return a, err
+}
+
+func (r *TruncateRetry) String() string {
+	return r.id
+}


### PR DESCRIPTION
Introduces `truncate-retry` group to support UDP truncation. Also improves handling of the TC bit when using UDP listeners as per #170