### PR TITLE
Separate DNSSEC queries from normal queries in the cache

### DIFF
--- a/cache-redis.go
+++ b/cache-redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -125,6 +126,8 @@ func (b *redisBackend) keyFromQuery(q *dns.Msg) string {
 
 	edns0 := q.IsEdns0()
 	if edns0 != nil {
+		key.WriteString(fmt.Sprintf("%t", edns0.Do()))
+		key.WriteByte(':')
 		// See if we have a subnet option
 		for _, opt := range edns0.Option {
 			if subnet, ok := opt.(*dns.EDNS0_SUBNET); ok {

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -23,6 +23,7 @@ type cacheItem struct {
 type lruKey struct {
 	Question dns.Question
 	Net      string
+	Do       bool
 }
 
 type cacheAnswer struct {
@@ -210,6 +211,7 @@ func lruKeyFromQuery(q *dns.Msg) lruKey {
 
 	edns0 := q.IsEdns0()
 	if edns0 != nil {
+		key.Do = edns0.Do()
 		// See if we have a subnet option
 		for _, opt := range edns0.Option {
 			if subnet, ok := opt.(*dns.EDNS0_SUBNET); ok {


### PR DESCRIPTION
Fixes #320 by including the `Do` flag in the cache-key.