### PR TITLE
Implement GeoIP blocking based on ASN

### DIFF
--- a/asn-db.go
+++ b/asn-db.go
@@ -1,0 +1,96 @@
+package rdns
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/oschwald/maxminddb-golang"
+)
+
+// ASNDB holds blocklist rules based on ASN location. When an IP is queried,
+// its ASN is looked up in a database and the result is compared to the
+// blocklist rules.
+type ASNDB struct {
+	name      string
+	loader    BlocklistLoader
+	geoDB     *maxminddb.Reader
+	geoDBFile string
+	db        map[uint64]struct{}
+}
+
+var _ IPBlocklistDB = &ASNDB{}
+
+// NewASN returns a new instance of a matcher for a ASN rules.
+func NewASNDB(name string, loader BlocklistLoader, geoDBFile string) (*ASNDB, error) {
+	if geoDBFile == "" {
+		geoDBFile = "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+	}
+	geoDB, err := maxminddb.Open(geoDBFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open geo asn database file: %w", err)
+	}
+
+	rules, err := loader.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	db := make(map[uint64]struct{})
+	for _, r := range rules {
+		r = strings.TrimSpace(r)
+		if strings.HasPrefix(r, "#") || r == "" {
+			continue
+		}
+		r = strings.Split(r, "#")[0] // possible comment at the end of the line
+		r = strings.TrimSpace(r)
+		value, err := strconv.ParseUint(r, 10, 64) // GeoNames ID
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse asn id in rule '%s': %w", r, err)
+		}
+		db[value] = struct{}{}
+	}
+	return &ASNDB{
+		name:      name,
+		geoDB:     geoDB,
+		geoDBFile: geoDBFile,
+		db:        db,
+		loader:    loader,
+	}, nil
+}
+
+func (m *ASNDB) Reload() (IPBlocklistDB, error) {
+	return NewASNDB(m.name, m.loader, m.geoDBFile)
+}
+
+func (m *ASNDB) Match(ip net.IP) (*BlocklistMatch, bool) {
+	var record struct {
+		ASN          uint64 `maxminddb:"autonomous_system_number"`
+		Organization string `maxminddb:"autonomous_system_organization"`
+	}
+
+	if err := m.geoDB.Lookup(ip, &record); err != nil {
+		Log.WithField("ip", ip).WithError(err).Error("failed to lookup ip in geo location database")
+		return nil, false
+	}
+
+	fmt.Println(record)
+
+	// Check if the ASN is on the blocklist
+	if _, ok := m.db[record.ASN]; ok {
+		return &BlocklistMatch{
+			List: m.name,
+			Rule: fmt.Sprintf("%d", record.ASN),
+		}, true
+	}
+	return nil, false
+}
+
+func (m *ASNDB) Close() error {
+	return m.geoDB.Close()
+}
+
+func (m *ASNDB) String() string {
+	return "ASN-blocklist"
+}

--- a/asn-db.go
+++ b/asn-db.go
@@ -71,7 +71,7 @@ func (m *ASNDB) Match(ip net.IP) (*BlocklistMatch, bool) {
 	}
 
 	if err := m.geoDB.Lookup(ip, &record); err != nil {
-		Log.WithField("ip", ip).WithError(err).Error("failed to lookup ip in geo location database")
+		Log.Error("failed to lookup ip in geo location database", "ip", ip, "error", err)
 		return nil, false
 	}
 

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -957,6 +957,8 @@ func newIPBlocklistDB(l list, locationDB string, rules []string) (rdns.IPBlockli
 		return rdns.NewCidrDB(name, loader)
 	case "location":
 		return rdns.NewGeoIPDB(name, loader, locationDB)
+	case "asn":
+		return rdns.NewASNDB(name, loader, locationDB)
 	default:
 		return nil, fmt.Errorf("unsupported format '%s'", l.Format)
 	}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -753,7 +753,7 @@ Options:
 - `location-db` - If location-based IP blocking is used, this specifies the GeoIP data file to load. Optional. Defaults to /usr/share/GeoIP/GeoLite2-City.mmdb
 - `edns0-ede` - Optional, include an extended error code in the response if it's blocked. Only used when the response is blocked, not when it's spoofed. The value is a struct with two keys, `code` (number) and `text` (string). Possible values for `code` are defined in [rfc8914](https://datatracker.ietf.org/doc/html/rfc8914) while `text` can carry additional information that is displayed by `dig` for example. The `text` value is a template that has access to a number of fields of query to allow customizing the response based on data in the query. See [Templates](#templates) for details. Simple placeholders in `text` would be `{{ .Question }}` for the question in the query or `{{ .ID }}` to be replaced with the query ID.
 
-Location-based blocking requires a list of GeoName IDs of geographical entities (Continent, Country, City or Subdivision) and the GeoName ID, like `2750405` for Netherlands. The GeoName ID can be looked up in [https://www.geonames.org/](https://www.geonames.org/). Locations are read from a MAXMIND GeoIP2 database that either has to be present in `/usr/share/GeoIP/GeoLite2-City.mmdb` or is configured with the `location-db` option.
+Location-based blocking requires a list of GeoName IDs of geographical entities (Continent, Country, City or Subdivision) and the GeoName ID, like `2750405` for Netherlands. The GeoName ID can be looked up in [https://www.geonames.org/](https://www.geonames.org/). Locations are read from a MAXMIND GeoIP2 database that either has to be present in `/usr/share/GeoIP/GeoLite2-City.mmdb` or is configured with the `location-db` option. Similarly, using a different location database (`/usr/share/GeoIP/GeoLite2-ASN.mmdb`) it is possible to block IP resonses located in specific ASNs (Autonomous System Number). `blocklist-format` should be set to `asn` in that case.
 
 Examples:
 
@@ -829,7 +829,19 @@ blocklist           = [
 ]
 ```
 
-Example config files: [response-blocklist-ip.toml](../cmd/routedns/example-config/response-blocklist-ip.toml), [response-blocklist-name.toml](../cmd/routedns/example-config/response-blocklist-name.toml), [response-blocklist-ip-remote.toml](../cmd/routedns/example-config/response-blocklist-ip-remote.toml), [response-blocklist-name-remote.toml](../cmd/routedns/example-config/response-blocklist-name-remote.toml), [response-blocklist-ip-resolver.toml](../cmd/routedns/example-config/response-blocklist-ip-resolver.toml), [response-blocklist-name-resolver.toml](../cmd/routedns/example-config/response-blocklist-name-resolver.toml), [response-blocklist-geo.toml](../cmd/routedns/example-config/response-blocklist-geo.toml)
+Response blocklist based on ASN of the IP. The ASNs of the organizations to be blocked must be provided as an array of string.
+
+```toml
+[groups.cloudflare-blocklist]
+type                = "response-blocklist-ip"
+resolvers           = ["cloudflare-dot"]
+blocklist-format    = "asn"
+blocklist           = [
+  "15169", # Google
+]
+```
+
+Example config files: [response-blocklist-ip.toml](../cmd/routedns/example-config/response-blocklist-ip.toml), [response-blocklist-name.toml](../cmd/routedns/example-config/response-blocklist-name.toml), [response-blocklist-ip-remote.toml](../cmd/routedns/example-config/response-blocklist-ip-remote.toml), [response-blocklist-name-remote.toml](../cmd/routedns/example-config/response-blocklist-name-remote.toml), [response-blocklist-ip-resolver.toml](../cmd/routedns/example-config/response-blocklist-ip-resolver.toml), [response-blocklist-name-resolver.toml](../cmd/routedns/example-config/response-blocklist-name-resolver.toml), [response-blocklist-geo.toml](../cmd/routedns/example-config/response-blocklist-geo.toml), [response-blocklist-asn.toml](../cmd/routedns/example-config/response-blocklist-asn.toml)
 
 ### Client Blocklist
 


### PR DESCRIPTION
Support for blocking of IPs from specific organizations (ASN). Requires `/usr/share/GeoIP/GeoLite2-ASN.mmdb` or similar to be present which may require a GeoLite2 account + running `geoipupdate` on Linux.

```toml
 [groups.cloudflare-blocklist]
type                = "response-blocklist-ip"
resolvers           = ["cloudflare-dot"]
blocklist-format    = "asn"
blocklist           = [
  "15169", # Google
]
```

Implements #94 