### PR TITLE
New static-template group

### DIFF
--- a/cmd/routedns/example-config/static-template.toml
+++ b/cmd/routedns/example-config/static-template.toml
@@ -1,0 +1,18 @@
+# Static template responder that builds a response based on data in the query
+
+[listeners.local-udp]
+address = "127.0.0.1:53"
+protocol = "udp"
+resolver = "static"
+
+[groups.static]
+type   = "static-template"
+answer = [
+    '{{ .Question }} IN {{ .QuestionType }} {{ trimSuffix .Question ".rebind."}}'
+]
+ns = [
+    '{{ .Question }} 18000 IN NS ns1.{{ .Question }}',
+]
+extra = [
+    'ns1.{{ .Question }} 1800 IN A 127.0.0.1',
+]

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -769,6 +769,23 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 		if err != nil {
 			return err
 		}
+	case "static-template":
+		edeTpl, err := rdns.NewEDNS0EDETemplate(g.EDNS0EDE.Code, g.EDNS0EDE.Text)
+		if err != nil {
+			return fmt.Errorf("failed to parse edn0 template in %q: %w", id, err)
+		}
+		opt := rdns.StaticResolverOptions{
+			Answer:           g.Answer,
+			NS:               g.NS,
+			Extra:            g.Extra,
+			RCode:            g.RCode,
+			Truncate:         g.Truncate,
+			EDNS0EDETemplate: edeTpl,
+		}
+		resolvers[id], err = rdns.NewStaticTemplateResolver(id, opt)
+		if err != nil {
+			return err
+		}
 	case "response-minimize":
 		if len(gr) != 1 {
 			return fmt.Errorf("type response-minimize only supports one resolver in '%s'", id)

--- a/static-template.go
+++ b/static-template.go
@@ -1,0 +1,99 @@
+package rdns
+
+import (
+	"github.com/miekg/dns"
+)
+
+// StaticTemplateResolver is a resolver that always returns a predefined set of records
+// which can be customized with information from the question. It is similar to
+// StaticResolver but allows the use of templates with placeholders as input.
+type StaticTemplateResolver struct {
+	id       string
+	answer   []*Template
+	ns       []*Template
+	extra    []*Template
+	rcode    int
+	truncate bool
+	opt      StaticResolverOptions
+}
+
+var _ Resolver = &StaticTemplateResolver{}
+
+// NewStaticTemplateResolver returns a new instance of a StaticTemplateResolver resolver.
+func NewStaticTemplateResolver(id string, opt StaticResolverOptions) (*StaticTemplateResolver, error) {
+	r := &StaticTemplateResolver{id: id, opt: opt}
+
+	for _, record := range opt.Answer {
+		tpl, err := NewTemplate(record)
+		if err != nil {
+			return nil, err
+		}
+		r.answer = append(r.answer, tpl)
+	}
+	for _, record := range opt.NS {
+		tpl, err := NewTemplate(record)
+		if err != nil {
+			return nil, err
+		}
+		r.ns = append(r.ns, tpl)
+	}
+	for _, record := range opt.Extra {
+		tpl, err := NewTemplate(record)
+		if err != nil {
+			return nil, err
+		}
+		r.extra = append(r.extra, tpl)
+	}
+	r.rcode = opt.RCode
+	r.truncate = opt.Truncate
+
+	return r, nil
+}
+
+// Resolve a DNS query by incorporating data from the query into a fixed response.
+func (r *StaticTemplateResolver) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+	answer := new(dns.Msg)
+	answer.SetReply(q)
+	log := logger(r.id, q, ci)
+
+	answer.Answer = r.processRRTemplates(q, ci, r.answer...)
+	answer.Ns = r.processRRTemplates(q, ci, r.ns...)
+	answer.Extra = r.processRRTemplates(q, ci, r.extra...)
+	answer.Rcode = r.rcode
+	answer.Truncated = r.truncate
+
+	if err := r.opt.EDNS0EDETemplate.Apply(answer, q); err != nil {
+		log.WithError(err).Error("failed to apply edns0ede template")
+	}
+
+	logger(r.id, q, ci).WithField("truncated", r.truncate).Debug("responding")
+
+	return answer, nil
+}
+
+func (r *StaticTemplateResolver) String() string {
+	return r.id
+}
+
+func (r *StaticTemplateResolver) processRRTemplates(q *dns.Msg, ci ClientInfo, templates ...*Template) []dns.RR {
+	log := logger(r.id, q, ci)
+
+	resp := make([]dns.RR, 0, len(templates))
+	for _, tpl := range templates {
+		text, err := tpl.Apply(q)
+		if err != nil {
+			log.WithError(err).Error("failed to apply template")
+			continue
+		}
+
+		rr, err := dns.NewRR(text)
+		if err != nil {
+			log.WithError(err).Error("failed to parse template output")
+			continue
+		}
+		// Update the name of every answer record to match that of the query
+		// rr.Header().Name = qName(q)
+		resp = append(resp, rr)
+	}
+	return resp
+}

--- a/template.go
+++ b/template.go
@@ -1,0 +1,61 @@
+package rdns
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+
+	"github.com/miekg/dns"
+)
+
+type Template struct {
+	textTemplate *template.Template
+}
+
+func NewTemplate(text string) (*Template, error) {
+	funcMap := template.FuncMap{
+		"replaceAll": strings.ReplaceAll,
+		"trimPrefix": strings.TrimPrefix,
+		"trimSuffix": strings.TrimSuffix,
+		"split":      strings.Split,
+		"join":       strings.Join,
+	}
+	textTemplate := template.New("template").Funcs(funcMap)
+	textTemplate, err := textTemplate.Parse(text)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Template{
+		textTemplate: textTemplate,
+	}, nil
+}
+
+// Data that is passed to any templates.
+type templateInput struct {
+	ID            uint16
+	Question      string
+	QuestionClass string
+	QuestionType  string
+}
+
+// Apply executes the template, e.g. replacing placeholders in the text
+// with values from the Query.
+func (t *Template) Apply(q *dns.Msg) (string, error) {
+	if t == nil {
+		return "", nil
+	}
+	var question dns.Question
+	if len(q.Question) > 0 {
+		question = q.Question[0]
+	}
+	input := templateInput{
+		ID:            q.Id,
+		Question:      question.Name,
+		QuestionClass: dns.ClassToString[question.Qclass],
+		QuestionType:  dns.TypeToString[question.Qtype],
+	}
+	text := new(bytes.Buffer)
+	err := t.textTemplate.Execute(text, input)
+	return text.String(), err
+}


### PR DESCRIPTION
Related to https://github.com/folbricht/routedns/issues/366

Introduces a new group `static-template` which works exactly like `static-responder` but instead of plain strings uses templates that are processed at query-time allowing responses to be based on data in the query such as the question, type, id, or class. For example:

```toml
[groups.static]
type   = "static-template"
answer = [
    '{{ .Question }} IN {{ .QuestionType }} {{ trimSuffix .Question ".rebind."}}'
]
```

