### PR TITLE
Implement Redis backend for cache

### DIFF
--- a/cache-redis.go
+++ b/cache-redis.go
@@ -1,0 +1,86 @@
+package rdns
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/redis/go-redis/v9"
+)
+
+type redisBackend struct {
+	client *redis.Client
+	opt    RedisBackendOptions
+}
+
+type RedisBackendOptions struct {
+	RedisOptions redis.Options
+}
+
+var _ CacheBackend = (*redisBackend)(nil)
+
+func NewRedisBackend(opt RedisBackendOptions) *redisBackend {
+	b := &redisBackend{
+		client: redis.NewClient(&opt.RedisOptions),
+		opt:    opt,
+	}
+	return b
+}
+
+func (b *redisBackend) Store(query *dns.Msg, item *cacheAnswer) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	key := redisKeyFromQuery(query)
+	value, err := json.Marshal(item)
+	if err != nil {
+		Log.WithError(err).Error("failed to marshal cache record")
+		return
+	}
+	fmt.Println(string(value))
+	if err := b.client.Set(ctx, key, value, time.Until(item.Expiry)).Err(); err != nil {
+		Log.WithError(err).Error("failed to write to redis")
+	}
+}
+
+func (b *redisBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
+	// TODO
+	return nil, false, false
+}
+
+func (b *redisBackend) Flush() {
+	// TODO
+}
+
+func (b *redisBackend) Size() int {
+	// TODO
+	return 0
+}
+
+func (b *redisBackend) Close() error {
+	return b.client.Close()
+}
+
+// Build a key string to be used in redis.
+func redisKeyFromQuery(q *dns.Msg) string {
+	var b strings.Builder
+	b.WriteString(q.Question[0].Name)
+	b.WriteByte(':')
+	b.WriteString(dns.Class(q.Question[0].Qclass).String())
+	b.WriteByte(':')
+	b.WriteString(dns.Type(q.Question[0].Qtype).String())
+	b.WriteByte(':')
+
+	edns0 := q.IsEdns0()
+	if edns0 != nil {
+		// See if we have a subnet option
+		for _, opt := range edns0.Option {
+			if subnet, ok := opt.(*dns.EDNS0_SUBNET); ok {
+				b.WriteString(subnet.Address.String())
+			}
+		}
+	}
+	return b.String()
+}

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -60,11 +60,16 @@ type doh struct {
 
 // Cache backend options
 type cacheBackend struct {
-	Type         string // Cache backend type.Defaults to "memory"
-	Size         int    // Max number of items to keep in the cache. Default 0 == unlimited. Deprecated, use backend
-	GCPeriod     int    `toml:"gc-period"` // Time-period (seconds) used to expire cached items
-	Filename     string // File to load/store cache content, optional, for "memory" type cache
-	SaveInterval int    `toml:"save-interval"` // Seconds to write the cache to file
+	Type          string // Cache backend type.Defaults to "memory"
+	Size          int    // Max number of items to keep in the cache. Default 0 == unlimited. Deprecated, use backend
+	GCPeriod      int    `toml:"gc-period"` // Time-period (seconds) used to expire cached items
+	Filename      string // File to load/store cache content, optional, for "memory" type cache
+	SaveInterval  int    `toml:"save-interval"`  // Seconds to write the cache to file
+	RedisNetwork  string `toml:"redis-network"`  // The network type, either tcp or unix. Defaults to tcp.
+	RedisAddress  string `toml:"redis-address"`  // Address for redis cache
+	RedisPassword string `toml:"redis-password"` // Redis password
+	RedisDB       int    `toml:"redis-db"`       // Redis database to be selected after connecting to the server
+
 }
 
 type group struct {

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -67,9 +67,9 @@ type cacheBackend struct {
 	SaveInterval  int    `toml:"save-interval"`  // Seconds to write the cache to file
 	RedisNetwork  string `toml:"redis-network"`  // The network type, either tcp or unix. Defaults to tcp.
 	RedisAddress  string `toml:"redis-address"`  // Address for redis cache
+	RedisUsername string `toml:"redis-username"` // Redis username
 	RedisPassword string `toml:"redis-password"` // Redis password
 	RedisDB       int    `toml:"redis-db"`       // Redis database to be selected after connecting to the server
-
 }
 
 type group struct {

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -60,16 +60,17 @@ type doh struct {
 
 // Cache backend options
 type cacheBackend struct {
-	Type          string // Cache backend type.Defaults to "memory"
-	Size          int    // Max number of items to keep in the cache. Default 0 == unlimited. Deprecated, use backend
-	GCPeriod      int    `toml:"gc-period"` // Time-period (seconds) used to expire cached items
-	Filename      string // File to load/store cache content, optional, for "memory" type cache
-	SaveInterval  int    `toml:"save-interval"`  // Seconds to write the cache to file
-	RedisNetwork  string `toml:"redis-network"`  // The network type, either tcp or unix. Defaults to tcp.
-	RedisAddress  string `toml:"redis-address"`  // Address for redis cache
-	RedisUsername string `toml:"redis-username"` // Redis username
-	RedisPassword string `toml:"redis-password"` // Redis password
-	RedisDB       int    `toml:"redis-db"`       // Redis database to be selected after connecting to the server
+	Type           string // Cache backend type.Defaults to "memory"
+	Size           int    // Max number of items to keep in the cache. Default 0 == unlimited. Deprecated, use backend
+	GCPeriod       int    `toml:"gc-period"` // Time-period (seconds) used to expire cached items
+	Filename       string // File to load/store cache content, optional, for "memory" type cache
+	SaveInterval   int    `toml:"save-interval"`    // Seconds to write the cache to file
+	RedisNetwork   string `toml:"redis-network"`    // The network type, either tcp or unix. Defaults to tcp.
+	RedisAddress   string `toml:"redis-address"`    // Address for redis cache
+	RedisUsername  string `toml:"redis-username"`   // Redis username
+	RedisPassword  string `toml:"redis-password"`   // Redis password
+	RedisKeyPrefix string `toml:"redis-key-prefix"` // Prefix any cache entry
+	RedisDB        int    `toml:"redis-db"`         // Redis database to be selected after connecting to the server
 }
 
 type group struct {

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -60,17 +60,20 @@ type doh struct {
 
 // Cache backend options
 type cacheBackend struct {
-	Type           string // Cache backend type.Defaults to "memory"
-	Size           int    // Max number of items to keep in the cache. Default 0 == unlimited. Deprecated, use backend
-	GCPeriod       int    `toml:"gc-period"` // Time-period (seconds) used to expire cached items
-	Filename       string // File to load/store cache content, optional, for "memory" type cache
-	SaveInterval   int    `toml:"save-interval"`    // Seconds to write the cache to file
-	RedisNetwork   string `toml:"redis-network"`    // The network type, either tcp or unix. Defaults to tcp.
-	RedisAddress   string `toml:"redis-address"`    // Address for redis cache
-	RedisUsername  string `toml:"redis-username"`   // Redis username
-	RedisPassword  string `toml:"redis-password"`   // Redis password
-	RedisKeyPrefix string `toml:"redis-key-prefix"` // Prefix any cache entry
-	RedisDB        int    `toml:"redis-db"`         // Redis database to be selected after connecting to the server
+	Type                 string // Cache backend type.Defaults to "memory"
+	Size                 int    // Max number of items to keep in the cache. Default 0 == unlimited. Deprecated, use backend
+	GCPeriod             int    `toml:"gc-period"` // Time-period (seconds) used to expire cached items
+	Filename             string // File to load/store cache content, optional, for "memory" type cache
+	SaveInterval         int    `toml:"save-interval"`           // Seconds to write the cache to file
+	RedisNetwork         string `toml:"redis-network"`           // The network type, either tcp or unix. Defaults to tcp.
+	RedisAddress         string `toml:"redis-address"`           // Address for redis cache
+	RedisUsername        string `toml:"redis-username"`          // Redis username
+	RedisPassword        string `toml:"redis-password"`          // Redis password
+	RedisDB              int    `toml:"redis-db"`                // Redis database to be selected after connecting to the server
+	RedisKeyPrefix       string `toml:"redis-key-prefix"`        // Prefix any cache entry
+	RedisMaxRetries      int    `toml:"redis-max-retries"`       // Maximum number of retries before giving up. Default is 3 retries; -1 (not 0) disables retries.
+	RedisMinRetryBackoff int    `toml:"redis-min-retry-backoff"` // Minimum back-off between each retry. Default is 8 milliseconds; -1 disables back-off.
+	RedisMaxRetryBackoff int    `toml:"redis-max-retry-backoff"` // Maximum back-off between each retry. Default is 512 milliseconds; -1 disables back-off.
 }
 
 type group struct {

--- a/cmd/routedns/example-config/cache-redis.toml
+++ b/cmd/routedns/example-config/cache-redis.toml
@@ -1,4 +1,4 @@
-# Simple proxy using a cache.
+# Cache backed by Redis database
 
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
@@ -9,7 +9,7 @@ type = "cache"
 resolvers = ["cloudflare-dot"]
 cache-negative-ttl = 10         # Optional, TTL to apply to responses without a SOA
 cache-answer-shuffle = "round-robin" # Optional, rotate the order of cached responses
-backend = {type = "memory", size = 1000, filename = "/tmp/cache.json", save-interval = 60}
+backend = {type = "redis", redis-address = "127.0.0.1:6379" }
 
 [listeners.local-udp]
 address = "127.0.0.1:53"

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -606,6 +606,7 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 					RedisOptions: redis.Options{
 						Network:               g.Backend.RedisNetwork,
 						Addr:                  g.Backend.RedisAddress,
+						Username:              g.Backend.RedisUsername,
 						Password:              g.Backend.RedisPassword,
 						DB:                    g.Backend.RedisDB,
 						ContextTimeoutEnabled: true,

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -611,6 +611,7 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 						DB:                    g.Backend.RedisDB,
 						ContextTimeoutEnabled: true,
 					},
+					KeyPrefix: g.Backend.RedisKeyPrefix,
 				})
 			default:
 				return fmt.Errorf("unsupported cache backend %q", g.Backend.Type)

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -602,6 +602,14 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 				})
 				onClose = append(onClose, func() { backend.Close() })
 			case "redis":
+				minRetryBackoff := time.Duration(g.Backend.RedisMinRetryBackoff) * time.Millisecond
+				if g.Backend.RedisMinRetryBackoff == -1 {
+					minRetryBackoff = -1
+				}
+				maxRetryBackoff := time.Duration(g.Backend.RedisMaxRetryBackoff) * time.Millisecond
+				if g.Backend.RedisMaxRetryBackoff == -1 {
+					maxRetryBackoff = -1
+				}
 				backend = rdns.NewRedisBackend(rdns.RedisBackendOptions{
 					RedisOptions: redis.Options{
 						Network:               g.Backend.RedisNetwork,
@@ -610,6 +618,9 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 						Password:              g.Backend.RedisPassword,
 						DB:                    g.Backend.RedisDB,
 						ContextTimeoutEnabled: true,
+						MaxRetries:            g.Backend.RedisMaxRetries,
+						MinRetryBackoff:       minRetryBackoff,
+						MaxRetryBackoff:       maxRetryBackoff,
 					},
 					KeyPrefix: g.Backend.RedisKeyPrefix,
 				})

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -308,18 +308,28 @@ Options:
 - `cache-flush-query` - A query name (FQDN with trailing `.`) that if received from a client will trigger a cache flush (reset). Inactive if not set. Simple way to support flushing the cache by sending a pre-defined query name of any type. If successful, the response will be empty. The query will not be forwarded upstream by the cache.
 - `cache-prefetch-trigger`- If a query is received for a record with less that `cache-prefetch-trigger` TTL left, the cache will send another, independent query to upstream with the goal of automatically refreshing the record in the cache with the response.
 - `cache-prefetch-eligible` - Only records with at least `prefetch-eligible` seconds TTL are eligible to be prefetched.
-- `backend` - Define what kind of storage is used for the cache. Contains multiple keys depending on type that can configure the behavior. Defaults to memory backend if not configued.
+- `backend` - Define what kind of storage is used for the cache. Contains multiple keys depending on type that can configure the behavior. Defaults to `memory` backend if not configued.
 
 Backends:
 
 **Memory backend**
 
-The memory backend will keep all cache items in memory. It can be configured to write the content of the cache to disk on shutdown. Memmory backend config has the following options:
+The memory backend will keep all cache items in memory. It can be configured to write the content of the cache to disk on shutdown. Memory backend config has the following options:
 
 - `type="memory"`
 - `size` - Max number of responses to cache. Defaults to 0 which means no limit.
 - `filename` - File to use for persistent storage to disk. The cache will be initialized with the content from the file and it'll write the content to the same file on shutdown. Defaults to no persistence
 - `save-interval` - Interval (in seconds) to save the cache to file. Optional. If not set, the file is written only on shutdown.
+
+**Redis backend**
+
+The `redis` backend stores cached items in a Redis database. This allows multiple instances of routedns to share a common cache backend. The following options are supported:
+
+- `type="redis"`
+- `redis-network` - The network type, either `tcp` or `unix`. Defaults to `tcp`.
+- `redis-address` - Address of redis database, host:port
+- `redis-password` - Redis password
+- `redis-db` - Redis database to be selected
 
 #### Examples
 
@@ -353,7 +363,17 @@ cache-flush-query = "flush.cache."
 backend = {type = "memory", filename = "/var/tmp/cache.json"}
 ```
 
-Example config files: [cache.toml](../cmd/routedns/example-config/cache.toml), [block-split-cache.toml](../cmd/routedns/example-config/block-split-cache.toml), [cache-flush.toml](../cmd/routedns/example-config/cache-flush.toml), [cache-with-prefetch.toml](../cmd/routedns/example-config/cache-with-prefetch.toml), [cache-rcode.toml](../cmd/routedns/example-config/cache-rcode.toml)
+Cache that is uses Redis as backend.
+
+```toml
+[groups.cloudflare-cached]
+type = "cache"
+resolvers = ["cloudflare-dot"]
+cache-flush-query = "flush.cache."
+backend = {type = "redis", redis-address = "127.0.0.1:6379" }
+```
+
+Example config files: [cache.toml](../cmd/routedns/example-config/cache.toml), [block-split-cache.toml](../cmd/routedns/example-config/block-split-cache.toml), [cache-flush.toml](../cmd/routedns/example-config/cache-flush.toml), [cache-with-prefetch.toml](../cmd/routedns/example-config/cache-with-prefetch.toml), [cache-rcode.toml](../cmd/routedns/example-config/cache-rcode.toml), [cache-redis.toml](../cmd/routedns/example-config/cache-redis.toml)
 
 ### TTL modifier
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -328,6 +328,7 @@ The `redis` backend stores cached items in a Redis database. This allows multipl
 - `type="redis"`
 - `redis-network` - The network type, either `tcp` or `unix`. Defaults to `tcp`.
 - `redis-address` - Address of redis database, host:port
+- `redis-username` - Redis username
 - `redis-password` - Redis password
 - `redis-db` - Redis database to be selected
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -332,6 +332,9 @@ The `redis` backend stores cached items in a Redis database. This allows multipl
 - `redis-password` - Redis password
 - `redis-db` - Redis database to be selected
 - `redis-key-prefix` - Prefixes the key of every record with this string. This can be used to share a database with other clients and avoid key conflicts.
+- `redis-max-retries` - Maximum number of retries before giving up. Default is 3 retries; -1 (not 0) disables retries.
+- `redis-min-retry-backoff` - Minimum back-off between each retry in milliseconds. Default is 8 milliseconds; -1 disables back-off.
+- `redis-max-retry-backoff` - Maximum back-off between each retry in milliseconds. Default is 512 milliseconds; -1 disables back-off.
 
 #### Examples
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -331,6 +331,7 @@ The `redis` backend stores cached items in a Redis database. This allows multipl
 - `redis-username` - Redis username
 - `redis-password` - Redis password
 - `redis-db` - Redis database to be selected
+- `redis-key-prefix` - Prefixes the key of every record with this string. This can be used to share a database with other clients and avoid key conflicts.
 
 #### Examples
 
@@ -371,7 +372,7 @@ Cache that is uses Redis as backend.
 type = "cache"
 resolvers = ["cloudflare-dot"]
 cache-flush-query = "flush.cache."
-backend = {type = "redis", redis-address = "127.0.0.1:6379" }
+backend = {type = "redis", redis-address = "127.0.0.1:6379", redis-key-prefix = "routedns-"}
 ```
 
 Example config files: [cache.toml](../cmd/routedns/example-config/cache.toml), [block-split-cache.toml](../cmd/routedns/example-config/block-split-cache.toml), [cache-flush.toml](../cmd/routedns/example-config/cache-flush.toml), [cache-with-prefetch.toml](../cmd/routedns/example-config/cache-with-prefetch.toml), [cache-rcode.toml](../cmd/routedns/example-config/cache-rcode.toml), [cache-redis.toml](../cmd/routedns/example-config/cache-redis.toml)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,9 @@ require (
 )
 
 require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/golang/mock v1.6.0 // indirect
@@ -35,6 +37,7 @@ require (
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-19 v0.2.1 // indirect
 	github.com/quic-go/qtls-go1-20 v0.1.1 // indirect
+	github.com/redis/go-redis/v9 v9.0.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/exp v0.0.0-20221227203929-1b447090c38c // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pion/dtls/v2 v2.2.4
 	github.com/pkg/errors v0.9.1
 	github.com/quic-go/quic-go v0.33.0
+	github.com/redis/go-redis/v9 v9.0.4
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
@@ -37,7 +38,6 @@ require (
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-19 v0.2.1 // indirect
 	github.com/quic-go/qtls-go1-20 v0.1.1 // indirect
-	github.com/redis/go-redis/v9 v9.0.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/exp v0.0.0-20221227203929-1b447090c38c // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91 h1:vX+gnvBc56EbWYrmlhYbFYRaeikAke1GL84N4BEYOFE=
 github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91/go.mod h1:cDLGBht23g0XQdLjzn6xOGXDkLK182YfINAaZEQLCHQ=
+github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
+github.com/bsm/gomega v1.26.0 h1:LhQm+AFcgV2M0WyKroMASzAzCAJVpAxQXv4SaI9a69Y=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/go.sum
+++ b/go.sum
@@ -2,11 +2,15 @@ github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91 h1:vX+gnvBc56EbWYrmlhYbFYRaeikAke1GL84N4BEYOFE=
 github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91/go.mod h1:cDLGBht23g0XQdLjzn6xOGXDkLK182YfINAaZEQLCHQ=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
@@ -62,6 +66,8 @@ github.com/quic-go/qtls-go1-20 v0.1.1 h1:KbChDlg82d3IHqaj2bn6GfKRj84Per2VGf5XV3w
 github.com/quic-go/qtls-go1-20 v0.1.1/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
 github.com/quic-go/quic-go v0.33.0 h1:ItNoTDN/Fm/zBlq769lLJc8ECe9gYaW40veHCCco7y0=
 github.com/quic-go/quic-go v0.33.0/go.mod h1:YMuhaAV9/jIu0XclDXwZPAsP/2Kgr5yMYhe9oxhhOFA=
+github.com/redis/go-redis/v9 v9.0.4 h1:FC82T+CHJ/Q/PdyLW++GeCO+Ol59Y4T7R4jbgjvktgc=
+github.com/redis/go-redis/v9 v9.0.4/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Support for storing caches in Redis to allow for multiple instances sharing a common cache.

```toml
[groups.cloudflare-cached]
type = "cache"
resolvers = ["cloudflare-dot"]
backend = {type = "redis", redis-address = "127.0.0.1:6379" }
```

Implements #278 