### PR TITLE
Re-align log-levels with logrus

### DIFF
--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net"
 	"net/url"
 	"os"
@@ -85,11 +86,13 @@ func start(opt options, args []string) error {
 	// Convert logrus levels to slog levels
 	var level slog.Level
 	switch opt.logLevel {
-	case 0:
+	case 0, 1:
+		level = math.MaxInt // Basically disables logging
+	case 2:
 		level = slog.LevelError
-	case 1, 2:
+	case 3:
 		level = slog.LevelWarn
-	case 3, 4:
+	case 4:
 		level = slog.LevelInfo
 	case 5, 6:
 		level = slog.LevelDebug


### PR DESCRIPTION
https://github.com/folbricht/routedns/pull/422 switched from logrus to slog. It slightly changed the meaning of log-levels which caused https://github.com/folbricht/routedns/issues/433
