### PR TITLE
New 'allow-failure' flag for blocklist loaders

### DIFF
--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -36,7 +36,7 @@ func NewDomainDB(name string, loader BlocklistLoader) (*DomainDB, error) {
 		// Strip trailing . in case the list has FQDN names with . suffixes.
 		r = strings.TrimSuffix(r, ".")
 
-		// Break up the domain into its parts and iterare backwards over them, building
+		// Break up the domain into its parts and iterate backwards over them, building
 		// a graph of maps
 		parts := strings.Split(r, ".")
 		n := root

--- a/blocklistloader-local.go
+++ b/blocklistloader-local.go
@@ -8,24 +8,44 @@ import (
 // FileLoader reads blocklist rules from a local file. Used to refresh blocklists
 // from a file on the local machine.
 type FileLoader struct {
-	filename string
+	filename    string
+	opt         FileLoaderOptions
+	lastSuccess []string
+}
+
+// FileLoaderOptions holds options for file blocklist loaders.
+type FileLoaderOptions struct {
+	// Don't fail when trying to load the list
+	AllowFailure bool
 }
 
 var _ BlocklistLoader = &FileLoader{}
 
-func NewFileLoader(filename string) *FileLoader {
-	return &FileLoader{filename}
+func NewFileLoader(filename string, opt FileLoaderOptions) *FileLoader {
+	return &FileLoader{filename, opt, nil}
 }
 
-func (l *FileLoader) Load() ([]string, error) {
+func (l *FileLoader) Load() (rules []string, err error) {
 	log := Log.WithField("file", l.filename)
 	log.Trace("loading blocklist")
+
+	// If AllowFailure is enabled, return the last successfully loaded list
+	// and nil
+	defer func() {
+		if err != nil && l.opt.AllowFailure {
+			log.WithError(err).Warn("failed to load blocklist, continuing with previous ruleset")
+			rules = l.lastSuccess
+			err = nil
+		} else {
+			l.lastSuccess = rules
+		}
+	}()
+
 	f, err := os.Open(l.filename)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-	var rules []string
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		rules = append(rules, scanner.Text())

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -142,10 +142,11 @@ type group struct {
 
 // Block/Allowlist items for blocklist-v2
 type list struct {
-	Name     string
-	Format   string
-	Source   string
-	CacheDir string `toml:"cache-dir"` // Where to store copies of remote blocklists for faster startup
+	Name         string
+	Format       string
+	Source       string
+	CacheDir     string `toml:"cache-dir"`     // Where to store copies of remote blocklists for faster startup
+	AllowFailure bool   `toml:"allow-failure"` // Don't fail on error and keep using the prior ruleset
 }
 
 type router struct {

--- a/cmd/routedns/example-config/blocklist-remote.toml
+++ b/cmd/routedns/example-config/blocklist-remote.toml
@@ -10,12 +10,12 @@ type = "blocklist-v2"
 resolvers = ["cloudflare-dot"]
 blocklist-refresh = 86400
 blocklist-source = [
-   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.domain.list"},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.domain.list", allow-failure = true},
    {format = "regexp", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.regexp.list"},
 ]
 allowlist-refresh = 86400
 allowlist-source = [
-   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.allowlist.domain.list"},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.allowlist.domain.list", allow-failure = true},
    {format = "regexp", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.allowlist.regexp.list"},
 ]
 

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -759,11 +759,15 @@ func newBlocklistDB(l list, rules []string) (rdns.BlocklistDB, error) {
 		switch loc.Scheme {
 		case "http", "https":
 			opt := rdns.HTTPLoaderOptions{
-				CacheDir: l.CacheDir,
+				CacheDir:     l.CacheDir,
+				AllowFailure: l.AllowFailure,
 			}
 			loader = rdns.NewHTTPLoader(l.Source, opt)
 		case "":
-			loader = rdns.NewFileLoader(l.Source)
+			opt := rdns.FileLoaderOptions{
+				AllowFailure: l.AllowFailure,
+			}
+			loader = rdns.NewFileLoader(l.Source, opt)
 		default:
 			return nil, fmt.Errorf("unsupported scheme '%s' in '%s'", loc.Scheme, l.Source)
 		}
@@ -796,11 +800,15 @@ func newIPBlocklistDB(l list, locationDB string, rules []string) (rdns.IPBlockli
 		switch loc.Scheme {
 		case "http", "https":
 			opt := rdns.HTTPLoaderOptions{
-				CacheDir: l.CacheDir,
+				CacheDir:     l.CacheDir,
+				AllowFailure: l.AllowFailure,
 			}
 			loader = rdns.NewHTTPLoader(l.Source, opt)
 		case "":
-			loader = rdns.NewFileLoader(l.Source)
+			opt := rdns.FileLoaderOptions{
+				AllowFailure: l.AllowFailure,
+			}
+			loader = rdns.NewFileLoader(l.Source, opt)
 		default:
 			return nil, fmt.Errorf("unsupported scheme '%s' in '%s'", loc.Scheme, l.Source)
 		}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -557,9 +557,11 @@ Options:
 - `allowlist-resolver` - Alternative resolver for queries matching the allowlist, rather than forwarding to the default resolver.
 - `allowlist-format` - The format the allowlist is provided in. Only used if `allowlist-source` is not provided. Can be `regexp`, `domain`, or `hosts`. Defaults to `regexp`.
 - `allowlist-refresh` - Time interval (in seconds) in which external allowlists are reloaded. Optional.
-- `allowlist-source` - An array of allowlists, each with `format`, `source`, and optionally `cache-dir`.
+- `allowlist-source` - An array of allowlists, each with `format`, `source`, and optionally `cache-dir` or `allow-failure`.
 
 When using the `cache-dir` option on a list that loads rules via HTTP, the results are cached into a file in the given directory. The filename is the URL of the source hashed with SHA256 so multiple blocklists can be cached in the same directory. If a cached file exists on startup, it is used instead of refreshing the list from the remote location (slowing down startup).
+
+To avoid errors at startup when for example a remote blocklist isn't available, the `allow-failure` option can be used. Any errors encountered will be logged but not cause a failure to start. If a failure occurs during runtime, the previous ruleset will be reused.
 
 #### Examples
 
@@ -573,6 +575,7 @@ blocklist-format ="regexp"               # "domain", "hosts" or "regexp", defaul
 blocklist        = [                     # Define the names to be blocked
   '(^|\.)evil\.com\.$',
   '(^|\.)unsafe[123]\.org\.$',
+]
 ```
 
 Simple blocklist with static `domain`-format rule in the configuration.
@@ -615,7 +618,7 @@ blocklist-source = [
 ]
 ```
 
-Remote blocklist that is cached to local disk (`cache-dir="/var/tmp"`) and loaded from it at startup.
+Remote blocklist that is cached to local disk (`cache-dir="/var/tmp"`) and loaded from it at startup. It also ignores failures to load the remote blocklist and does not prevent startup.
 
 ```toml
 [groups.cloudflare-blocklist]
@@ -623,7 +626,7 @@ type = "blocklist-v2"
 resolvers = ["cloudflare-dot"]
 blocklist-refresh = 86400
 blocklist-source = [
-   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.domain.list", cache-dir = "/var/tmp"},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.domain.list", cache-dir = "/var/tmp", allow-failure = true},
 ]
 ```
 


### PR DESCRIPTION
Implements #153 

Adds a new `allow-failure` bool flag to avoid failure on startup