### PR TITLE
Support inverting the behavior of response-blocklist-ip / -name

### DIFF
--- a/blocklistdb.go
+++ b/blocklistdb.go
@@ -26,3 +26,17 @@ type BlocklistMatch struct {
 	List string // Identifier or name of the blocklist
 	Rule string // Identifier for the rule that matched
 }
+
+func (m *BlocklistMatch) GetList() string {
+	if m == nil {
+		return "none"
+	}
+	return m.List
+}
+
+func (m *BlocklistMatch) GetRule() string {
+	if m == nil {
+		return "none"
+	}
+	return m.Rule
+}

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -125,6 +125,7 @@ type group struct {
 	AllowlistSource   []list   `toml:"allowlist-source"`
 	AllowlistRefresh  int      `toml:"allowlist-refresh"`
 	LocationDB        string   `toml:"location-db"` // GeoIP database file for response blocklist. Default "/usr/share/GeoIP/GeoLite2-City.mmdb"
+	Inverted          bool     // Only allow IPs on the blocklist. Supported in response-blocklist-ip and response-blocklist-name
 
 	// Static responder options
 	Answer   []string

--- a/cmd/routedns/example-config/response-blocklist-ip.toml
+++ b/cmd/routedns/example-config/response-blocklist-ip.toml
@@ -15,3 +15,8 @@ blocklist           = [
 address = ":53"
 protocol = "udp"
 resolver = "cloudflare-blocklist"
+
+[listeners.local-tcp]
+address = ":53"
+protocol = "tcp"
+resolver = "cloudflare-blocklist"

--- a/cmd/routedns/example-config/response-blocklist-ip.toml
+++ b/cmd/routedns/example-config/response-blocklist-ip.toml
@@ -8,8 +8,6 @@ resolvers           = ["cloudflare-dot"]
 blocklist           = [
   '127.0.0.0/24',
   '157.240.0.0/16',
-  '104.16.132.229',
-  # '104.16.133.229',
 ]
 #filter = true # Set to true if the response RRs should be filtered rather than returning NXDOMAIN (default)
 

--- a/cmd/routedns/example-config/response-blocklist-ip.toml
+++ b/cmd/routedns/example-config/response-blocklist-ip.toml
@@ -8,15 +8,12 @@ resolvers           = ["cloudflare-dot"]
 blocklist           = [
   '127.0.0.0/24',
   '157.240.0.0/16',
+  '104.16.132.229',
+  # '104.16.133.229',
 ]
 #filter = true # Set to true if the response RRs should be filtered rather than returning NXDOMAIN (default)
 
 [listeners.local-udp]
 address = ":53"
 protocol = "udp"
-resolver = "cloudflare-blocklist"
-
-[listeners.local-tcp]
-address = ":53"
-protocol = "tcp"
 resolver = "cloudflare-blocklist"

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -662,6 +662,7 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 			BlocklistDB:       blocklistDB,
 			BlocklistRefresh:  time.Duration(g.BlocklistRefresh) * time.Second,
 			Filter:            g.Filter,
+			Inverted:          g.Inverted,
 		}
 		resolvers[id], err = rdns.NewResponseBlocklistIP(id, gr[0], opt)
 		if err != nil {
@@ -698,6 +699,7 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 			BlocklistResolver: resolvers[g.BlockListResolver],
 			BlocklistDB:       blocklistDB,
 			BlocklistRefresh:  time.Duration(g.BlocklistRefresh) * time.Second,
+			Inverted:          g.Inverted,
 		}
 		resolvers[id], err = rdns.NewResponseBlocklistName(id, gr[0], opt)
 		if err != nil {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -703,7 +703,7 @@ Rather than filtering queries, response blocklists evaluate the response to a qu
 
 The configuration options of response blocklists are very similar to that of [query blocklists](#Query-Blocklist) with the exception of the `allowlists-*` options which are not supported in response blocklists.
 
-Query blocklists are instantiated with `type = "response-blocklist-ip"` or `type = "response-blocklist-name"` in the groups section of the configuration.
+Response blocklists are instantiated with `type = "response-blocklist-ip"` or `type = "response-blocklist-name"` in the groups section of the configuration.
 
 Options:
 
@@ -715,6 +715,7 @@ Options:
 - `blocklist-refresh` - Time interval (in seconds) in which external (remote or local) blocklists are reloaded. Optional.
 - `blocklist-source` - An array of blocklists, each with `format`, `source` and optionally `cache-dir` (see notes for [Query Blockists](#Query-Blocklist)) as well as `name` which assigns a name to the list used in logs (defaults to `source`).
 - `filter` - If set to `true` in `response-blocklist-ip`, matching records will be removed from responses rather than the whole response. If there is no answer record left after applying the filter, NXDOMAIN will be returned unless an alternative `blocklist-resolver` is defined.
+- `inverted` - Inverts the behavior of the blocklist. If set to `true`, only IPs that are on the blocklist are allowed and responses containing an IP not on the blocklist are blocked. Can be combined with `filter` to remove any IPs not on the blocklist from the response.
 - `location-db` - If location-based IP blocking is used, this specifies the GeoIP data file to load. Optional. Defaults to /usr/share/GeoIP/GeoLite2-City.mmdb
 
 Location-based blocking requires a list of GeoName IDs of geographical entities (Continent, Country, City or Subdivision) and the GeoName ID, like `2750405` for Netherlands. The GeoName ID can be looked up in [https://www.geonames.org/](https://www.geonames.org/). Locations are read from a MAXMIND GeoIP2 database that either has to be present in `/usr/share/GeoIP/GeoLite2-City.mmdb` or is configured with the `location-db` option.

--- a/response-blocklist-ip.go
+++ b/response-blocklist-ip.go
@@ -41,6 +41,9 @@ type ResponseBlocklistIPOptions struct {
 	// If true, removes matching records from the response rather than replying with NXDOMAIN. Can
 	// not be combined with alternative blockist-resolver
 	Filter bool
+
+	// Inverted behavior, only allow responses that can be found on at least one list.
+	Inverted bool
 }
 
 // NewResponseBlocklistIP returns a new instance of a response blocklist resolver.
@@ -103,7 +106,7 @@ func (r *ResponseBlocklistIP) blockIfMatch(query, answer *dns.Msg, ci ClientInfo
 			default:
 				continue
 			}
-			if match, ok := r.BlocklistDB.Match(ip); ok {
+			if match, ok := r.BlocklistDB.Match(ip); ok != r.Inverted {
 				log := logger(r.id, query, ci).WithFields(logrus.Fields{"list": match.List, "rule": match.Rule, "ip": ip})
 				if r.BlocklistResolver != nil {
 					log.WithField("resolver", r.BlocklistResolver).Debug("blocklist match, forwarding to blocklist-resolver")
@@ -147,7 +150,7 @@ func (r *ResponseBlocklistIP) filterRR(query *dns.Msg, ci ClientInfo, rrs []dns.
 			newRRs = append(newRRs, rr)
 			continue
 		}
-		if match, ok := r.BlocklistDB.Match(ip); ok {
+		if match, ok := r.BlocklistDB.Match(ip); ok != r.Inverted {
 			logger(r.id, query, ci).WithFields(logrus.Fields{"list": match.List, "rule": match.Rule, "ip": ip}).Debug("filtering response")
 			continue
 		}

--- a/response-blocklist-ip.go
+++ b/response-blocklist-ip.go
@@ -107,7 +107,7 @@ func (r *ResponseBlocklistIP) blockIfMatch(query, answer *dns.Msg, ci ClientInfo
 				continue
 			}
 			if match, ok := r.BlocklistDB.Match(ip); ok != r.Inverted {
-				log := logger(r.id, query, ci).WithFields(logrus.Fields{"list": match.List, "rule": match.Rule, "ip": ip})
+				log := logger(r.id, query, ci).WithFields(logrus.Fields{"list": match.GetList(), "rule": match.GetRule(), "ip": ip})
 				if r.BlocklistResolver != nil {
 					log.WithField("resolver", r.BlocklistResolver).Debug("blocklist match, forwarding to blocklist-resolver")
 					return r.BlocklistResolver.Resolve(query, ci)
@@ -151,7 +151,7 @@ func (r *ResponseBlocklistIP) filterRR(query *dns.Msg, ci ClientInfo, rrs []dns.
 			continue
 		}
 		if match, ok := r.BlocklistDB.Match(ip); ok != r.Inverted {
-			logger(r.id, query, ci).WithFields(logrus.Fields{"list": match.List, "rule": match.Rule, "ip": ip}).Debug("filtering response")
+			logger(r.id, query, ci).WithFields(logrus.Fields{"list": match.GetList(), "rule": match.GetRule(), "ip": ip}).Debug("filtering response")
 			continue
 		}
 		newRRs = append(newRRs, rr)

--- a/response-blocklist-name.go
+++ b/response-blocklist-name.go
@@ -26,6 +26,9 @@ type ResponseBlocklistNameOptions struct {
 
 	// Refresh period for the blocklist. Disabled if 0.
 	BlocklistRefresh time.Duration
+
+	// Inverted behavior, only allow responses that can be found on at least one list.
+	Inverted bool
 }
 
 // NewResponseBlocklistName returns a new instance of a response blocklist resolver.
@@ -87,7 +90,7 @@ func (r *ResponseBlocklistName) blockIfMatch(query, answer *dns.Msg, ci ClientIn
 			default:
 				continue
 			}
-			if _, _, rule, ok := r.BlocklistDB.Match(dns.Question{Name: name}); ok {
+			if _, _, rule, ok := r.BlocklistDB.Match(dns.Question{Name: name}); ok != r.Inverted {
 				log := logger(r.id, query, ci).WithField("rule", rule.Rule)
 				if r.BlocklistResolver != nil {
 					log.WithField("resolver", r.BlocklistResolver).Debug("blocklist match, forwarding to blocklist-resolver")

--- a/response-blocklist-name.go
+++ b/response-blocklist-name.go
@@ -91,7 +91,7 @@ func (r *ResponseBlocklistName) blockIfMatch(query, answer *dns.Msg, ci ClientIn
 				continue
 			}
 			if _, _, rule, ok := r.BlocklistDB.Match(dns.Question{Name: name}); ok != r.Inverted {
-				log := logger(r.id, query, ci).WithField("rule", rule.Rule)
+				log := logger(r.id, query, ci).WithField("rule", rule.GetRule())
 				if r.BlocklistResolver != nil {
 					log.WithField("resolver", r.BlocklistResolver).Debug("blocklist match, forwarding to blocklist-resolver")
 					return r.BlocklistResolver.Resolve(query, ci)


### PR DESCRIPTION
Implements #343 

Adds support for a new flag `inverted = true` on response blocklists to invert their logic and only allow responses that exist on at least one list