### PR TITLE
Return all names for a PTR lookup in hosts blocklist

### DIFF
--- a/blocklist.go
+++ b/blocklist.go
@@ -51,6 +51,11 @@ type BlocklistMetrics struct {
 	allowed *expvar.Int
 }
 
+const (
+	// Max number of name records to reply with for PTR lookups
+	maxPTRResponses = 10
+)
+
 func NewBlocklistMetrics(id string) *BlocklistMetrics {
 	return &BlocklistMetrics{
 		allowed: getVarInt("router", id, "allow"),
@@ -118,6 +123,9 @@ func (r *Blocklist) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	// If we got names for the PTR query, respond to it
 	if question.Qtype == dns.TypePTR && len(names) > 0 {
 		log.Debug("responding with ptr blocklist from blocklist")
+		if len(names) > maxPTRResponses {
+			names = names[:maxPTRResponses]
+		}
 		return ptr(q, names), nil
 	}
 

--- a/blocklist.go
+++ b/blocklist.go
@@ -105,7 +105,7 @@ func (r *Blocklist) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		}
 	}
 
-	ip, name, match, ok := blocklistDB.Match(question)
+	ip, names, match, ok := blocklistDB.Match(question)
 	if !ok {
 		// Didn't match anything, pass it on to the next resolver
 		log.WithField("resolver", r.resolver.String()).Debug("forwarding unmodified query to resolver")
@@ -115,10 +115,10 @@ func (r *Blocklist) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	log = log.WithFields(logrus.Fields{"list": match.List, "rule": match.Rule})
 	r.metrics.blocked.Add(1)
 
-	// If we got a name for the PTR query, respond to it
-	if question.Qtype == dns.TypePTR && name != "" {
+	// If we got names for the PTR query, respond to it
+	if question.Qtype == dns.TypePTR && len(names) > 0 {
 		log.Debug("responding with ptr blocklist from blocklist")
-		return ptr(q, name), nil
+		return ptr(q, names), nil
 	}
 
 	// If an optional blocklist-resolver was given, send the query to that instead of returning NXDOMAIN.

--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -63,7 +63,7 @@ func (m *DomainDB) Reload() (BlocklistDB, error) {
 	return NewDomainDB(m.name, m.loader)
 }
 
-func (m *DomainDB) Match(q dns.Question) (net.IP, string, *BlocklistMatch, bool) {
+func (m *DomainDB) Match(q dns.Question) (net.IP, []string, *BlocklistMatch, bool) {
 	s := strings.TrimSuffix(q.Name, ".")
 	var matched []string
 	parts := strings.Split(s, ".")
@@ -72,12 +72,12 @@ func (m *DomainDB) Match(q dns.Question) (net.IP, string, *BlocklistMatch, bool)
 		part := parts[i]
 		subNode, ok := n[part]
 		if !ok {
-			return nil, "", nil, false
+			return nil, nil, nil, false
 		}
 		matched = append(matched, part)
 		if _, ok := subNode[""]; ok { // exact and sub-domain match
 			return nil,
-				"",
+				nil,
 				&BlocklistMatch{
 					List: m.name,
 					Rule: matchedDomainParts(".", matched),
@@ -86,7 +86,7 @@ func (m *DomainDB) Match(q dns.Question) (net.IP, string, *BlocklistMatch, bool)
 		}
 		if _, ok := subNode["*"]; ok && i > 0 { // wildcard match on sub-domains
 			return nil,
-				"",
+				nil,
 				&BlocklistMatch{
 					List: m.name,
 					Rule: matchedDomainParts("*.", matched),
@@ -96,7 +96,7 @@ func (m *DomainDB) Match(q dns.Question) (net.IP, string, *BlocklistMatch, bool)
 		n = subNode
 	}
 	return nil,
-		"",
+		nil,
 		&BlocklistMatch{
 			List: m.name,
 			Rule: matchedDomainParts("", matched),

--- a/blocklistdb-hosts.go
+++ b/blocklistdb-hosts.go
@@ -80,9 +80,13 @@ func (m *HostsDB) Reload() (BlocklistDB, error) {
 func (m *HostsDB) Match(q dns.Question) (net.IP, []string, *BlocklistMatch, bool) {
 	if q.Qtype == dns.TypePTR {
 		names, ok := m.ptrMap[q.Name]
+		var rule string
+		if len(names) > 0 {
+			rule = names[0]
+		}
 		return nil, names, &BlocklistMatch{
 			List: m.name,
-			Rule: names[0],
+			Rule: rule,
 		}, ok
 	}
 	name := strings.TrimSuffix(q.Name, ".")

--- a/blocklistdb-multi.go
+++ b/blocklistdb-multi.go
@@ -30,13 +30,13 @@ func (m MultiDB) Reload() (BlocklistDB, error) {
 	return NewMultiDB(newDBs...)
 }
 
-func (m MultiDB) Match(q dns.Question) (net.IP, string, *BlocklistMatch, bool) {
+func (m MultiDB) Match(q dns.Question) (net.IP, []string, *BlocklistMatch, bool) {
 	for _, db := range m.dbs {
 		if ip, name, match, ok := db.Match(q); ok {
 			return ip, name, match, ok
 		}
 	}
-	return nil, "", nil, false
+	return nil, nil, nil, false
 }
 
 func (m MultiDB) String() string {

--- a/blocklistdb-regexp.go
+++ b/blocklistdb-regexp.go
@@ -43,13 +43,13 @@ func (m *RegexpDB) Reload() (BlocklistDB, error) {
 	return NewRegexpDB(m.name, m.loader)
 }
 
-func (m *RegexpDB) Match(q dns.Question) (net.IP, string, *BlocklistMatch, bool) {
+func (m *RegexpDB) Match(q dns.Question) (net.IP, []string, *BlocklistMatch, bool) {
 	for _, rule := range m.rules {
 		if rule.MatchString(q.Name) {
-			return nil, "", &BlocklistMatch{List: m.name, Rule: rule.String()}, true
+			return nil, nil, &BlocklistMatch{List: m.name, Rule: rule.String()}, true
 		}
 	}
-	return nil, "", nil, false
+	return nil, nil, nil, false
 }
 
 func (m *RegexpDB) String() string {

--- a/blocklistdb.go
+++ b/blocklistdb.go
@@ -13,8 +13,9 @@ type BlocklistDB interface {
 	Reload() (BlocklistDB, error)
 
 	// Returns true if the question matches a rule. If the IP is not nil,
-	// respond with the given IP. NXDOMAIN otherwise.
-	Match(q dns.Question) (net.IP, string, *BlocklistMatch, bool)
+	// respond with the given IP. NXDOMAIN otherwise. The returned names,
+	// if set, are used to answer PTR queries
+	Match(q dns.Question) (ip net.IP, names []string, m *BlocklistMatch, matched bool)
 
 	fmt.Stringer
 }

--- a/message.go
+++ b/message.go
@@ -53,11 +53,12 @@ func responseWithCode(q *dns.Msg, rcode int) *dns.Msg {
 }
 
 // Answers a PTR query with a name
-func ptr(q *dns.Msg, name string) *dns.Msg {
+func ptr(q *dns.Msg, names []string) *dns.Msg {
 	a := new(dns.Msg)
 	a.SetReply(q)
-	a.Answer = []dns.RR{
-		&dns.PTR{
+	answer := make([]dns.RR, 0, len(names))
+	for _, name := range names {
+		rr := &dns.PTR{
 			Hdr: dns.RR_Header{
 				Name:   q.Question[0].Name,
 				Rrtype: dns.TypePTR,
@@ -65,8 +66,10 @@ func ptr(q *dns.Msg, name string) *dns.Msg {
 				Ttl:    3600,
 			},
 			Ptr: dns.Fqdn(name),
-		},
+		}
+		answer = append(answer, rr)
 	}
+	a.Answer = answer
 	return a
 }
 


### PR DESCRIPTION
When doing a PTR lookup with an IP on a hosts file blocklist, previously it would return just the first name. Now it'll return all.

Implements #107 