### PR TITLE
Set RecursionAvailable in static responses

### DIFF
--- a/blocklist.go
+++ b/blocklist.go
@@ -141,6 +141,7 @@ func (r *Blocklist) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 
 	answer := new(dns.Msg)
 	answer.SetReply(q)
+	answer.RecursionAvailable = q.RecursionDesired
 
 	// We have an IP address to return, make sure it's of the right type. If not return NXDOMAIN.
 	var spoof []dns.RR

--- a/message.go
+++ b/message.go
@@ -56,6 +56,7 @@ func responseWithCode(q *dns.Msg, rcode int) *dns.Msg {
 func ptr(q *dns.Msg, names []string) *dns.Msg {
 	a := new(dns.Msg)
 	a.SetReply(q)
+	a.RecursionAvailable = q.RecursionDesired
 	answer := make([]dns.RR, 0, len(names))
 	for _, name := range names {
 		rr := &dns.PTR{

--- a/static-template.go
+++ b/static-template.go
@@ -54,6 +54,7 @@ func NewStaticTemplateResolver(id string, opt StaticResolverOptions) (*StaticTem
 func (r *StaticTemplateResolver) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	answer := new(dns.Msg)
 	answer.SetReply(q)
+	answer.RecursionAvailable = q.RecursionDesired
 	log := logger(r.id, q, ci)
 
 	answer.Answer = r.processRRTemplates(q, ci, r.answer...)

--- a/static.go
+++ b/static.go
@@ -66,6 +66,7 @@ func NewStaticResolver(id string, opt StaticResolverOptions) (*StaticResolver, e
 func (r *StaticResolver) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	answer := new(dns.Msg)
 	answer.SetReply(q)
+	answer.RecursionAvailable = q.RecursionDesired
 	log := logger(r.id, q, ci)
 
 	// Update the name of every answer record to match that of the query


### PR DESCRIPTION
Sets RecursionAvailable flag in static responses (static-responder, blocklists, etc) when the query requested it. This is to avoid the warning
```
;; WARNING: recursion requested but not available
```
Ref https://github.com/folbricht/routedns/pull/403