### PR TITLE
Copy queries prior to packing them in resolvers

### DIFF
--- a/dnsclient.go
+++ b/dnsclient.go
@@ -62,6 +62,9 @@ func NewDNSClient(id, endpoint, network string, opt DNSClientOptions) (*DNSClien
 
 // Resolve a DNS query.
 func (d *DNSClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+	// Packing a message is not always a read-only operation, make a copy
+	q = q.Copy()
+
 	logger(d.id, q, ci).WithFields(logrus.Fields{
 		"resolver": d.endpoint,
 		"protocol": d.net,

--- a/dohclient.go
+++ b/dohclient.go
@@ -352,6 +352,9 @@ func (s *quicConnection) NextConnection() quic.Connection {
 }
 
 func quicRestart(s *quicConnection) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// Try to open a new connection, but clean up our mess before we do so
 	// This function should be called with the quicConnection locked, but lock checking isn't provided
 	// in golang; the issue was closed with "Won't fix"

--- a/dohclient.go
+++ b/dohclient.go
@@ -96,6 +96,9 @@ func NewDoHClient(id, endpoint string, opt DoHClientOptions) (*DoHClient, error)
 
 // Resolve a DNS query.
 func (d *DoHClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+	// Packing a message is not always a read-only operation, make a copy
+	q = q.Copy()
+
 	logger(d.id, q, ci).WithFields(logrus.Fields{
 		"resolver": d.endpoint,
 		"protocol": "doh",

--- a/dohclient.go
+++ b/dohclient.go
@@ -352,9 +352,6 @@ func (s *quicConnection) NextConnection() quic.Connection {
 }
 
 func quicRestart(s *quicConnection) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	// Try to open a new connection, but clean up our mess before we do so
 	// This function should be called with the quicConnection locked, but lock checking isn't provided
 	// in golang; the issue was closed with "Won't fix"

--- a/dotclient.go
+++ b/dotclient.go
@@ -68,6 +68,9 @@ func NewDoTClient(id, endpoint string, opt DoTClientOptions) (*DoTClient, error)
 
 // Resolve a DNS query.
 func (d *DoTClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+	// Packing a message is not always a read-only operation, make a copy
+	q = q.Copy()
+
 	logger(d.id, q, ci).WithFields(logrus.Fields{
 		"resolver": d.endpoint,
 		"protocol": "dot",

--- a/dtlsclient.go
+++ b/dtlsclient.go
@@ -90,6 +90,9 @@ func NewDTLSClient(id, endpoint string, opt DTLSClientOptions) (*DTLSClient, err
 
 // Resolve a DNS query.
 func (d *DTLSClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+	// Packing a message is not always a read-only operation, make a copy
+	q = q.Copy()
+
 	logger(d.id, q, ci).WithFields(logrus.Fields{
 		"resolver": d.endpoint,
 		"protocol": "dtls",


### PR DESCRIPTION
Turns out that packing a query is not a read-only operation and potentially modifies it. That means it's not safe to run multiple operations on it concurrently which is the case when using the "fastest" group for example. So make a copy before packing in resolvers.

Also addresses a race condition in the quic restart logic

Fixes #198 