### PR TITLE
Support no-tls option on DoH (TCP) servers

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -28,6 +28,7 @@ type listener struct {
 	ServerKey  string   `toml:"server-key"`
 	ServerCrt  string   `toml:"server-crt"`
 	MutualTLS  bool     `toml:"mutual-tls"`
+	NoTLS      bool     `toml:"no-tls"` // Disable TLS in DoH servers
 	AllowedNet []string `toml:"allowed-net"`
 	Frontend   dohFrontend
 }

--- a/cmd/routedns/example-config/doh-no-tls.toml
+++ b/cmd/routedns/example-config/doh-no-tls.toml
@@ -1,0 +1,11 @@
+# Example of a DoH server that doesn't use TLS (insecure).
+
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[listeners.local-doh]
+address = ":8080"
+protocol = "doh"
+resolver = "cloudflare-dot"
+no-tls = true

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -184,7 +184,7 @@ Example config files: [mutual-tls-dot-server.toml](../cmd/routedns/example-confi
 
 ### DNS-over-HTTPS
 
-As per [RFC8484](https://tools.ietf.org/html/rfc8484), DNS using the HTTPS protocol are configured with `protocol = "doh"`. By default, DoH uses TCP as transport, but it can also be run over QUIC by providing the option `transport = "quic"`.
+As per [RFC8484](https://tools.ietf.org/html/rfc8484), DNS using the HTTPS protocol are configured with `protocol = "doh"`. By default, DoH uses TCP as transport, but it can also be run over QUIC by providing the option `transport = "quic"`. For TCP transport, TLS can be disabled with the `no-tls = true` option which can be used for testing or when the server is only accessible via reverse proxy that terminates TLS already.
 
 Examples:
 
@@ -223,7 +223,7 @@ server-key = "/path/to/server.key"
 frontend = { trusted-proxy = "192.168.1.0/24" }
 ```
 
-Example config files: [mutual-tls-doh-server.toml](../cmd/routedns/example-config/mutual-tls-doh-server.toml), [doh-quic-server.toml](../cmd/routedns/example-config/doh-quic-server.toml), [doh-behind-proxy.toml](../cmd/routedns/example-config/doh-behind-proxy.toml)
+Example config files: [mutual-tls-doh-server.toml](../cmd/routedns/example-config/mutual-tls-doh-server.toml), [doh-quic-server.toml](../cmd/routedns/example-config/doh-quic-server.toml), [doh-behind-proxy.toml](../cmd/routedns/example-config/doh-behind-proxy.toml), [doh-no-tls.toml](../cmd/routedns/example-config/doh-no-tls.toml)
 
 ### DNS-over-DTLS
 

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -49,6 +49,9 @@ type DoHListenerOptions struct {
 
 	// IP(v4/v6) subnet of known reverse proxies in front of this server.
 	HTTPProxyNet *net.IPNet
+
+	// Disable TLS on the server (insecure, for testing purposes only).
+	NoTLS bool
 }
 
 type DoHListenerMetrics struct {
@@ -119,6 +122,9 @@ func (s *DoHListener) startTCP() error {
 		return err
 	}
 	defer ln.Close()
+	if s.opt.NoTLS {
+		return s.httpServer.Serve(ln)
+	}
 	return s.httpServer.ServeTLS(ln, "", "")
 }
 


### PR DESCRIPTION
Allows disabling TLS on TCP-DoH servers to support reverse proxies that terminate TLS already.

Fixes #214 