### PR TITLE
New 'query-timeout' option for resolvers

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -50,6 +50,7 @@ type resolver struct {
 	BootstrapAddr string `toml:"bootstrap-address"`
 	LocalAddr     string `toml:"local-address"`
 	EDNS0UDPSize  uint16 `toml:"edns0-udp-size"` // UDP resolver option
+	QueryTimeout  int    `toml:"query-timeout"`  // Query timout in seconds
 }
 
 // DoH-specific resolver options

--- a/cmd/routedns/resolver.go
+++ b/cmd/routedns/resolver.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"time"
 
 	rdns "github.com/folbricht/routedns"
 )
@@ -23,6 +24,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			BootstrapAddr: r.BootstrapAddr,
 			LocalAddr:     net.ParseIP(r.LocalAddr),
 			TLSConfig:     tlsConfig,
+			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
 		}
 		resolvers[id], err = rdns.NewDoQClient(id, r.Address, opt)
 		if err != nil {
@@ -39,6 +41,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			BootstrapAddr: r.BootstrapAddr,
 			LocalAddr:     net.ParseIP(r.LocalAddr),
 			TLSConfig:     tlsConfig,
+			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
 		}
 		resolvers[id], err = rdns.NewDoTClient(id, r.Address, opt)
 		if err != nil {
@@ -56,6 +59,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			LocalAddr:     net.ParseIP(r.LocalAddr),
 			DTLSConfig:    dtlsConfig,
 			UDPSize:       r.EDNS0UDPSize,
+			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
 		}
 		resolvers[id], err = rdns.NewDTLSClient(id, r.Address, opt)
 		if err != nil {
@@ -74,6 +78,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			BootstrapAddr: r.BootstrapAddr,
 			Transport:     r.Transport,
 			LocalAddr:     net.ParseIP(r.LocalAddr),
+			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
 		}
 		resolvers[id], err = rdns.NewDoHClient(id, r.Address, opt)
 		if err != nil {
@@ -83,8 +88,9 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 		r.Address = rdns.AddressWithDefault(r.Address, rdns.PlainDNSPort)
 
 		opt := rdns.DNSClientOptions{
-			LocalAddr: net.ParseIP(r.LocalAddr),
-			UDPSize:   r.EDNS0UDPSize,
+			LocalAddr:    net.ParseIP(r.LocalAddr),
+			UDPSize:      r.EDNS0UDPSize,
+			QueryTimeout: time.Duration(r.QueryTimeout) * time.Second,
 		}
 		resolvers[id], err = rdns.NewDNSClient(id, r.Address, r.Protocol, opt)
 		if err != nil {

--- a/dnsclient.go
+++ b/dnsclient.go
@@ -3,6 +3,7 @@ package rdns
 import (
 	"crypto/tls"
 	"net"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
@@ -24,6 +25,8 @@ type DNSClientOptions struct {
 	// Sets the EDNS0 UDP size for all queries sent upstream. If set to 0, queries
 	// are not changed.
 	UDPSize uint16
+
+	QueryTimeout time.Duration
 }
 
 var _ Resolver = &DNSClient{}
@@ -55,7 +58,7 @@ func NewDNSClient(id, endpoint, network string, opt DNSClientOptions) (*DNSClien
 		id:       id,
 		net:      network,
 		endpoint: endpoint,
-		pipeline: NewPipeline(id, endpoint, client),
+		pipeline: NewPipeline(id, endpoint, client, opt.QueryTimeout),
 		opt:      opt,
 	}, nil
 }

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1346,6 +1346,7 @@ Resolvers are defined in the configuration like so `[resolvers.NAME]` and have t
 - `bootstrap-address` - Use this IP address if the name in `address` can't be resolved. Using the IP in `address` directly may not work when TLS/certificates are used by the server.
 - `local-address` - IP of the local interface to use for outgoing connections. The address is automatically chosen if this option is left blank.
 - `edns0-udp-size` - If set, modifies the EDNS0 UDP size option in all queries sent upstream. Only meaningful when using UDP or DTLS resolvers. Upstream resolvers may not respect this value and apply their own limits.
+- `query-timeout` - Sets the query timeout to allow.
 
 Secure resolvers such as DoT, DoH, or DoQ offer additional options to configure the TLS connections.
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1346,7 +1346,7 @@ Resolvers are defined in the configuration like so `[resolvers.NAME]` and have t
 - `bootstrap-address` - Use this IP address if the name in `address` can't be resolved. Using the IP in `address` directly may not work when TLS/certificates are used by the server.
 - `local-address` - IP of the local interface to use for outgoing connections. The address is automatically chosen if this option is left blank.
 - `edns0-udp-size` - If set, modifies the EDNS0 UDP size option in all queries sent upstream. Only meaningful when using UDP or DTLS resolvers. Upstream resolvers may not respect this value and apply their own limits.
-- `query-timeout` - Sets the query timeout to allow.
+- `query-timeout` - Sets the query timeout to allow. In seconds.
 
 Secure resolvers such as DoT, DoH, or DoQ offer additional options to configure the TLS connections.
 

--- a/dotclient.go
+++ b/dotclient.go
@@ -3,6 +3,7 @@ package rdns
 import (
 	"crypto/tls"
 	"net"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/pkg/errors"
@@ -27,6 +28,8 @@ type DoTClientOptions struct {
 	LocalAddr net.IP
 
 	TLSConfig *tls.Config
+
+	QueryTimeout time.Duration
 }
 
 var _ Resolver = &DoTClient{}
@@ -62,7 +65,7 @@ func NewDoTClient(id, endpoint string, opt DoTClientOptions) (*DoTClient, error)
 	return &DoTClient{
 		id:       id,
 		endpoint: endpoint,
-		pipeline: NewPipeline(id, endpoint, client),
+		pipeline: NewPipeline(id, endpoint, client, opt.QueryTimeout),
 	}, nil
 }
 

--- a/dtlsclient.go
+++ b/dtlsclient.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/pion/dtls/v2"
@@ -32,6 +33,8 @@ type DTLSClientOptions struct {
 	UDPSize uint16
 
 	DTLSConfig *dtls.Config
+
+	QueryTimeout time.Duration
 }
 
 var _ Resolver = &DTLSClient{}
@@ -83,7 +86,7 @@ func NewDTLSClient(id, endpoint string, opt DTLSClientOptions) (*DTLSClient, err
 	return &DTLSClient{
 		id:       id,
 		endpoint: endpoint,
-		pipeline: NewPipeline(id, endpoint, client),
+		pipeline: NewPipeline(id, endpoint, client, opt.QueryTimeout),
 		opt:      opt,
 	}, nil
 }

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -20,7 +20,7 @@ func TestPipelineQueryTimeout(t *testing.T) {
 		time.Sleep(2 * time.Second)
 		return nil, errors.New("failed")
 	}
-	p := NewPipeline("test", "localhost:53", testDialer(df))
+	p := NewPipeline("test", "localhost:53", testDialer(df), time.Second)
 
 	q := new(dns.Msg)
 	q.SetQuestion("example.com.", dns.TypeA)
@@ -35,5 +35,5 @@ func TestPipelineQueryTimeout(t *testing.T) {
 
 	// Make sure we get a timeout error and it took the right amount to come back
 	require.ErrorAs(t, err, &QueryTimeoutError{})
-	require.WithinDuration(t, start.Add(queryTimeout), time.Now(), 10*time.Millisecond)
+	require.WithinDuration(t, start.Add(time.Second), time.Now(), 10*time.Millisecond)
 }


### PR DESCRIPTION
Implements #286 

New flag that can be used to set a query timeout.
```toml
[resolvers.cloudflare-dot]
address = "1.1.1.1:853"
protocol = "dot"
query-timeout = 4 # seconds
```