### PR TITLE
Give EDNS0-EDE templates access to blocklist matches

### DIFF
--- a/blocklist.go
+++ b/blocklist.go
@@ -176,7 +176,7 @@ func (r *Blocklist) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 
 	// Block the request with NXDOMAIN if there was a match but no valid spoofed IP is given
 	log.Debug("blocking request")
-	if err := r.EDNS0EDETemplate.Apply(answer, q); err != nil {
+	if err := r.EDNS0EDETemplate.Apply(answer, EDNS0EDEInput{q, match}); err != nil {
 		log.WithError(err).Error("failed to apply edns0ede template")
 	}
 	answer.SetRcode(q, dns.RcodeNameError)

--- a/cmd/routedns/example-config/blocklist-domain-ede.toml
+++ b/cmd/routedns/example-config/blocklist-domain-ede.toml
@@ -14,6 +14,6 @@ blocklist        = [                  # Define the names to be blocked
 ]
 
 [listeners.local-udp]
-address = ":1153"
+address = ":53"
 protocol = "udp"
 resolver = "cloudflare-blocklist"

--- a/cmd/routedns/example-config/blocklist-domain-ede.toml
+++ b/cmd/routedns/example-config/blocklist-domain-ede.toml
@@ -6,7 +6,7 @@ protocol = "dot"
 type             = "blocklist-v2"
 resolvers        = ["cloudflare-dot"] # Anything that passes the filter is sent on to this resolver
 blocklist-format = "domain"           # "domain", "hosts" or "regexp", defaults to "regexp"
-edns0-ede = {code = 15, text = "Blocked {{ .Question }} with ID {{ .ID }} because reasons "} # Extended error code
+edns0-ede = {code = 15, text = "Blocked {{ .Question }} with ID {{ .ID }} because rule {{ .BlocklistRule }} on {{ .Blocklist}}"} # Extended error code
 blocklist        = [                  # Define the names to be blocked
   'evil.com',
   '.facebook.com',
@@ -14,6 +14,6 @@ blocklist        = [                  # Define the names to be blocked
 ]
 
 [listeners.local-udp]
-address = ":53"
+address = ":1153"
 protocol = "udp"
 resolver = "cloudflare-blocklist"

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -630,7 +630,7 @@ Simple blocklist with static `domain`-format rule in the configuration. This wil
 type             = "blocklist-v2"
 resolvers        = ["upstream-resolver"]
 blocklist-format = "domain"
-edns0-ede        = {code = 15, text = "Blocked {{ .Question }}"}
+edns0-ede        = {code = 15, text = "Blocked {{ .Question }} because rule {{ .BlocklistRule }} on {{ .Blocklist}}"}
 blocklist = [
   'domain1.com',               # Exact match
   '.domain2.com',              # Exact match and all sub-domains
@@ -1677,6 +1677,8 @@ The following pieces of information from the query are available in the template
 - `Question` - The question string.
 - `QuestionType` - The question type, `A`, `AAAA`, `CNAME` etc.
 - `QuestionClass` - The query class, `IN`, `ANY`, etc.
+- `Blocklist` - The name of the blocklist (only present if this request was blocked).
+- `BlocklistRule` - The rule on the blocklist that matched (only present if this was blocked).
 
 In addition to the [built-in template functions](https://pkg.go.dev/text/template#hdr-Functions), the following functions are available.
 

--- a/response-blocklist-ip.go
+++ b/response-blocklist-ip.go
@@ -118,7 +118,7 @@ func (r *ResponseBlocklistIP) blockIfMatch(query, answer *dns.Msg, ci ClientInfo
 				}
 				log.Debug("blocking response")
 				answer = nxdomain(query)
-				if err := r.EDNS0EDETemplate.Apply(answer, query); err != nil {
+				if err := r.EDNS0EDETemplate.Apply(answer, EDNS0EDEInput{query, match}); err != nil {
 					log.WithError(err).Error("failed to apply edns0ede template")
 				}
 				return answer, nil

--- a/response-blocklist-name.go
+++ b/response-blocklist-name.go
@@ -111,7 +111,7 @@ func (r *ResponseBlocklistName) blockIfMatch(query, answer *dns.Msg, ci ClientIn
 				}
 				log.Debug("blocking response")
 				answer = nxdomain(query)
-				if err := r.EDNS0EDETemplate.Apply(answer, query); err != nil {
+				if err := r.EDNS0EDETemplate.Apply(answer, EDNS0EDEInput{query, rule}); err != nil {
 					log.WithError(err).Error("failed to apply edns0ede template")
 				}
 				return answer, nil

--- a/static.go
+++ b/static.go
@@ -80,7 +80,7 @@ func (r *StaticResolver) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	answer.Rcode = r.rcode
 	answer.Truncated = r.truncate
 
-	if err := r.opt.EDNS0EDETemplate.Apply(answer, q); err != nil {
+	if err := r.opt.EDNS0EDETemplate.Apply(answer, EDNS0EDEInput{q, nil}); err != nil {
 		log.WithError(err).Error("failed to apply edns0ede template")
 	}
 

--- a/template.go
+++ b/template.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"strings"
 	"text/template"
-
-	"github.com/miekg/dns"
 )
 
 type Template struct {
@@ -37,23 +35,15 @@ type templateInput struct {
 	Question      string
 	QuestionClass string
 	QuestionType  string
+	Blocklist     string // Only populated if this was blocked
+	BlocklistRule string // Only populated if this was blocked
 }
 
 // Apply executes the template, e.g. replacing placeholders in the text
 // with values from the Query.
-func (t *Template) Apply(q *dns.Msg) (string, error) {
+func (t *Template) Apply(input templateInput) (string, error) {
 	if t == nil {
 		return "", nil
-	}
-	var question dns.Question
-	if len(q.Question) > 0 {
-		question = q.Question[0]
-	}
-	input := templateInput{
-		ID:            q.Id,
-		Question:      question.Name,
-		QuestionClass: dns.ClassToString[question.Qclass],
-		QuestionType:  dns.TypeToString[question.Qtype],
 	}
 	text := new(bytes.Buffer)
 	err := t.textTemplate.Execute(text, input)


### PR DESCRIPTION
This gives EDNS0-EDE templates access to two new fields
- `Blocklist` - the list a request matched
- `BlocklistRule` - the rule that matched

For example:
```toml
edns0-ede = {code = 15, text = "Blocked {{ .Question }} with ID {{ .ID }} because rule {{ .BlocklistRule }} on {{ .Blocklist}}"}
```

Based on discussion on https://github.com/folbricht/routedns/pull/367