### PR TITLE
New ip-version option for listeners

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -22,6 +22,7 @@ type config struct {
 type listener struct {
 	Address    string
 	Protocol   string
+	IPVersion  int `toml:"ip-version"` // 4 = IPv4, 6 = IPv6
 	Transport  string
 	Resolver   string
 	CA         string

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -196,7 +196,7 @@ func start(opt options, args []string) error {
 			return err
 		}
 
-		if l.IPVersion != 4 && l.IPVersion != 6 {
+		if l.IPVersion != 4 && l.IPVersion != 6 && l.IPVersion != 0 {
 			return errors.New("ip-version must be 4 or 6")
 		}
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -119,6 +119,7 @@ Common options for all listeners:
 
 - `address` - Listen address.
 - `protocol` - The DNS protocol used to receive queries, can be `udp`, `tcp`, `dot`, `doh`, `doq`.
+- `ip-version` - IP version (4 or 6) to use for the listener. Optional, defaults to both.
 - `resolver` - Name/identifier of the next element in the pipeline. Can be a router, group, modifier or resolver.
 - `allowed-net` - Array of network addresses that are allowed to send queries to this listener, in CIDR notation, such as `["192.167.1.0/24", "::1/128"]`. If not set, no filter is applied, all clients can send queries.
 

--- a/dotlistener.go
+++ b/dotlistener.go
@@ -23,12 +23,15 @@ type DoTListenerOptions struct {
 }
 
 // NewDoTListener returns an instance of a DNS-over-TLS listener.
-func NewDoTListener(id, addr string, opt DoTListenerOptions, resolver Resolver) *DoTListener {
+func NewDoTListener(id, addr, network string, opt DoTListenerOptions, resolver Resolver) *DoTListener {
+	if network == "" {
+		network = "tcp-tls"
+	}
 	return &DoTListener{
 		id: id,
 		Server: &dns.Server{
 			Addr:      addr,
-			Net:       "tcp-tls",
+			Net:       network,
 			TLSConfig: opt.TLSConfig,
 			Handler:   listenHandler(id, "dot", addr, resolver, opt.AllowedNet),
 		},


### PR DESCRIPTION
Implements #355 

Adds a new option `ip-version` to listeners (values `4` or `6`) which will force a listener to only bind to one, rather than the default which listens on both.