### PR TITLE
Return multiple spoofed IPs from hosts-based blocklist

### DIFF
--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -63,7 +63,7 @@ func (m *DomainDB) Reload() (BlocklistDB, error) {
 	return NewDomainDB(m.name, m.loader)
 }
 
-func (m *DomainDB) Match(q dns.Question) (net.IP, []string, *BlocklistMatch, bool) {
+func (m *DomainDB) Match(q dns.Question) ([]net.IP, []string, *BlocklistMatch, bool) {
 	s := strings.TrimSuffix(q.Name, ".")
 	var matched []string
 	parts := strings.Split(s, ".")

--- a/blocklistdb-multi.go
+++ b/blocklistdb-multi.go
@@ -30,7 +30,7 @@ func (m MultiDB) Reload() (BlocklistDB, error) {
 	return NewMultiDB(newDBs...)
 }
 
-func (m MultiDB) Match(q dns.Question) (net.IP, []string, *BlocklistMatch, bool) {
+func (m MultiDB) Match(q dns.Question) ([]net.IP, []string, *BlocklistMatch, bool) {
 	for _, db := range m.dbs {
 		if ip, name, match, ok := db.Match(q); ok {
 			return ip, name, match, ok

--- a/blocklistdb-regexp.go
+++ b/blocklistdb-regexp.go
@@ -43,7 +43,7 @@ func (m *RegexpDB) Reload() (BlocklistDB, error) {
 	return NewRegexpDB(m.name, m.loader)
 }
 
-func (m *RegexpDB) Match(q dns.Question) (net.IP, []string, *BlocklistMatch, bool) {
+func (m *RegexpDB) Match(q dns.Question) ([]net.IP, []string, *BlocklistMatch, bool) {
 	for _, rule := range m.rules {
 		if rule.MatchString(q.Name) {
 			return nil, nil, &BlocklistMatch{List: m.name, Rule: rule.String()}, true

--- a/blocklistdb.go
+++ b/blocklistdb.go
@@ -15,7 +15,7 @@ type BlocklistDB interface {
 	// Returns true if the question matches a rule. If the IP is not nil,
 	// respond with the given IP. NXDOMAIN otherwise. The returned names,
 	// if set, are used to answer PTR queries
-	Match(q dns.Question) (ip net.IP, names []string, m *BlocklistMatch, matched bool)
+	Match(q dns.Question) (ip []net.IP, names []string, m *BlocklistMatch, matched bool)
 
 	fmt.Stringer
 }


### PR DESCRIPTION
When a hosts-based blocklist contains more than one IP for a name, return all (up to 10) of the IPs as spoofed IP records.

Implements #326 