### PR TITLE
harden example systemd service

### DIFF
--- a/cmd/routedns/routedns.service
+++ b/cmd/routedns/routedns.service
@@ -4,7 +4,8 @@ After=network.target
 
 [Service]
 Type=simple
-User=routedns
+DynamicUser=true
+NoNewPrivileges=true
 WorkingDirectory=/opt/routedns
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 ExecStart=/opt/routedns/routedns config.toml


### PR DESCRIPTION
This will use a dynamic uid choosen randomly at service start and
prevent subprocesses from gaining new capabilities.
https://www.freedesktop.org/software/systemd/man/systemd.exec.html#DynamicUser=

Signed-off-by: Jeroen Simonetti <jeroen@simonetti.nl>