### PR TITLE
Ability to route by DoH path

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -156,6 +156,7 @@ type route struct {
 	Weekdays      []string // 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'
 	After, Before string   // Hour:Minute in 24h format, for example "14:30"
 	Invert        bool     // Invert the result of the match
+	DoHPath       string   `toml:"doh-path"` // DoH query path if received over DoH (regexp)
 	Resolver      string
 }
 

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -701,7 +701,7 @@ func instantiateRouter(id string, r router, resolvers map[string]rdns.Resolver) 
 		if route.Type != "" { // Support the deprecated "Type" by just adding it to "Types" if defined
 			types = append(types, route.Type)
 		}
-		r, err := rdns.NewRoute(route.Name, route.Class, types, route.Weekdays, route.Before, route.After, route.Source, resolver)
+		r, err := rdns.NewRoute(route.Name, route.Class, types, route.Weekdays, route.Before, route.After, route.Source, route.DoHPath, resolver)
 		if err != nil {
 			return fmt.Errorf("failure parsing routes for router '%s' : %s", id, err.Error())
 		}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1043,6 +1043,7 @@ A route has the following fields:
 - `after` - Time of day in the format HH:mm after which the rule matches. Uses 24h format. For example `09:00`. Note that together with the `before` parameter it is possible to accidentally write routes that can never trigger. For example `after=12:00 before=11:00` can never match as both conditions have to be met for the route to be used.
 - `before` - Time of day in the format HH:mm before which the rule matches. Uses 24h format. For example `17:30`.
 - `invert` - Invert the result of the matching if set to `true`. Optional.
+- `doh-path` - Regexp that matches on the DoH query path the client used.
 - `resolver` - The identifier of a resolver, group, or another router. Required.
 
 Examples:

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -242,7 +242,15 @@ func (s *DoHListener) parseAndRespond(b []byte, w http.ResponseWriter, r *http.R
 		SourceIP: clientIP,
 		DoHPath:  r.URL.Path,
 	}
-	log := Log.WithFields(logrus.Fields{"id": s.id, "client": ci.SourceIP, "qname": qName(q), "protocol": "doh", "addr": s.addr})
+	log := Log.WithFields(logrus.Fields{
+		"id":       s.id,
+		"client":   ci.SourceIP,
+		"qtype":    qType(q),
+		"qname":    qName(q),
+		"protocol": "doh",
+		"addr":     s.addr,
+		"path":     r.URL.Path,
+	})
 	log.Debug("received query")
 
 	var err error

--- a/example_test.go
+++ b/example_test.go
@@ -44,8 +44,8 @@ func Example_router() {
 
 	// Build a router that will send all "*.cloudflare.com" to the cloudflare
 	// resolver while everything else goes to the google resolver (default)
-	route1, _ := rdns.NewRoute(`\.cloudflare\.com\.$`, "", nil, nil, "", "", "", cloudflare)
-	route2, _ := rdns.NewRoute("", "", nil, nil, "", "", "", google)
+	route1, _ := rdns.NewRoute(`\.cloudflare\.com\.$`, "", nil, nil, "", "", "", "", cloudflare)
+	route2, _ := rdns.NewRoute("", "", nil, nil, "", "", "", "", google)
 	r := rdns.NewRouter("my-router")
 	r.Add(route1, route2)
 

--- a/listener.go
+++ b/listener.go
@@ -16,6 +16,10 @@ type Listener interface {
 // can be used to route requests.
 type ClientInfo struct {
 	SourceIP net.IP
+
+	// DoH query path used by the client. Only populated when
+	// the query was received over DoH.
+	DoHPath string
 }
 
 // Metrics that are available from listeners and clients.

--- a/net-resolver.go
+++ b/net-resolver.go
@@ -78,7 +78,7 @@ func (c *packetConn) Write(p []byte) (n int, err error) {
 		return len(p), err
 	}
 
-	a, err := c.r.Resolve(q, ClientInfo{net.IP{127, 0, 0, 1}})
+	a, err := c.r.Resolve(q, ClientInfo{SourceIP: net.IP{127, 0, 0, 1}})
 	if err != nil {
 		return len(p), err
 	}

--- a/route_test.go
+++ b/route_test.go
@@ -79,7 +79,7 @@ func TestRoute(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		r, err := NewRoute(test.rName, test.rClass, test.rType, nil, "", "", "", &TestResolver{})
+		r, err := NewRoute(test.rName, test.rClass, test.rType, nil, "", "", "", "", &TestResolver{})
 		require.NoError(t, err)
 		r.Invert(test.rInvert)
 

--- a/router.go
+++ b/router.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
 )
 
 // Router for DNS requests based on query type and/or name. Implements the Resolver interface.
@@ -56,7 +57,10 @@ func (r *Router) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		if !route.match(q, ci) {
 			continue
 		}
-		log.WithField("resolver", route.resolver.String()).Debug("routing query to resolver")
+		log.WithFields(logrus.Fields{
+			"route":    route.String(),
+			"resolver": route.resolver.String()},
+		).Debug("routing query to resolver")
 		r.metrics.route.Add(route.resolver.String(), 1)
 		a, err := route.resolver.Resolve(q, ci)
 		if err != nil {

--- a/router_test.go
+++ b/router_test.go
@@ -14,8 +14,8 @@ func TestRouterType(t *testing.T) {
 	q := new(dns.Msg)
 	var ci ClientInfo
 
-	route1, _ := NewRoute("", "", []string{"MX"}, nil, "", "", "", r1)
-	route2, _ := NewRoute("", "", nil, nil, "", "", "", r2)
+	route1, _ := NewRoute("", "", []string{"MX"}, nil, "", "", "", "", r1)
+	route2, _ := NewRoute("", "", nil, nil, "", "", "", "", r2)
 
 	router := NewRouter("my-router")
 	router.Add(route1, route2)
@@ -41,8 +41,8 @@ func TestRouterClass(t *testing.T) {
 	q := new(dns.Msg)
 	var ci ClientInfo
 
-	route1, _ := NewRoute("", "ANY", nil, nil, "", "", "", r1)
-	route2, _ := NewRoute("", "", nil, nil, "", "", "", r2)
+	route1, _ := NewRoute("", "ANY", nil, nil, "", "", "", "", r1)
+	route2, _ := NewRoute("", "", nil, nil, "", "", "", "", r2)
 
 	router := NewRouter("my-router")
 	router.Add(route1, route2)
@@ -69,8 +69,8 @@ func TestRouterName(t *testing.T) {
 	q := new(dns.Msg)
 	var ci ClientInfo
 
-	route1, _ := NewRoute(`\.acme\.test\.$`, "", nil, nil, "", "", "", r1)
-	route2, _ := NewRoute("", "", nil, nil, "", "", "", r2)
+	route1, _ := NewRoute(`\.acme\.test\.$`, "", nil, nil, "", "", "", "", r1)
+	route2, _ := NewRoute("", "", nil, nil, "", "", "", "", r2)
 
 	router := NewRouter("my-router")
 	router.Add(route1, route2)
@@ -96,8 +96,8 @@ func TestRouterSource(t *testing.T) {
 	q := new(dns.Msg)
 	q.SetQuestion("acme.test.", dns.TypeA)
 
-	route1, _ := NewRoute("", "", nil, nil, "", "", "192.168.1.100/32", r1)
-	route2, _ := NewRoute("", "", nil, nil, "", "", "", r2)
+	route1, _ := NewRoute("", "", nil, nil, "", "", "192.168.1.100/32", "", r1)
+	route2, _ := NewRoute("", "", nil, nil, "", "", "", "", r2)
 
 	router := NewRouter("my-router")
 	router.Add(route1, route2)


### PR DESCRIPTION
Adds support for routers to direct queries based on the DoH query path used by the client as per #234 

```toml
{ doh-path = "^/dns-query$", resolver = "cloudflare-dot" },
```
