### PR TITLE
Enabling 0-RTT for QUIC/H3 clients

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -57,6 +57,9 @@ type resolver struct {
 	Socks5Username     string `toml:"socks5-username"`
 	Socks5Password     string `toml:"socks5-password"`
 	Socks5ResolveLocal bool   `toml:"socks5-resolve-local"` // Resolve DNS server address locally (i.e. bootstrap-resolver), not on the SOCK5 proxy
+
+	//QUIC and DoH/3 configuration
+	Use0RTT       bool
 }
 
 // DoH-specific resolver options

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -59,7 +59,7 @@ type resolver struct {
 	Socks5ResolveLocal bool   `toml:"socks5-resolve-local"` // Resolve DNS server address locally (i.e. bootstrap-resolver), not on the SOCK5 proxy
 
 	//QUIC and DoH/3 configuration
-	Use0RTT       bool
+	Use0RTT       bool   `toml:"enable-0rtt"`
 }
 
 // DoH-specific resolver options

--- a/cmd/routedns/example-config/doh-quic-client.toml
+++ b/cmd/routedns/example-config/doh-quic-client.toml
@@ -1,9 +1,12 @@
 # DNS-over-HTTPS using the QUIC protocol.
+# New connections get initiated with 0-RTT if possible.
+# Use0RTT will overwrite the method to GET. 
 
 [resolvers.cloudflare-doh-quic]
 address = "https://cloudflare-dns.com/dns-query"
 protocol = "doh"
 transport = "quic"
+Use0RTT = true
 
 [listeners.local-udp]
 address = "127.0.0.1:53"

--- a/cmd/routedns/example-config/doh-quic-client.toml
+++ b/cmd/routedns/example-config/doh-quic-client.toml
@@ -6,7 +6,7 @@
 address = "https://cloudflare-dns.com/dns-query"
 protocol = "doh"
 transport = "quic"
-Use0RTT = true
+enable-0rtt = true
 
 [listeners.local-udp]
 address = "127.0.0.1:53"

--- a/cmd/routedns/example-config/doq-client.toml
+++ b/cmd/routedns/example-config/doq-client.toml
@@ -1,11 +1,13 @@
 # This config starts a UDP and a TCP resolver on the loopback interface for plain DNS.
 # All queries are forwarded to a local DNS-over-QUIC server.
+# New connections get initiated with 0-RTT if possible.
 
 [resolvers.local-doq]
 address = "server.acme.test:8853"
 protocol = "doq"
 ca = "example-config/server.crt"
 bootstrap-address = "127.0.0.1"
+Use0RTT = true
 
 [listeners.local-udp]
 address = "127.0.0.1:53"

--- a/cmd/routedns/example-config/doq-client.toml
+++ b/cmd/routedns/example-config/doq-client.toml
@@ -7,7 +7,7 @@ address = "server.acme.test:8853"
 protocol = "doq"
 ca = "example-config/server.crt"
 bootstrap-address = "127.0.0.1"
-Use0RTT = true
+enable-0rtt = true
 
 [listeners.local-udp]
 address = "127.0.0.1:53"

--- a/cmd/routedns/resolver.go
+++ b/cmd/routedns/resolver.go
@@ -25,6 +25,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			LocalAddr:     net.ParseIP(r.LocalAddr),
 			TLSConfig:     tlsConfig,
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
+			Use0RTT:       r.Use0RTT,
 		}
 		resolvers[id], err = rdns.NewDoQClient(id, r.Address, opt)
 		if err != nil {
@@ -81,6 +82,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			LocalAddr:     net.ParseIP(r.LocalAddr),
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
 			Dialer:        socks5DialerFromConfig(r),
+			Use0RTT:       r.Use0RTT,
 		}
 		resolvers[id], err = rdns.NewDoHClient(id, r.Address, opt)
 		if err != nil {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1508,6 +1508,7 @@ Example config files: [well-known.toml](../cmd/routedns/example-config/well-know
 ### DNS-over-HTTPS Resolver
 
 DNS resolvers using the HTTPS protocol are configured with `protocol = "doh"`. By default, DoH uses TCP as transport, but it can also be run over QUIC (UDP) by providing the option `transport = "quic"`. DoH supports two HTTP methods, GET and POST. By default RouteDNS uses the POST method, but can be configured to use GET as well using the option `doh = { method = "GET" }`.
+DoH with QUIC supports 0-RTT. The DoH resolver will try to use 0-RTT connection establishment if `transport = "quic"` and `enable-0rtt = true` are configured. When 0-RTT is enabled, the resolver will disregard the configured method and always use GET instead.
 
 Examples:
 
@@ -1535,6 +1536,7 @@ DoH resolver using QUIC transport.
 address = "https://cloudflare-dns.com/dns-query"
 protocol = "doh"
 transport = "quic"
+enable-0rtt = true
 ```
 
 Example config files: [well-known.toml](../cmd/routedns/example-config/well-known.toml), [simple-doh.toml](../cmd/routedns/example-config/simple-doh.toml), [mutual-tls-doh-client.toml](../cmd/routedns/example-config/mutual-tls-doh-client.toml)
@@ -1560,6 +1562,7 @@ Example config files: [dtls-client.toml](../cmd/routedns/example-config/dtls-cli
 ### DNS-over-QUIC Resolver
 
 Similar to DoT, but uses a QUIC connection as transport as per [RFC9250](https://datatracker.ietf.org/doc/rfc9250/). Configured with `protocol = "doq"`. Note that this is different from DoH over QUIC. See [DNS-over-HTTPS](#DNS-over-HTTPS-Resolver) for how to configure this.
+The DoQ resolver will try to use 0-RTT connection establishment if `enable-0rtt = true` is configured.
 
 Examples:
 
@@ -1569,6 +1572,7 @@ address = "server.acme.test:8853"
 protocol = "doq"
 ca = "example-config/server.crt"
 bootstrap-address = "127.0.0.1"
+enable-0rtt = true
 ```
 
 Example config files: [doq-client.toml](../cmd/routedns/example-config/doq-client.toml)

--- a/dohclient.go
+++ b/dohclient.go
@@ -187,7 +187,7 @@ func (d *DoHClient) ResolveGET(q *dns.Msg) (*dns.Msg, error) {
 	defer cancel()
 
 	method := http.MethodGet
-	if d.opt.Use0RTT {
+	if d.opt.Use0RTT && d.opt.Transport == "quic" {
 		method = http3.MethodGet0RTT
 	}
 

--- a/dohclient.go
+++ b/dohclient.go
@@ -44,6 +44,8 @@ type DoHClientOptions struct {
 
 	// Optional dialer, e.g. proxy
 	Dialer Dialer
+
+	Use0RTT bool
 }
 
 // DoHClient is a DNS-over-HTTP resolver with support fot HTTP/2.
@@ -84,6 +86,9 @@ func NewDoHClient(id, endpoint string, opt DoHClientOptions) (*DoHClient, error)
 
 	if opt.Method == "" {
 		opt.Method = "POST"
+	}
+	if opt.Use0RTT && opt.Transport == "quic" {
+		opt.Method = "GET"
 	}
 	if opt.Method != "POST" && opt.Method != "GET" {
 		return nil, fmt.Errorf("unsupported method '%s'", opt.Method)
@@ -182,7 +187,7 @@ func (d *DoHClient) ResolveGET(q *dns.Msg) (*dns.Msg, error) {
 	defer cancel()
 
 	method := http.MethodGet
-	if d.opt.Transport == "quic" {
+	if d.opt.Use0RTT {
 		method = http3.MethodGet0RTT
 	}
 

--- a/doqclient.go
+++ b/doqclient.go
@@ -77,6 +77,9 @@ func NewDoQClient(id, endpoint string, opt DoQClientOptions) (*DoQClient, error)
 	// quic-go requires the ServerName be set explicitly
 	tlsConfig.ServerName = host
 
+	// enable TLS session caching for session resumption and 0-RTT
+	tlsConfig.ClientSessionCache = tls.NewLRUClientSessionCache(100)
+
 	if opt.QueryTimeout == 0 {
 		opt.QueryTimeout = defaultQueryTimeout
 	}

--- a/doqclient.go
+++ b/doqclient.go
@@ -216,21 +216,7 @@ func (s *quicConnection) getStream(endpoint string, log *logrus.Entry) (quic.Str
 	// If we don't have a connection yet, make one
 	if s.EarlyConnection == nil {
 		var err error
-		s.udpConn, err = net.ListenUDP("udp", nil)
-		if err != nil {
-			log.WithError(err).Debug("couldn't create UDP connection")
-			return nil, err
-		}
-
-		// Resolve the UDP address for the endpoint
-		udpAddr, err := net.ResolveUDPAddr("udp", endpoint)
-		if err != nil {
-			log.WithError(err).Debug("couldn't resolve UDP address for endpoint [" + endpoint + "]")
-			return nil, err
-		}
-
-		// Use quic.DialEarly to attempt to use 0-RTT DNS queries for lower latency
-		s.EarlyConnection, err = quic.DialEarly(context.TODO(), s.udpConn, udpAddr, s.tlsConfig, s.config)
+		s.EarlyConnection, s.udpConn, err = quicDial(context.TODO(), s.hostname, endpoint, s.lAddr, s.tlsConfig, s.config)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"hostname": s.hostname,

--- a/doqclient.go
+++ b/doqclient.go
@@ -42,6 +42,8 @@ type DoQClientOptions struct {
 	TLSConfig *tls.Config
 
 	QueryTimeout time.Duration
+
+	Use0RTT       bool
 }
 
 var _ Resolver = &DoQClient{}
@@ -78,7 +80,9 @@ func NewDoQClient(id, endpoint string, opt DoQClientOptions) (*DoQClient, error)
 	tlsConfig.ServerName = host
 
 	// enable TLS session caching for session resumption and 0-RTT
-	tlsConfig.ClientSessionCache = tls.NewLRUClientSessionCache(100)
+	if opt.Use0RTT {
+		tlsConfig.ClientSessionCache = tls.NewLRUClientSessionCache(100)
+	}
 
 	if opt.QueryTimeout == 0 {
 		opt.QueryTimeout = defaultQueryTimeout


### PR DESCRIPTION
Updated the DoQ and DoH QUIC client to enable 0-RTT based on the guide from: https://quic-go.net/docs/http3/client/#using-0-rtt