### PR TITLE
New use-ecs option in client-blocklist

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -139,6 +139,7 @@ type group struct {
 	AllowlistRefresh  int      `toml:"allowlist-refresh"`
 	LocationDB        string   `toml:"location-db"` // GeoIP database file for response blocklist. Default "/usr/share/GeoIP/GeoLite2-City.mmdb"
 	Inverted          bool     // Only allow IPs on the blocklist. Supported in response-blocklist-ip and response-blocklist-name
+	UseECS            bool     `toml:"use-ecs"` // Use ECS IP address in client-blocklist
 
 	// Static responder options
 	Answer   []string

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -763,6 +763,7 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 			BlocklistResolver: resolvers[g.BlockListResolver],
 			BlocklistDB:       blocklistDB,
 			BlocklistRefresh:  time.Duration(g.BlocklistRefresh) * time.Second,
+			UseECS:            g.UseECS,
 		}
 		resolvers[id], err = rdns.NewClientBlocklist(id, gr[0], opt)
 		if err != nil {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -847,6 +847,7 @@ Options:
 - `blocklist-refresh` - Time interval (in seconds) in which external (remote or local) blocklists are reloaded. Optional.
 - `blocklist-source` - An array of blocklists, each with `format` and `source` and optionally `name`.
 - `location-db` - If location-based IP blocking is used, this specifies the GeoIP data file to load. Optional. Defaults to /usr/share/GeoIP/GeoLite2-City.mmdb
+- `use-ecs` - If set to true, will use the IP address in the client's ECS record instead of the real IP. Can be used to simulate queries from other source IPs. The address should be set to the IP, not a subnet for this to work. Uses the client's real IP if no ECS record is found in the query.
 
 Examples:
 


### PR DESCRIPTION
Implements #348 

Adds a new `use-ecs` option (bool) to `client-blocklist`. If set, the blocklist will use the IP address in the ECS record instead of the client's real IP.