### PR TITLE
New cache-rcode-max-ttl option for caches

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -79,13 +79,14 @@ type group struct {
 	ServfailError bool `toml:"servfail-error"` // If true, SERVFAIL responses are considered errors and cause failover etc.
 
 	// Cache options
-	CacheSize                int    `toml:"cache-size"`                  // Max number of items to keep in the cache. Default 0 == unlimited
-	CacheNegativeTTL         uint32 `toml:"cache-negative-ttl"`          // TTL to apply to negative responses, default 60.
-	CacheAnswerShuffle       string `toml:"cache-answer-shuffle"`        // Algorithm to use for modifying the response order of cached items
-	CacheHardenBelowNXDOMAIN bool   `toml:"cache-harden-below-nxdomain"` // Return NXDOMAIN if an NXDOMAIN is cached for a parent domain
-	CacheFlushQuery          string `toml:"cache-flush-query"`           // Flush the cache when a query for this name is received
-	PrefetchTrigger          uint32 `toml:"cache-prefetch-trigger"`      // Prefetch when the TTL of a query has fallen below this value
-	PrefetchEligible         uint32 `toml:"cache-prefetch-eligible"`     // Only records with TTL greater than this are considered for prefetch
+	CacheSize                int               `toml:"cache-size"`                  // Max number of items to keep in the cache. Default 0 == unlimited
+	CacheNegativeTTL         uint32            `toml:"cache-negative-ttl"`          // TTL to apply to negative responses, default 60.
+	CacheAnswerShuffle       string            `toml:"cache-answer-shuffle"`        // Algorithm to use for modifying the response order of cached items
+	CacheHardenBelowNXDOMAIN bool              `toml:"cache-harden-below-nxdomain"` // Return NXDOMAIN if an NXDOMAIN is cached for a parent domain
+	CacheFlushQuery          string            `toml:"cache-flush-query"`           // Flush the cache when a query for this name is received
+	PrefetchTrigger          uint32            `toml:"cache-prefetch-trigger"`      // Prefetch when the TTL of a query has fallen below this value
+	PrefetchEligible         uint32            `toml:"cache-prefetch-eligible"`     // Only records with TTL greater than this are considered for prefetch
+	CacheRcodeMaxTTL         map[string]uint32 `toml:"cache-rcode-max-ttl"`         // Rcode specific max TTL to keep in the cache
 
 	// Blocklist options
 	Blocklist []string // Blocklist rules, only used by "blocklist" type

--- a/cmd/routedns/example-config/cache-rcode.toml
+++ b/cmd/routedns/example-config/cache-rcode.toml
@@ -1,0 +1,15 @@
+# Cache that sets an upper bound on the TTL of NXDOMAIN even if they have a SOA.
+
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[groups.cloudflare-cached]
+type = "cache"
+resolvers = ["cloudflare-dot"]
+cache-rcode-max-ttl = { 3 = 60 } # NXDOMAIN records should not be cached for more than a minute
+
+[listeners.local-udp]
+address = "127.0.0.1:53"
+protocol = "udp"
+resolver = "cloudflare-cached"

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"strconv"
 	"time"
 
 	syslog "github.com/RackSec/srslog"
@@ -553,10 +554,21 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 		default:
 			return fmt.Errorf("unsupported shuffle function %q", g.CacheAnswerShuffle)
 		}
+
+		cacheRcodeMaxTTL := make(map[int]uint32)
+		for k, v := range g.CacheRcodeMaxTTL {
+			code, err := strconv.Atoi(k)
+			if err != nil {
+				return fmt.Errorf("failed to decode key in cache-rcode-max-ttl: %w", err)
+			}
+			cacheRcodeMaxTTL[code] = v
+		}
+
 		opt := rdns.CacheOptions{
 			GCPeriod:            time.Duration(g.GCPeriod) * time.Second,
 			Capacity:            g.CacheSize,
 			NegativeTTL:         g.CacheNegativeTTL,
+			CacheRcodeMaxTTL:    cacheRcodeMaxTTL,
 			ShuffleAnswerFunc:   shuffleFunc,
 			HardenBelowNXDOMAIN: g.CacheHardenBelowNXDOMAIN,
 			FlushQuery:          g.CacheFlushQuery,

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -300,6 +300,7 @@ Options:
 - `resolvers` - Array of upstream resolvers, only one is supported.
 - `cache-size` - Max number of responses to cache. Defaults to 0 which means no limit. Optional
 - `cache-negative-ttl` - TTL (in seconds) to apply to responses without a SOA. Default: 60. Optional
+- `cache-rcode-max-ttl` - Map of RCODE to max TTL (in seconds) to use for records based on the status code regardless of SOA. Response codes are given in their numerical form: 0 = NOERROR, 1 = FORMERR, 2 = SERVFAIL, 3 = NXDOMAIN, ... See [rfc2929#section-2.3](https://tools.ietf.org/html/rfc2929#section-2.3) for a more complete list. For example `{1 = 60, 3 = 60}` would set a limit on how long FORMERR or NXDOMAIN responses can be cached.
 - `cache-answer-shuffle` - Specifies a method for changing the order of cached A/AAAA answer records. Possible values `random` or `round-robin`. Defaults to static responses if not set.
 - `cache-harden-below-nxdomain` - Return NXDOMAIN for domain queries if the parent domain has a cached NXDOMAIN. See [RFC8020](https://tools.ietf.org/html/rfc8020).
 - `cache-flush-query` - A query name (FQDN with trailing `.`) that if received from a client will trigger a cache flush (reset). Inactive if not set. Simple way to support flushing the cache by sending a pre-defined query name of any type. If successful, the response will be empty. The query will not be forwarded upstream by the cache.
@@ -336,7 +337,7 @@ resolvers = ["cloudflare-dot"]
 cache-flush-query = "flush.cache."
 ```
 
-Example config files: [cache.toml](../cmd/routedns/example-config/cache.toml), [block-split-cache.toml](../cmd/routedns/example-config/block-split-cache.toml), [cache-flush.toml](../cmd/routedns/example-config/cache-flush.toml), [cache-with-prefetch.toml](../cmd/routedns/example-config/cache-with-prefetch.toml)
+Example config files: [cache.toml](../cmd/routedns/example-config/cache.toml), [block-split-cache.toml](../cmd/routedns/example-config/block-split-cache.toml), [cache-flush.toml](../cmd/routedns/example-config/cache-flush.toml), [cache-with-prefetch.toml](../cmd/routedns/example-config/cache-with-prefetch.toml), [cache-rcode.toml](../cmd/routedns/example-config/cache-rcode.toml)
 
 ### TTL modifier
 


### PR DESCRIPTION
Per https://github.com/folbricht/routedns/issues/301, this allows setting and upper limit on how long records can be cached based on the RCODE of the response

For example
```toml
[groups.cloudflare-cached]
type = "cache"
resolvers = ["cloudflare-dot"]
cache-rcode-max-ttl = { 3 = 60 } # NXDOMAIN records should not be cached for more than a minute
```