### PR TITLE
Support blocking based on MAC-address

### DIFF
--- a/blocklist.go
+++ b/blocklist.go
@@ -102,7 +102,7 @@ func (r *Blocklist) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 
 	// Forward to upstream or the optional allowlist-resolver immediately if there's a match in the allowlist
 	if allowlistDB != nil {
-		if _, _, match, ok := allowlistDB.Match(question); ok {
+		if _, _, match, ok := allowlistDB.Match(q); ok {
 			log = log.WithFields(logrus.Fields{"list": match.List, "rule": match.Rule})
 			r.metrics.allowed.Add(1)
 			if r.AllowListResolver != nil {
@@ -114,7 +114,7 @@ func (r *Blocklist) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		}
 	}
 
-	ips, names, match, ok := blocklistDB.Match(question)
+	ips, names, match, ok := blocklistDB.Match(q)
 	if !ok {
 		// Didn't match anything, pass it on to the next resolver
 		log.WithField("resolver", r.resolver.String()).Debug("forwarding unmodified query to resolver")

--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -63,7 +63,8 @@ func (m *DomainDB) Reload() (BlocklistDB, error) {
 	return NewDomainDB(m.name, m.loader)
 }
 
-func (m *DomainDB) Match(q dns.Question) ([]net.IP, []string, *BlocklistMatch, bool) {
+func (m *DomainDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
+	q := msg.Question[0]
 	s := strings.TrimSuffix(q.Name, ".")
 	var matched []string
 	parts := strings.Split(s, ".")

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -46,8 +46,10 @@ func TestDomainDB(t *testing.T) {
 		{"com.", false},
 	}
 	for _, test := range tests {
-		q := dns.Question{Name: test.q, Qtype: dns.TypeA, Qclass: dns.ClassINET}
-		_, _, _, ok := m.Match(q)
+		msg := new(dns.Msg)
+		msg.SetQuestion(test.q, dns.TypeA)
+
+		_, _, _, ok := m.Match(msg)
 		require.Equal(t, test.match, ok, "query: %s", test.q)
 	}
 }

--- a/blocklistdb-hosts.go
+++ b/blocklistdb-hosts.go
@@ -86,7 +86,8 @@ func (m *HostsDB) Reload() (BlocklistDB, error) {
 	return NewHostsDB(m.name, m.loader)
 }
 
-func (m *HostsDB) Match(q dns.Question) ([]net.IP, []string, *BlocklistMatch, bool) {
+func (m *HostsDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
+	q := msg.Question[0]
 	if q.Qtype == dns.TypePTR {
 		names, ok := m.ptrMap[q.Name]
 		var rule string

--- a/blocklistdb-hosts_test.go
+++ b/blocklistdb-hosts_test.go
@@ -38,8 +38,9 @@ func TestHostsDB(t *testing.T) {
 		{"domainX.com.", dns.TypeA, false, nil},
 	}
 	for _, test := range tests {
-		q := dns.Question{Name: test.q, Qtype: test.typ, Qclass: dns.ClassINET}
-		ip, _, match, ok := m.Match(q)
+		msg := new(dns.Msg)
+		msg.SetQuestion(test.q, test.typ)
+		ip, _, match, ok := m.Match(msg)
 
 		require.Equal(t, test.match, ok, "query: %s", test.q)
 		require.EqualValues(t, test.ip, ip, "query: %s", test.q)

--- a/blocklistdb-multi.go
+++ b/blocklistdb-multi.go
@@ -30,7 +30,7 @@ func (m MultiDB) Reload() (BlocklistDB, error) {
 	return NewMultiDB(newDBs...)
 }
 
-func (m MultiDB) Match(q dns.Question) ([]net.IP, []string, *BlocklistMatch, bool) {
+func (m MultiDB) Match(q *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
 	for _, db := range m.dbs {
 		if ip, name, match, ok := db.Match(q); ok {
 			return ip, name, match, ok

--- a/blocklistdb-regexp.go
+++ b/blocklistdb-regexp.go
@@ -43,7 +43,8 @@ func (m *RegexpDB) Reload() (BlocklistDB, error) {
 	return NewRegexpDB(m.name, m.loader)
 }
 
-func (m *RegexpDB) Match(q dns.Question) ([]net.IP, []string, *BlocklistMatch, bool) {
+func (m *RegexpDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
+	q := msg.Question[0]
 	for _, rule := range m.rules {
 		if rule.MatchString(q.Name) {
 			return nil, nil, &BlocklistMatch{List: m.name, Rule: rule.String()}, true

--- a/blocklistdb.go
+++ b/blocklistdb.go
@@ -15,7 +15,7 @@ type BlocklistDB interface {
 	// Returns true if the question matches a rule. If the IP is not nil,
 	// respond with the given IP. NXDOMAIN otherwise. The returned names,
 	// if set, are used to answer PTR queries
-	Match(q dns.Question) (ip []net.IP, names []string, m *BlocklistMatch, matched bool)
+	Match(msg *dns.Msg) (ip []net.IP, names []string, m *BlocklistMatch, matched bool)
 
 	fmt.Stringer
 }

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -59,7 +59,7 @@ type resolver struct {
 	Socks5ResolveLocal bool   `toml:"socks5-resolve-local"` // Resolve DNS server address locally (i.e. bootstrap-resolver), not on the SOCK5 proxy
 
 	//QUIC and DoH/3 configuration
-	Use0RTT       bool   `toml:"enable-0rtt"`
+	Use0RTT bool `toml:"enable-0rtt"`
 }
 
 // DoH-specific resolver options
@@ -118,7 +118,7 @@ type group struct {
 
 	// Blocklist options
 	Blocklist []string // Blocklist rules, only used by "blocklist" type
-	Format    string   // Blocklist input format: "regex", "domain", or "hosts"
+	Format    string   // Blocklist input format: "regex", "domain", "hosts", or "mac"
 	Source    string   // Location of external blocklist, can be a local path or remote URL
 	Refresh   int      // Blocklist refresh when using an external source, in seconds
 

--- a/cmd/routedns/example-config/blocklist-mac.toml
+++ b/cmd/routedns/example-config/blocklist-mac.toml
@@ -1,0 +1,22 @@
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[groups.cloudflare-blocklist]
+type             = "blocklist-v2"
+resolvers        = ["cloudflare-dot"] # Anything that passes the filter is sent on to this resolver
+blocklist-format = "mac"              # "mac, "domain", "hosts" or "regexp", defaults to "regexp"
+blocklist        = [                  # Define the MAC addresses to be blocked, these are expected to be supplied by the client in EDNS0 option 65001
+  '01:23:45:ab:cd:ef',
+  '01:01:01:ff:ff:ff',
+]
+
+[listeners.local-udp]
+address = ":53"
+protocol = "udp"
+resolver = "cloudflare-blocklist"
+
+[listeners.local-tcp]
+address = ":53"
+protocol = "tcp"
+resolver = "cloudflare-blocklist"

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -881,6 +881,8 @@ func newBlocklistDB(l list, rules []string) (rdns.BlocklistDB, error) {
 		return rdns.NewDomainDB(name, loader)
 	case "hosts":
 		return rdns.NewHostsDB(name, loader)
+	case "mac":
+		return rdns.NewMACDB(name, loader)
 	default:
 		return nil, fmt.Errorf("unsupported format '%s'", l.Format)
 	}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -574,7 +574,7 @@ This replacer could be used where the company has multiple environment behind VP
 
 Query blocklists can be added to resolver-chains to prevent further processing of queries (return NXDOMAIN or spoofed IP) or to send queries to different resolvers if the query name matches a rule on the blocklist. A blocklist can have multiple rule-sets, with different formats. In its simplest form, the blocklist has just one upstream resolver and forwards anything that does not match its rules. If a query matches, it'll be answered with NXDOMAIN or a spoofed IP, depending on what blocklist format is used.
 
-The blocklist group supports 3 types of blocklist formats:
+The blocklist group supports 4 types of blocklist formats:
 
 - `regexp` - The entire query string is matched against a list of regular expressions and NXDOMAIN returned if a match is found.
 - `domain` - A list of domains with some wildcard capabilities. Also results in an NXDOMAIN. Entries in the list are matched as follows:
@@ -582,6 +582,7 @@ The blocklist group supports 3 types of blocklist formats:
   - `.domain.com` matches domain.com and all sub-domains.
   - `*.domain.com` matches all subdomains but not domain.com. Only one wildcard (at the start of the string) is allowed.
 - `hosts` - A blocklist in hosts-file format. If a non-zero IP address is provided for a record, the response is spoofed rather than returning NXDOMAIN.
+- `mac` - A blocklist of MAC addresses in the form `01:23:34:ab:bc:de` representing the MAC address of a client. The query is expected to contain the value of the client's MAC in EDNS0 option 65001.
 
 In addition to reading the blocklist rules from the configuration file, routedns supports reading from the local filesystem and from remote servers via HTTP(S). Use the `blocklist-source` property of the blocklist to provide a list of blocklists of different formats, either local files or URLs. The `blocklist-refresh` property can be used to specify a reload-period (in seconds). If no `blocklist-refresh` period is given, the blocklist will only be loaded once at startup. The following example loads a regexp blocklist via HTTP once a day.
 
@@ -694,7 +695,7 @@ allowlist-source = [
 ]
 ```
 
-Example config files: [blocklist-regexp.toml](../cmd/routedns/example-config/blocklist-regexp.toml), [block-split-cache.toml](../cmd/routedns/example-config/block-split-cache.toml), [blocklist-domain.toml](../cmd/routedns/example-config/blocklist-domain.toml), [blocklist-hosts.toml](../cmd/routedns/example-config/blocklist-hosts.toml), [blocklist-local.toml](../cmd/routedns/example-config/blocklist-local.toml), [blocklist-remote.toml](../cmd/routedns/example-config/blocklist-remote.toml), [blocklist-allow.toml](../cmd/routedns/example-config/blocklist-allow.toml), [blocklist-resolver.toml](../cmd/routedns/example-config/blocklist-resolver.toml), [blocklist-domain-ede.toml](../cmd/routedns/example-config/blocklist-domain-ede.toml)
+Example config files: [blocklist-regexp.toml](../cmd/routedns/example-config/blocklist-regexp.toml), [block-split-cache.toml](../cmd/routedns/example-config/block-split-cache.toml), [blocklist-domain.toml](../cmd/routedns/example-config/blocklist-domain.toml), [blocklist-hosts.toml](../cmd/routedns/example-config/blocklist-hosts.toml), [blocklist-local.toml](../cmd/routedns/example-config/blocklist-local.toml), [blocklist-remote.toml](../cmd/routedns/example-config/blocklist-remote.toml), [blocklist-allow.toml](../cmd/routedns/example-config/blocklist-allow.toml), [blocklist-resolver.toml](../cmd/routedns/example-config/blocklist-resolver.toml), [blocklist-domain-ede.toml](../cmd/routedns/example-config/blocklist-domain-ede.toml), [blocklist-mac.toml](../cmd/routedns/example-config/blocklist-mac.toml)
 
 ### Response Blocklist
 

--- a/mac-db.go
+++ b/mac-db.go
@@ -1,0 +1,120 @@
+package rdns
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// MACDB holds a list of MAC addresses used to clients with the given MAC (as per
+// EDNS0 option 65001).
+type MACDB struct {
+	name   string
+	loader BlocklistLoader
+	macs   [][]byte // TODO: for large lists, a trie would be more efficient
+}
+
+var _ BlocklistDB = &MACDB{}
+
+// NewMACDB returns a new instance of a matcher for a list of MAC addresses.
+func NewMACDB(name string, loader BlocklistLoader) (*MACDB, error) {
+	rules, err := loader.Load()
+	if err != nil {
+		return nil, err
+	}
+	db := &MACDB{
+		name:   name,
+		macs:   make([][]byte, 0, len(rules)),
+		loader: loader,
+	}
+	for _, r := range rules {
+		r = strings.TrimSpace(r)
+		if strings.HasPrefix(r, "#") || r == "" {
+			continue
+		}
+		mac, err := parseMAC(r)
+		if err != nil {
+			return nil, err
+		}
+		db.macs = append(db.macs, mac)
+	}
+	return db, nil
+}
+
+func (m *MACDB) Reload() (BlocklistDB, error) {
+	return NewMACDB(m.name, m.loader)
+}
+
+func (m *MACDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
+	// Do we have an EDNS0 record?
+	edns0 := msg.IsEdns0()
+	if edns0 == nil {
+		return nil, nil, nil, false
+	}
+
+	// Check if there's an option 65001 in it
+	var opt65001 []byte
+	for _, opt := range edns0.Option {
+		// Option 65001 is currently decoded into *dns.EDNS0_LOCAL. This
+		// will break when/if it's standardized and gets a dedicate type.
+		local, ok := opt.(*dns.EDNS0_LOCAL)
+		if !ok {
+			continue
+		}
+		if local.Code != 65001 {
+			continue
+		}
+		if len(local.Data) != 6 { // Not a MAC?
+			continue
+		}
+		opt65001 = local.Data
+	}
+
+	// Did we find a EDNS0 record with option 65001
+	if len(opt65001) != 6 {
+		return nil, nil, nil, false
+	}
+
+	// Match against the MAC addresses on the blocklist
+	for _, mac := range m.macs {
+		if bytes.Equal(mac, opt65001) {
+			return nil, nil, &BlocklistMatch{List: m.name, Rule: hex.EncodeToString(mac)}, true
+		}
+
+	}
+	return nil, nil, nil, false
+}
+
+func (m *MACDB) Close() error {
+	return nil
+}
+
+func (m *MACDB) String() string {
+	return "MAC-blocklist"
+}
+
+// ParseMAC decodes a MAC address given in the format 01:23:45:ab:cd:ef to
+// an array of 6 bytes.
+func parseMAC(addr string) ([]byte, error) {
+	b := []byte(addr)
+	if len(b) != 17 { // check total length
+		return nil, fmt.Errorf("unable to parse mac address %q, expected format 01:23:45:ab:cd:ef", addr)
+	}
+	// Check the format, we need 6 parts with 5 separator characters (:) in it
+	for i := 0; i < 5; i++ {
+		if b[(i*3)+2] != ':' {
+			return nil, fmt.Errorf("unable to parse mac address %q, expected format 01:23:45:ab:cd:ef", addr)
+		}
+	}
+	b = bytes.ReplaceAll(b, []byte{':'}, nil)
+	out := make([]byte, 6)
+	n, err := hex.Decode(out[:], b)
+	if err != nil || n != 6 {
+		return nil, fmt.Errorf("unable to parse mac address %q, expected format 01:23:45:ab:cd:ef", addr)
+	}
+	return out, nil
+}

--- a/mac-db_test.go
+++ b/mac-db_test.go
@@ -1,0 +1,78 @@
+package rdns
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMACParse(t *testing.T) {
+	var tests = []struct {
+		input string
+		out   []byte
+	}{
+		{
+			input: "01:23:45:ab:cd:ef",
+			out:   []byte{0x01, 0x23, 0x45, 0xab, 0xcd, 0xef},
+		},
+		{
+			input: "01:23:45:AB:CD:EF",
+			out:   []byte{0x01, 0x23, 0x45, 0xab, 0xcd, 0xef},
+		},
+	}
+	for _, test := range tests {
+		out, err := parseMAC(test.input)
+		require.NoError(t, err)
+		require.Equal(t, test.out, out)
+	}
+}
+
+func TestMACParseFail(t *testing.T) {
+	var tests = []string{
+		"",
+		"01:23:45:ab:cd:ef:ab",
+		"01:2345:ab:cd:ef:",
+		"012345abcdef",
+		"012345abcdef:::::",
+		":::::012345abcdef",
+	}
+	for _, input := range tests {
+		_, err := parseMAC(input)
+		require.Errorf(t, err, "value %q", input)
+	}
+}
+
+func TestMACDB(t *testing.T) {
+	loader := NewStaticLoader([]string{
+		"# some comment",
+		"              ",
+		"01:23:45:ab:cd:ef",
+		"01:01:01:ff:ff:ff",
+	})
+
+	m, err := NewMACDB("testlist", loader)
+	require.NoError(t, err)
+
+	tests := []struct {
+		mac   []byte
+		match bool
+	}{
+		{[]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}, false},
+		{[]byte{0x01, 0x23, 0x45, 0xab, 0xcd, 0xef}, true},
+	}
+	for _, test := range tests {
+		msg := new(dns.Msg)
+		msg.SetQuestion("example.com.", dns.TypeA)
+		e := new(dns.EDNS0_LOCAL)
+		e.Code = 65001
+		e.Data = test.mac
+		msg.SetEdns0(4096, false)
+		edns0 := msg.IsEdns0()
+		edns0.Option = append(edns0.Option, e)
+
+		_, _, _, ok := m.Match(msg)
+		require.Equal(t, test.match, ok, "value: %s", hex.EncodeToString(test.mac))
+	}
+}

--- a/response-blocklist-name.go
+++ b/response-blocklist-name.go
@@ -103,7 +103,9 @@ func (r *ResponseBlocklistName) blockIfMatch(query, answer *dns.Msg, ci ClientIn
 			default:
 				continue
 			}
-			if _, _, rule, ok := r.BlocklistDB.Match(dns.Question{Name: name}); ok != r.Inverted {
+			msg := new(dns.Msg)
+			msg.SetQuestion(name, 0)
+			if _, _, rule, ok := r.BlocklistDB.Match(msg); ok != r.Inverted {
 				log := logger(r.id, query, ci).WithField("rule", rule.GetRule())
 				if r.BlocklistResolver != nil {
 					log.WithField("resolver", r.BlocklistResolver).Debug("blocklist match, forwarding to blocklist-resolver")


### PR DESCRIPTION
Adds a new blocklist format "mac" which can be used to filter based on MAC addresses in EDNS0 option 65001

```toml
[groups.cloudflare-blocklist]
type             = "blocklist-v2"
resolvers        = ["cloudflare-dot"]
blocklist-format = "mac"
blocklist        = [ # Define the MAC addresses to be blocked, these are expected to be supplied by the client in EDNS0 option 65001
  '01:23:45:ab:cd:ef',
  '01:01:01:ff:ff:ff',
]
```
Implements #398 

