### PR TITLE
Match blocklist items regardless of case

### DIFF
--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -36,6 +36,9 @@ func NewDomainDB(name string, loader BlocklistLoader) (*DomainDB, error) {
 		// Strip trailing . in case the list has FQDN names with . suffixes.
 		r = strings.TrimSuffix(r, ".")
 
+		// Force all domain names to lower case
+		r = strings.ToLower(r)
+
 		// Break up the domain into its parts and iterate backwards over them, building
 		// a graph of maps
 		parts := strings.Split(r, ".")
@@ -65,7 +68,7 @@ func (m *DomainDB) Reload() (BlocklistDB, error) {
 
 func (m *DomainDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
 	q := msg.Question[0]
-	s := strings.TrimSuffix(q.Name, ".")
+	s := strings.ToLower(strings.TrimSuffix(q.Name, "."))
 	var matched []string
 	parts := strings.Split(s, ".")
 	n := m.root

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -16,6 +16,7 @@ func TestDomainDB(t *testing.T) {
 		"x.x.domain3.com", // more general wildcard above should take precedence
 		"domain4.com",     // the more general rule below wins
 		".domain4.com",
+		".DOMAIN5.com",
 	})
 
 	m, err := NewDomainDB("testlist", loader)
@@ -44,6 +45,12 @@ func TestDomainDB(t *testing.T) {
 		// not matching
 		{"unblocked.test.", false},
 		{"com.", false},
+
+		// capitalized query
+		{"Domain1.com.", true},
+
+		// match capital blocklist item
+		{"domain5.com.", true},
 	}
 	for _, test := range tests {
 		msg := new(dns.Msg)

--- a/blocklistdb-hosts.go
+++ b/blocklistdb-hosts.go
@@ -58,7 +58,7 @@ func NewHostsDB(name string, loader BlocklistLoader) (*HostsDB, error) {
 			ip = nil
 		}
 		for _, name := range names {
-			name = strings.TrimSuffix(name, ".")
+			name = strings.ToLower(strings.TrimSuffix(name, "."))
 			ips := filters[name]
 			if isIP4 {
 				if len(ips.ip4) > maxHostsResponses {
@@ -89,7 +89,7 @@ func (m *HostsDB) Reload() (BlocklistDB, error) {
 func (m *HostsDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
 	q := msg.Question[0]
 	if q.Qtype == dns.TypePTR {
-		names, ok := m.ptrMap[q.Name]
+		names, ok := m.ptrMap[strings.ToLower(q.Name)]
 		var rule string
 		if len(names) > 0 {
 			rule = names[0]
@@ -99,7 +99,7 @@ func (m *HostsDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool
 			Rule: rule,
 		}, ok
 	}
-	name := strings.TrimSuffix(q.Name, ".")
+	name := strings.ToLower(strings.TrimSuffix(q.Name, "."))
 	ips, ok := m.filters[name]
 	if q.Qtype == dns.TypeA {
 		return ips.ip4,

--- a/blocklistdb-hosts_test.go
+++ b/blocklistdb-hosts_test.go
@@ -18,6 +18,7 @@ func TestHostsDB(t *testing.T) {
 		"::          domain5.com",
 		"::1         domain6.com",
 		"192.168.1.1 domain6.com",
+		"127.0.0.1   DOMAIN7.com",
 	})
 
 	m, err := NewHostsDB("testlist", loader)
@@ -36,6 +37,8 @@ func TestHostsDB(t *testing.T) {
 		{"domain6.com.", dns.TypeA, true, []net.IP{net.ParseIP("192.168.1.1")}},
 		{"domain6.com.", dns.TypeAAAA, true, []net.IP{net.ParseIP("::1")}},
 		{"domainX.com.", dns.TypeA, false, nil},
+		{"Domain1.com.", dns.TypeA, true, []net.IP{net.ParseIP("127.0.0.1")}},
+		{"domain7.com.", dns.TypeA, true, []net.IP{net.ParseIP("127.0.0.1")}},
 	}
 	for _, test := range tests {
 		msg := new(dns.Msg)


### PR DESCRIPTION
Uses case-insensitive matching for blocklist items. Also forces lowercase for any value provided in blocklists.

Fixes #441 