### PR TITLE
Use case-insensitive query names when caching

### DIFF
--- a/cache-memory.go
+++ b/cache-memory.go
@@ -83,6 +83,7 @@ func (b *memoryBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 	// elements might make changes.
 	answer = answer.Copy()
 	answer.Id = q.Id
+	answer.Question = q.Question // restore the case used in the question
 
 	// Calculate the time the record spent in the cache. We need to
 	// subtract that from the TTL of each answer record.

--- a/cache-redis.go
+++ b/cache-redis.go
@@ -67,6 +67,7 @@ func (b *redisBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 	answer := a.Msg
 	prefetchEligible := a.PrefetchEligible
 	answer.Id = q.Id
+	answer.Question = q.Question // restore the case used in the question
 
 	// Calculate the time the record spent in the cache. We need to
 	// subtract that from the TTL of each answer record.
@@ -117,7 +118,7 @@ func (b *redisBackend) Close() error {
 func (b *redisBackend) keyFromQuery(q *dns.Msg) string {
 	var key strings.Builder
 	key.WriteString(b.opt.KeyPrefix)
-	key.WriteString(q.Question[0].Name)
+	key.WriteString(strings.ToLower(q.Question[0].Name))
 	key.WriteByte(':')
 	key.WriteString(dns.Class(q.Question[0].Qclass).String())
 	key.WriteByte(':')

--- a/cache_test.go
+++ b/cache_test.go
@@ -52,6 +52,13 @@ func TestCache(t *testing.T) {
 	require.Equal(t, 1, r.HitCount())
 	require.True(t, a.Answer[0].Header().Ttl < answerTTL)
 
+	// Capital chars in the query should be preserved when serving from the cache
+	q.SetQuestion("Example.com.", dns.TypeA)
+	a, err = c.Resolve(q, ci)
+	require.NoError(t, err)
+	require.Equal(t, 1, r.HitCount())
+	require.Equal(t, "Example.com.", a.Question[0].Name)
+
 	// Different question should go through to upstream again, low TTL
 	answerTTL = 1
 	q.SetQuestion("example2.com.", dns.TypeA)
@@ -67,6 +74,7 @@ func TestCache(t *testing.T) {
 	_, err = c.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, 3, r.HitCount())
+
 }
 
 func TestCacheNXDOMAIN(t *testing.T) {

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -3,6 +3,7 @@ package rdns
 import (
 	"encoding/json"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/miekg/dns"
@@ -211,7 +212,10 @@ func (c *lruCache) deserialize(r io.Reader) error {
 }
 
 func lruKeyFromQuery(q *dns.Msg) lruKey {
-	key := lruKey{Question: q.Question[0]}
+	question := q.Question[0]
+	// disregard case of the question name when storing
+	question.Name = strings.ToLower(question.Name)
+	key := lruKey{Question: question}
 
 	edns0 := q.IsEdns0()
 	if edns0 != nil {


### PR DESCRIPTION
Use a lowercase query name when storing items in the cache as per #441 