### PR TITLE
Revert "Merge pull request #259 from folbricht/issue-153"

### DIFF
--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -24,12 +24,8 @@ type node map[string]node
 var _ BlocklistDB = &DomainDB{}
 
 // NewDomainDB returns a new instance of a matcher for a list of regular expressions.
-func NewDomainDB(name string, loader BlocklistLoader) *DomainDB {
-	return &DomainDB{name, nil, loader}
-}
-
-func (m *DomainDB) Reload() (BlocklistDB, error) {
-	rules, err := m.loader.Load()
+func NewDomainDB(name string, loader BlocklistLoader) (*DomainDB, error) {
+	rules, err := loader.Load()
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +36,7 @@ func (m *DomainDB) Reload() (BlocklistDB, error) {
 		// Strip trailing . in case the list has FQDN names with . suffixes.
 		r = strings.TrimSuffix(r, ".")
 
-		// Break up the domain into its parts and iterate backwards over them, building
+		// Break up the domain into its parts and iterare backwards over them, building
 		// a graph of maps
 		parts := strings.Split(r, ".")
 		n := root
@@ -60,7 +56,11 @@ func (m *DomainDB) Reload() (BlocklistDB, error) {
 			n = subNode
 		}
 	}
-	return &DomainDB{m.name, root, m.loader}, nil
+	return &DomainDB{name, root, loader}, nil
+}
+
+func (m *DomainDB) Reload() (BlocklistDB, error) {
+	return NewDomainDB(m.name, m.loader)
 }
 
 func (m *DomainDB) Match(q dns.Question) (net.IP, string, *BlocklistMatch, bool) {

--- a/blocklistdb-hosts.go
+++ b/blocklistdb-hosts.go
@@ -25,12 +25,8 @@ type ipRecords struct {
 var _ BlocklistDB = &HostsDB{}
 
 // NewHostsDB returns a new instance of a matcher for a list of regular expressions.
-func NewHostsDB(name string, loader BlocklistLoader) *HostsDB {
-	return &HostsDB{name, nil,nil, loader}
-}
-
-func (m *HostsDB) Reload() (BlocklistDB, error) {
-	rules, err := m.loader.Load()
+func NewHostsDB(name string, loader BlocklistLoader) (*HostsDB, error) {
+	rules, err := loader.Load()
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +70,11 @@ func (m *HostsDB) Reload() (BlocklistDB, error) {
 		}
 		ptrMap[reverseAddr] = names[0]
 	}
-	return &HostsDB{m.name, filters, ptrMap, m.loader}, nil
+	return &HostsDB{name, filters, ptrMap, loader}, nil
+}
 
+func (m *HostsDB) Reload() (BlocklistDB, error) {
+	return NewHostsDB(m.name, m.loader)
 }
 
 func (m *HostsDB) Match(q dns.Question) (net.IP, string, *BlocklistMatch, bool) {

--- a/blocklistdb-regexp.go
+++ b/blocklistdb-regexp.go
@@ -18,17 +18,12 @@ type RegexpDB struct {
 var _ BlocklistDB = &RegexpDB{}
 
 // NewRegexpDB returns a new instance of a matcher for a list of regular expressions.
-func NewRegexpDB(name string, loader BlocklistLoader) *RegexpDB {
-	return &RegexpDB{name, nil, loader}
-}
-
-func (m *RegexpDB) Reload() (BlocklistDB, error) {
-	rules, err := m.loader.Load()
+func NewRegexpDB(name string, loader BlocklistLoader) (*RegexpDB, error) {
+	rules, err := loader.Load()
 	if err != nil {
 		return nil, err
 	}
 	var filters []*regexp.Regexp
-
 	for _, r := range rules {
 		r = strings.TrimSpace(r)
 		if r == "" || strings.HasPrefix(r, "#") {
@@ -41,7 +36,11 @@ func (m *RegexpDB) Reload() (BlocklistDB, error) {
 		filters = append(filters, re)
 	}
 
-	return &RegexpDB{m.name, filters, m.loader}, nil
+	return &RegexpDB{name, filters, loader}, nil
+}
+
+func (m *RegexpDB) Reload() (BlocklistDB, error) {
+	return NewRegexpDB(m.name, m.loader)
 }
 
 func (m *RegexpDB) Match(q dns.Question) (net.IP, string, *BlocklistMatch, bool) {

--- a/cache.go
+++ b/cache.go
@@ -59,7 +59,7 @@ type CacheOptions struct {
 	// Query name that will trigger a cache flush. Disabled if empty.
 	FlushQuery string
 
-	// If a query is received for a record that less that PrefetchTrigger TTL left, the
+	// If a query is received for a record with less that PrefetchTrigger TTL left, the
 	// cache will send another query to upstream. The goal is to automatically refresh
 	// the record in the cache.
 	PrefetchTrigger uint32

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -142,11 +142,10 @@ type group struct {
 
 // Block/Allowlist items for blocklist-v2
 type list struct {
-	Name     	 string
-	Format   	 string
-	Source   	 string
-	CacheDir 	 string `toml:"cache-dir"` // Where to store copies of remote blocklists for faster startup
-	AllowFailOnStart bool   `toml:"allow-fail-on-startup"` // Don't fail if the blocklist can't be loaded on startup, just print a warning
+	Name     string
+	Format   string
+	Source   string
+	CacheDir string `toml:"cache-dir"` // Where to store copies of remote blocklists for faster startup
 }
 
 type router struct {

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -768,27 +768,17 @@ func newBlocklistDB(l list, rules []string) (rdns.BlocklistDB, error) {
 			return nil, fmt.Errorf("unsupported scheme '%s' in '%s'", loc.Scheme, l.Source)
 		}
 	}
-	var db rdns.BlocklistDB
 	switch l.Format {
 	case "regexp", "":
-		db = rdns.NewRegexpDB(name, loader)
+		return rdns.NewRegexpDB(name, loader)
 	case "domain":
-		db = rdns.NewDomainDB(name, loader)
+		return rdns.NewDomainDB(name, loader)
 	case "hosts":
-		db = rdns.NewHostsDB(name, loader)
+		return rdns.NewHostsDB(name, loader)
 	default:
 		return nil, fmt.Errorf("unsupported format '%s'", l.Format)
 	}
-	db, err = db.Reload()
-	if err != nil {
-		rdns.Log.WithError(err).Warn("failed to load list")
-		if !l.AllowFailOnStart {
-			return nil, fmt.Errorf("failed to load list on startup, set allow-fail-on-startup to skip: %w", err)
-		}
-	}
-	return db, nil
 }
-
 
 func newIPBlocklistDB(l list, locationDB string, rules []string) (rdns.IPBlocklistDB, error) {
 	loc, err := url.Parse(l.Source)
@@ -815,24 +805,15 @@ func newIPBlocklistDB(l list, locationDB string, rules []string) (rdns.IPBlockli
 			return nil, fmt.Errorf("unsupported scheme '%s' in '%s'", loc.Scheme, l.Source)
 		}
 	}
-	var db rdns.IPBlocklistDB
-	switch l.Format {
-		case "cidr", "":
-			db = rdns.NewCidrDB(name, loader)
-		case "location":
-			return rdns.NewGeoIPDB(name, loader, locationDB)
-		default:
-			return nil, fmt.Errorf("unsupported format '%s'", l.Format)
-	}
-	db, err = db.Reload()
 
-	if err != nil {
-                rdns.Log.WithError(err).Warn("failed to load list")
-                if !l.AllowFailOnStart {
-			return nil, fmt.Errorf("failed to load list on startup, set allow-fail-on-startup to skip: %w", err)
-		}
-        }
-        return db, nil
+	switch l.Format {
+	case "cidr", "":
+		return rdns.NewCidrDB(name, loader)
+	case "location":
+		return rdns.NewGeoIPDB(name, loader, locationDB)
+	default:
+		return nil, fmt.Errorf("unsupported format '%s'", l.Format)
+	}
 }
 
 func printVersion() {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1531,4 +1531,3 @@ protocol = "dot"
 ```
 
 Example config files: [bootstrap-resolver.toml](../cmd/routedns/example-config/bootstrap-resolver.toml), [use-case-6.toml](../cmd/routedns/example-config/use-case-6.toml)
-

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91 h1:vX+gnvBc56EbWYrmlhYbFYRaeikAke1GL84N4BEYOFE=
@@ -128,7 +127,7 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.4.0/go.mod h1:9P2UbLfCdcvo3p/nzKvsmas4TnlujnuoV9hGgYzW1lQ=
-golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=


### PR DESCRIPTION
This reverts commit c383a53be6a763b69f01d2e59fc6903aaa7a19df, reversing changes made to 3cd0d752f5ecf0bff9d0ed7b2cbcdb07b0793be8.

There are several issues with that implementation:
- Tests hadn't been updated
- It would start without loading the blocklists and only load them later
- https://github.com/folbricht/routedns/issues/291