### PR TITLE
Support templates in static-responder

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -142,7 +142,8 @@ type group struct {
 		Code uint16 `toml:"code"` // Code defined in https://datatracker.ietf.org/doc/html/rfc8914
 		Text string `toml:"text"` // Extra text containing additional information
 	} `toml:"edns0-ede"` // Extended DNS Errors
-	Truncate bool `toml:"truncate"` // When true, TC-Bit is set
+	Truncate bool   `toml:"truncate"` // When true, TC-Bit is set
+	Question string // Regex applied to the question used to expand placeholders in the response
 
 	// Rate-limiting options
 	Requests      uint   // Number of requests allowed

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -744,20 +744,21 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 		}
 
 	case "static-responder":
-		var edns0Options []dns.EDNS0
+		var ede *dns.EDNS0_EDE
 		if g.EDNS0EDE != nil {
-			edns0Options = append(edns0Options, &dns.EDNS0_EDE{
+			ede = &dns.EDNS0_EDE{
 				InfoCode:  g.EDNS0EDE.Code,
 				ExtraText: g.EDNS0EDE.Text,
-			})
+			}
 		}
 		opt := rdns.StaticResolverOptions{
-			Answer:       g.Answer,
-			NS:           g.NS,
-			Extra:        g.Extra,
-			RCode:        g.RCode,
-			Truncate:     g.Truncate,
-			EDNS0Options: edns0Options,
+			Answer:   g.Answer,
+			NS:       g.NS,
+			Extra:    g.Extra,
+			RCode:    g.RCode,
+			Truncate: g.Truncate,
+			EDNS0EDE: ede,
+			Query:    g.Question,
 		}
 		resolvers[id], err = rdns.NewStaticResolver(id, opt)
 		if err != nil {

--- a/static.go
+++ b/static.go
@@ -75,6 +75,7 @@ func (r *StaticResolver) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	answer.SetReply(q)
 	answer.Rcode = r.opt.RCode
 	answer.Truncated = r.opt.Truncate
+	answer.RecursionAvailable = q.RecursionDesired
 
 	// Apply any templates if we have a query regex
 	if r.question != nil {

--- a/static.go
+++ b/static.go
@@ -1,6 +1,8 @@
 package rdns
 
 import (
+	"regexp"
+
 	"github.com/miekg/dns"
 )
 
@@ -8,55 +10,61 @@ import (
 // Typically used in combination with a blocklist to define fixed block responses or
 // with a router when building a walled garden.
 type StaticResolver struct {
-	id           string
-	answer       []dns.RR
-	ns           []dns.RR
-	extra        []dns.RR
-	edns0Options []dns.EDNS0
-	rcode        int
-	truncate     bool
+	id       string
+	answer   []dns.RR
+	ns       []dns.RR
+	extra    []dns.RR
+	question *regexp.Regexp
+	opt      StaticResolverOptions
 }
 
 var _ Resolver = &StaticResolver{}
 
 type StaticResolverOptions struct {
 	// Records in zone-file format
-	Answer       []string
-	NS           []string
-	Extra        []string
-	EDNS0Options []dns.EDNS0
-	RCode        int
-	Truncate     bool
+	Answer   []string
+	NS       []string
+	Extra    []string
+	EDNS0EDE *dns.EDNS0_EDE
+	RCode    int
+	Truncate bool
+	Query    string
 }
 
 // NewStaticResolver returns a new instance of a StaticResolver resolver.
 func NewStaticResolver(id string, opt StaticResolverOptions) (*StaticResolver, error) {
-	r := &StaticResolver{id: id}
+	r := &StaticResolver{id: id, opt: opt}
 
-	for _, record := range opt.Answer {
-		rr, err := dns.NewRR(record)
+	if opt.Query != "" {
+		qr, err := regexp.Compile(opt.Query)
 		if err != nil {
 			return nil, err
 		}
-		r.answer = append(r.answer, rr)
-	}
-	for _, record := range opt.NS {
-		rr, err := dns.NewRR(record)
-		if err != nil {
-			return nil, err
+		r.question = qr
+	} else {
+		// pre-compile the answers if we don't have a regex to apply
+		for _, record := range opt.Answer {
+			rr, err := dns.NewRR(record)
+			if err != nil {
+				return nil, err
+			}
+			r.answer = append(r.answer, rr)
 		}
-		r.ns = append(r.ns, rr)
-	}
-	for _, record := range opt.Extra {
-		rr, err := dns.NewRR(record)
-		if err != nil {
-			return nil, err
+		for _, record := range opt.NS {
+			rr, err := dns.NewRR(record)
+			if err != nil {
+				return nil, err
+			}
+			r.ns = append(r.ns, rr)
 		}
-		r.extra = append(r.extra, rr)
+		for _, record := range opt.Extra {
+			rr, err := dns.NewRR(record)
+			if err != nil {
+				return nil, err
+			}
+			r.extra = append(r.extra, rr)
+		}
 	}
-	r.rcode = opt.RCode
-	r.edns0Options = opt.EDNS0Options
-	r.truncate = opt.Truncate
 
 	return r, nil
 }
@@ -65,26 +73,68 @@ func NewStaticResolver(id string, opt StaticResolverOptions) (*StaticResolver, e
 func (r *StaticResolver) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	answer := new(dns.Msg)
 	answer.SetReply(q)
+	answer.Rcode = r.opt.RCode
+	answer.Truncated = r.opt.Truncate
+
+	// Apply any templates if we have a query regex
+	if r.question != nil {
+		answer.Answer = make([]dns.RR, 0, len(r.opt.Answer))
+		for _, record := range r.opt.Answer {
+			record = r.question.ReplaceAllString(qName(q), record)
+			rr, err := dns.NewRR(record)
+			if err != nil {
+				return nil, err
+			}
+			answer.Answer = append(answer.Answer, rr)
+		}
+
+		answer.Ns = make([]dns.RR, 0, len(r.opt.NS))
+		for _, record := range r.opt.NS {
+			record = r.question.ReplaceAllString(qName(q), record)
+			rr, err := dns.NewRR(record)
+			if err != nil {
+				return nil, err
+			}
+			answer.Ns = append(answer.Ns, rr)
+		}
+
+		answer.Extra = make([]dns.RR, 0, len(r.opt.Extra))
+		for _, record := range r.opt.Extra {
+			record = r.question.ReplaceAllString(qName(q), record)
+			rr, err := dns.NewRR(record)
+			if err != nil {
+				return nil, err
+			}
+			answer.Extra = append(answer.Extra, rr)
+		}
+		if r.opt.EDNS0EDE != nil {
+			text := r.question.ReplaceAllString(qName(q), r.opt.EDNS0EDE.ExtraText)
+			answer.SetEdns0(4096, false)
+			opt := answer.IsEdns0()
+			opt.Option = append(opt.Option, &dns.EDNS0_EDE{
+				InfoCode:  r.opt.EDNS0EDE.InfoCode,
+				ExtraText: text,
+			})
+		}
+	} else {
+		answer.Answer = r.answer
+		answer.Ns = r.ns
+		answer.Extra = r.extra
+		if r.opt.EDNS0EDE != nil {
+			answer.SetEdns0(4096, false)
+			opt := answer.IsEdns0()
+			opt.Option = append(opt.Option, r.opt.EDNS0EDE)
+		}
+	}
 
 	// Update the name of every answer record to match that of the query
-	answer.Answer = make([]dns.RR, 0, len(r.answer))
-	for _, rr := range r.answer {
+	for i, rr := range answer.Answer {
 		r := dns.Copy(rr)
 		r.Header().Name = qName(q)
-		answer.Answer = append(answer.Answer, r)
-	}
-	answer.Ns = r.ns
-	answer.Extra = r.extra
-	answer.Rcode = r.rcode
-	answer.Truncated = r.truncate
-
-	if len(r.edns0Options) > 0 {
-		answer.SetEdns0(4096, false)
-		opt := answer.IsEdns0()
-		opt.Option = append(opt.Option, r.edns0Options...)
+		answer.Answer[i] = r
 	}
 
-	logger(r.id, q, ci).WithField("truncated", r.truncate).Debug("responding")
+	logger(r.id, q, ci).WithField("truncated", r.opt.Truncate).Debug("responding")
 
 	return answer, nil
 }


### PR DESCRIPTION
Adds support for passing a regex that's applied to the question string and can then be used to customize the answers from a static-responder like so

```toml
[groups.static]
type   = "static-responder"
question = '^(\d+)-(\d+)-(\d+)-(\d+)\.rebind\.$'
answer = ["IN A $1.$2.$3.$4"]
```

```toml
[groups.static]
type      = "static-responder"
question  = '^(.+)\.$'
answer    = [ "IN A 0.0.0.0" ]
edns0-ede = { code = 15, text = "IP $1 is in the blocklist" }
```

Implements #366 