### PR TITLE
Failback immediately if `reset-after` is set to 0 and new flag to fail on empty responses

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -109,7 +109,7 @@ type group struct {
 	EDNS0Data  []byte                  `toml:"edns0-data"`  // EDNS0 modifier option data
 
 	// Failover/Failback options
-	ResetAfter    int  `toml:"reset-after"`    // Time in seconds after which to reset resolvers in fail-back and random groups, default 0 (reset immediately).
+	ResetAfter    int  `toml:"reset-after"`    // Time in seconds after which to reset resolvers in fail-back and random groups, or -1 to reset immediately, default 60.
 	ServfailError bool `toml:"servfail-error"` // If true, SERVFAIL responses are considered errors and cause failover etc.
 	EmptyError    bool `toml:"empty-error"`    // If true, empty responses are considered errors and cause failover etc.
 

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -111,7 +111,7 @@ type group struct {
 	// Failover/Failback options
 	ResetAfter    int  `toml:"reset-after"`    // Time in seconds after which to reset resolvers in fail-back and random groups, default 0 (reset immediately).
 	ServfailError bool `toml:"servfail-error"` // If true, SERVFAIL responses are considered errors and cause failover etc.
-	EmptyError    bool `toml:"empty-error"`    // If true, empty responses that are unusual (such as NOERROR with no records instead of NXDOMAIN) are considered errors and cause failover etc.
+	EmptyError    bool `toml:"empty-error"`    // If true, empty responses are considered errors and cause failover etc.
 
 	// Cache options
 	Backend                  *cacheBackend

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -109,7 +109,7 @@ type group struct {
 	EDNS0Data  []byte                  `toml:"edns0-data"`  // EDNS0 modifier option data
 
 	// Failover/Failback options
-	ResetAfter    int  `toml:"reset-after"`    // Non-zero time in seconds after which to reset resolvers in fail-back and random groups, or negative to reset immediately, default 60.
+	ResetAfter    *int `toml:"reset-after"`    // Time in seconds after which to reset resolvers in fail-back and random groups, or 0 to reset immediately, default 60.
 	ServfailError bool `toml:"servfail-error"` // If true, SERVFAIL responses are considered errors and cause failover etc.
 	EmptyError    bool `toml:"empty-error"`    // If true, empty responses are considered errors and cause failover etc.
 

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -109,7 +109,7 @@ type group struct {
 	EDNS0Data  []byte                  `toml:"edns0-data"`  // EDNS0 modifier option data
 
 	// Failover/Failback options
-	ResetAfter    int  `toml:"reset-after"`    // Time in seconds after which to reset resolvers in fail-back and random groups, or -1 to reset immediately, default 60.
+	ResetAfter    int  `toml:"reset-after"`    // Non-zero time in seconds after which to reset resolvers in fail-back and random groups, or negative to reset immediately, default 60.
 	ServfailError bool `toml:"servfail-error"` // If true, SERVFAIL responses are considered errors and cause failover etc.
 	EmptyError    bool `toml:"empty-error"`    // If true, empty responses are considered errors and cause failover etc.
 

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -111,6 +111,7 @@ type group struct {
 	// Failover/Failback options
 	ResetAfter    int  `toml:"reset-after"`    // Time in seconds after which to reset resolvers in fail-back and random groups, default 0 (reset immediately).
 	ServfailError bool `toml:"servfail-error"` // If true, SERVFAIL responses are considered errors and cause failover etc.
+	EmptyError    bool `toml:"empty-error"`    // If true, empty responses that are unusual (such as NOERROR with no records instead of NXDOMAIN) are considered errors and cause failover etc.
 
 	// Cache options
 	Backend                  *cacheBackend

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -109,7 +109,7 @@ type group struct {
 	EDNS0Data  []byte                  `toml:"edns0-data"`  // EDNS0 modifier option data
 
 	// Failover/Failback options
-	ResetAfter    int  `toml:"reset-after"`    // Time in seconds after which to reset resolvers in fail-back and random groups, default 60.
+	ResetAfter    int  `toml:"reset-after"`    // Time in seconds after which to reset resolvers in fail-back and random groups, default 0 (reset immediately).
 	ServfailError bool `toml:"servfail-error"` // If true, SERVFAIL responses are considered errors and cause failover etc.
 
 	// Cache options

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -374,8 +374,12 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 		}
 		resolvers[id] = rdns.NewFailRotate(id, opt, gr...)
 	case "fail-back":
+		var resetAfterDefault int = 60
+		if g.ResetAfter == nil {
+			g.ResetAfter = &resetAfterDefault
+		}
 		opt := rdns.FailBackOptions{
-			ResetAfter:    time.Duration(time.Duration(g.ResetAfter) * time.Second),
+			ResetAfter:    time.Duration(time.Duration(*g.ResetAfter) * time.Second),
 			ServfailError: g.ServfailError,
 			EmptyError:    g.EmptyError,
 		}
@@ -383,8 +387,12 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 	case "fastest":
 		resolvers[id] = rdns.NewFastest(id, gr...)
 	case "random":
+		var resetAfterDefault int = 60
+		if g.ResetAfter == nil {
+			g.ResetAfter = &resetAfterDefault
+		}
 		opt := rdns.RandomOptions{
-			ResetAfter:    time.Duration(time.Duration(g.ResetAfter) * time.Second),
+			ResetAfter:    time.Duration(time.Duration(*g.ResetAfter) * time.Second),
 			ServfailError: g.ServfailError,
 			EmptyError:    g.EmptyError,
 		}

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -370,12 +370,14 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 	case "fail-rotate":
 		opt := rdns.FailRotateOptions{
 			ServfailError: g.ServfailError,
+			EmptyError:    g.EmptyError,
 		}
 		resolvers[id] = rdns.NewFailRotate(id, opt, gr...)
 	case "fail-back":
 		opt := rdns.FailBackOptions{
 			ResetAfter:    time.Duration(time.Duration(g.ResetAfter) * time.Second),
 			ServfailError: g.ServfailError,
+			EmptyError:    g.EmptyError,
 		}
 		resolvers[id] = rdns.NewFailBack(id, opt, gr...)
 	case "fastest":
@@ -384,6 +386,7 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 		opt := rdns.RandomOptions{
 			ResetAfter:    time.Duration(time.Duration(g.ResetAfter) * time.Second),
 			ServfailError: g.ServfailError,
+			EmptyError:    g.EmptyError,
 		}
 		resolvers[id] = rdns.NewRandom(id, opt, gr...)
 	case "blocklist":

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -519,6 +519,7 @@ Options:
 
 - `resolvers` - An array of upstream resolvers or modifiers.
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure triggering a switch to the next resolver. This can happen when DNSSEC validation fails for example. Default `false`.
+- `empty-error` - If `true`, a unusual empty reponse (such as NOERROR with no records instead of NXDOMAIN) from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
 
 #### Examples
 
@@ -539,8 +540,9 @@ Fail-Back groups are instantiated with `type = "fail-back"` in the groups sectio
 Options:
 
 - `resolvers` - An array of upstream resolvers or modifiers. The first in the array is the preferred resolver.
-- `reset-after` - Time in seconds before switching from an alternative resolver back to the preferred resolver (first in the list), default 60. Note: This is not a timeout argument. After a failure of the preferred resolver, this defines the amount of time to use alternative/failover resolvers before switching back to the preferred. You can have as many resolvers in the array as the time limit allows.
+- `reset-after` - Time in seconds before switching from an alternative resolver back to the preferred resolver (first in the list), default 0 (meaning it will switch after a single request). Note: This is not a timeout argument. After a failure of the preferred resolver, this defines the amount of time to use alternative/failover resolvers before switching back to the preferred. You can have as many resolvers in the array as the time limit allows.
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure triggering a failover. This can happen when DNSSEC validation fails for example. Default `false`.
+- `empty-error` - If `true`, a unusual empty reponse (such as NOERROR with no records instead of NXDOMAIN) from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
 
 #### Examples
 
@@ -561,8 +563,9 @@ Random groups are instantiated with `type = "random"` in the groups section of t
 Options:
 
 - `resolvers` - An array of upstream resolvers or modifiers.
-- `reset-after` - Time in seconds to disable a failed resolver, default 60.
+- `reset-after` - Time in seconds to disable a failed resolver, default 0 (disabled only for a single request).
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure which will take the resolver temporarily out of the group. This can happen when DNSSEC validation fails for example. Default `false`.
+- `empty-error` - If `true`, a unusual empty reponse (such as NOERROR with no records instead of NXDOMAIN) from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
 
 #### Examples
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -540,7 +540,7 @@ Fail-Back groups are instantiated with `type = "fail-back"` in the groups sectio
 Options:
 
 - `resolvers` - An array of upstream resolvers or modifiers. The first in the array is the preferred resolver.
-- `reset-after` - Time in seconds before switching from an alternative resolver back to the preferred resolver (first in the list), or -1 to switch back immediately, default 60. Note: This is not a timeout argument. After a failure of the preferred resolver, this defines the amount of time to use alternative/failover resolvers before switching back to the preferred. You can have as many resolvers in the array as the time limit allows.
+- `reset-after` - Non-zero time in seconds before switching from an alternative resolver back to the preferred resolver (first in the list), or a negative number to switch back immediately, default 60. Note: This is not a timeout argument. After a failure of the preferred resolver, this defines the amount of time to use alternative/failover resolvers before switching back to the preferred. You can have as many resolvers in the array as the time limit allows.
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure triggering a failover. This can happen when DNSSEC validation fails for example. Default `false`.
 - `empty-error` - If `true`, an empty reponse from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
 
@@ -563,7 +563,7 @@ Random groups are instantiated with `type = "random"` in the groups section of t
 Options:
 
 - `resolvers` - An array of upstream resolvers or modifiers.
-- `reset-after` - Time in seconds to disable a failed resolver, or -1 to disable it for a single request, default 60.
+- `reset-after` - Non-zero time in seconds to disable a failed resolver, or a negative number to disable only for a single request, default 60.
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure which will take the resolver temporarily out of the group. This can happen when DNSSEC validation fails for example. Default `false`.
 - `empty-error` - If `true`, an empty reponse from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -519,7 +519,7 @@ Options:
 
 - `resolvers` - An array of upstream resolvers or modifiers.
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure triggering a switch to the next resolver. This can happen when DNSSEC validation fails for example. Default `false`.
-- `empty-error` - If `true`, a unusual empty reponse (such as NOERROR with no records instead of NXDOMAIN) from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
+- `empty-error` - If `true`, an empty reponse from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
 
 #### Examples
 
@@ -542,7 +542,7 @@ Options:
 - `resolvers` - An array of upstream resolvers or modifiers. The first in the array is the preferred resolver.
 - `reset-after` - Time in seconds before switching from an alternative resolver back to the preferred resolver (first in the list), default 0 (meaning it will switch after a single request). Note: This is not a timeout argument. After a failure of the preferred resolver, this defines the amount of time to use alternative/failover resolvers before switching back to the preferred. You can have as many resolvers in the array as the time limit allows.
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure triggering a failover. This can happen when DNSSEC validation fails for example. Default `false`.
-- `empty-error` - If `true`, a unusual empty reponse (such as NOERROR with no records instead of NXDOMAIN) from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
+- `empty-error` - If `true`, an empty reponse from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
 
 #### Examples
 
@@ -565,7 +565,7 @@ Options:
 - `resolvers` - An array of upstream resolvers or modifiers.
 - `reset-after` - Time in seconds to disable a failed resolver, default 0 (disabled only for a single request).
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure which will take the resolver temporarily out of the group. This can happen when DNSSEC validation fails for example. Default `false`.
-- `empty-error` - If `true`, a unusual empty reponse (such as NOERROR with no records instead of NXDOMAIN) from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
+- `empty-error` - If `true`, an empty reponse from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
 
 #### Examples
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -540,7 +540,7 @@ Fail-Back groups are instantiated with `type = "fail-back"` in the groups sectio
 Options:
 
 - `resolvers` - An array of upstream resolvers or modifiers. The first in the array is the preferred resolver.
-- `reset-after` - Time in seconds before switching from an alternative resolver back to the preferred resolver (first in the list), default 0 (meaning it will switch after a single request). Note: This is not a timeout argument. After a failure of the preferred resolver, this defines the amount of time to use alternative/failover resolvers before switching back to the preferred. You can have as many resolvers in the array as the time limit allows.
+- `reset-after` - Time in seconds before switching from an alternative resolver back to the preferred resolver (first in the list), or -1 to switch back immediately, default 60. Note: This is not a timeout argument. After a failure of the preferred resolver, this defines the amount of time to use alternative/failover resolvers before switching back to the preferred. You can have as many resolvers in the array as the time limit allows.
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure triggering a failover. This can happen when DNSSEC validation fails for example. Default `false`.
 - `empty-error` - If `true`, an empty reponse from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
 
@@ -563,7 +563,7 @@ Random groups are instantiated with `type = "random"` in the groups section of t
 Options:
 
 - `resolvers` - An array of upstream resolvers or modifiers.
-- `reset-after` - Time in seconds to disable a failed resolver, default 0 (disabled only for a single request).
+- `reset-after` - Time in seconds to disable a failed resolver, or -1 to disable it for a single request, default 60.
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure which will take the resolver temporarily out of the group. This can happen when DNSSEC validation fails for example. Default `false`.
 - `empty-error` - If `true`, an empty reponse from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
 

--- a/failback.go
+++ b/failback.go
@@ -37,8 +37,8 @@ type FailBackOptions struct {
 	// error response and trigger a failover.
 	ServfailError bool
 
-	// Determines if an empty reponse (that isn't NXDOMAIN) returned by a resolver
-	// should be considered an error respone and trigger a failover.
+	// Determines if an empty reponse returned by a resolver should be considered an
+	// error respone and trigger a failover.
 	EmptyError bool
 }
 
@@ -160,6 +160,5 @@ func (r *FailBack) startResetTimer() chan struct{} {
 // Returns true is the response is considered successful given the options.
 func (r *FailBack) isSuccessResponse(a *dns.Msg) bool {
 	return a == nil || !(r.opt.ServfailError && a.Rcode == dns.RcodeServerFailure) &&
-	                   !(r.opt.EmptyError    && a.Rcode == dns.RcodeSuccess   && len(a.Answer) == 0 ||
-	       	                                    a.Rcode == dns.RcodeNameError && len(a.Answer) == 1 && a.Answer[0].Header().Rrtype == dns.TypeCNAME)
+	                   !(r.opt.EmptyError    && (len(a.Answer) == 0 || len(a.Answer) == 1 && a.Answer[0].Header().Rrtype == dns.TypeCNAME))
 }

--- a/failback.go
+++ b/failback.go
@@ -30,7 +30,7 @@ type FailBack struct {
 // FailBackOptions contain group-specific options.
 type FailBackOptions struct {
 	// Switch back to the first resolver in the group after no further failures
-	// for this amount of time. Default 1 minute.
+	// for this amount of time. Default 0 seconds (switch back immediately).
 	ResetAfter time.Duration
 
 	// Determines if a SERVFAIL returned by a resolver should be considered an
@@ -61,9 +61,6 @@ func NewFailRouterMetrics(id string, available int) *FailRouterMetrics {
 
 // NewFailBack returns a new instance of a failover resolver group.
 func NewFailBack(id string, opt FailBackOptions, resolvers ...Resolver) *FailBack {
-	if opt.ResetAfter == 0 {
-		opt.ResetAfter = time.Minute
-	}
 	return &FailBack{
 		id:        id,
 		resolvers: resolvers,

--- a/failback.go
+++ b/failback.go
@@ -159,6 +159,8 @@ func (r *FailBack) startResetTimer() chan struct{} {
 
 // Returns true is the response is considered successful given the options.
 func (r *FailBack) isSuccessResponse(a *dns.Msg) bool {
+	aLen := len(a.Answer)
 	return a == nil || !(r.opt.ServfailError && a.Rcode == dns.RcodeServerFailure) &&
-	                   !(r.opt.EmptyError    && (len(a.Answer) == 0 || len(a.Answer) == 1 && a.Answer[0].Header().Rrtype == dns.TypeCNAME))
+	                   !(r.opt.EmptyError    && (aLen == 0 || a.Answer[0].Header().Rrtype == dns.TypeCNAME &&
+	                                            (aLen == 1 || a.Answer[aLen-1].Header().Rrtype == dns.TypeCNAME)))
 }

--- a/failback_test.go
+++ b/failback_test.go
@@ -113,7 +113,7 @@ func TestFailBackServfailOKOption(t *testing.T) {
 	goodResolver := new(TestResolver)
 
 	// With ServfailError == false
-	g1 := NewFailBack("test-fb", FailBackOptions{}, failResolver, goodResolver)
+	g1 := NewFailBack("test-fb", FailBackOptions{ResetAfter: time.Second}, failResolver, goodResolver)
 	q := new(dns.Msg)
 	q.SetQuestion("test.com.", dns.TypeA)
 
@@ -123,7 +123,7 @@ func TestFailBackServfailOKOption(t *testing.T) {
 	require.Equal(t, 0, goodResolver.hitCount)
 
 	// With ServfailError == true
-	g2 := NewFailBack("test-fb", FailBackOptions{ServfailError: true}, failResolver, goodResolver)
+	g2 := NewFailBack("test-fb", FailBackOptions{ResetAfter: time.Second, ServfailError: true}, failResolver, goodResolver)
 
 	a, err = g2.Resolve(q, ci)
 	require.NoError(t, err)

--- a/failrotate.go
+++ b/failrotate.go
@@ -98,6 +98,8 @@ func (r *FailRotate) errorFrom(i int) {
 
 // Returns true is the response is considered successful given the options.
 func (r *FailRotate) isSuccessResponse(a *dns.Msg) bool {
+	aLen := len(a.Answer)
 	return a == nil || !(r.opt.ServfailError && a.Rcode == dns.RcodeServerFailure) &&
-	                   !(r.opt.EmptyError    && (len(a.Answer) == 0 || len(a.Answer) == 1 && a.Answer[0].Header().Rrtype == dns.TypeCNAME))
+	                   !(r.opt.EmptyError    && (aLen == 0 || a.Answer[0].Header().Rrtype == dns.TypeCNAME &&
+	                                            (aLen == 1 || a.Answer[aLen-1].Header().Rrtype == dns.TypeCNAME)))
 }

--- a/failrotate.go
+++ b/failrotate.go
@@ -113,7 +113,11 @@ func (r *FailRotate) isSuccessResponse(a *dns.Msg) bool {
 				break
 			}
 		}
-		if onlyCNAME {
+		// The answer may be blank because it was blocked by a filter.
+		// If so (as determined by the presence of an EDE option), we
+		// consider it "successful" as we shouldn't retry or fail-over
+		// in that case.
+		if onlyCNAME && !hasExtendedErrorBlocked(a) {
 			return false
 		}
 	}

--- a/failrotate.go
+++ b/failrotate.go
@@ -98,12 +98,23 @@ func (r *FailRotate) errorFrom(i int) {
 
 // Returns true is the response is considered successful given the options.
 func (r *FailRotate) isSuccessResponse(a *dns.Msg) bool {
-	if a == nil || r.opt.ServfailError && a.Rcode == dns.RcodeServerFailure { return false }
+	if a == nil {
+		return true
+	}
+	if r.opt.ServfailError && a.Rcode == dns.RcodeServerFailure {
+		return false
+	}
 	if r.opt.EmptyError {
-		switch aLen := len(a.Answer); aLen {
-			case 0:  return false
-			case 1:  if a.Answer[0].Header().Rrtype == dns.TypeCNAME { return false }
-			default: if a.Answer[0].Header().Rrtype == dns.TypeCNAME && a.Answer[aLen-1].Header().Rrtype == dns.TypeCNAME { return false }
+		// Check if there are only CNAMEs in the answer section
+		var onlyCNAME = true
+		for _, rr := range a.Answer {
+			if rr.Header().Rrtype != dns.TypeCNAME {
+				onlyCNAME = false
+				break
+			}
+		}
+		if onlyCNAME {
+			return false
 		}
 	}
 	return true

--- a/failrotate.go
+++ b/failrotate.go
@@ -28,8 +28,8 @@ type FailRotateOptions struct {
 	// error response and trigger a failover.
 	ServfailError bool
 
-	// Determines if an empty reponse (that isn't NXDOMAIN) returned by a resolver
-	// should be considered an error respone and trigger a failover.
+	// Determines if an empty reponse returned by a resolver should be considered an
+	// error respone and trigger a failover.
 	EmptyError bool
 }
 
@@ -99,6 +99,5 @@ func (r *FailRotate) errorFrom(i int) {
 // Returns true is the response is considered successful given the options.
 func (r *FailRotate) isSuccessResponse(a *dns.Msg) bool {
 	return a == nil || !(r.opt.ServfailError && a.Rcode == dns.RcodeServerFailure) &&
-	                   !(r.opt.EmptyError    && a.Rcode == dns.RcodeSuccess   && len(a.Answer) == 0 ||
-	       	                                    a.Rcode == dns.RcodeNameError && len(a.Answer) == 1 && a.Answer[0].Header().Rrtype == dns.TypeCNAME)
+	                   !(r.opt.EmptyError    && (len(a.Answer) == 0 || len(a.Answer) == 1 && a.Answer[0].Header().Rrtype == dns.TypeCNAME))
 }

--- a/random.go
+++ b/random.go
@@ -122,6 +122,8 @@ func (r *Random) reactivateLater(resolver Resolver) {
 
 // Returns true is the response is considered successful given the options.
 func (r *Random) isSuccessResponse(a *dns.Msg) bool {
+	aLen := len(a.Answer)
 	return a == nil || !(r.opt.ServfailError && a.Rcode == dns.RcodeServerFailure) &&
-	                   !(r.opt.EmptyError    && (len(a.Answer) == 0 || len(a.Answer) == 1 && a.Answer[0].Header().Rrtype == dns.TypeCNAME))
+	                   !(r.opt.EmptyError    && (aLen == 0 || a.Answer[0].Header().Rrtype == dns.TypeCNAME &&
+	                                            (aLen == 1 || a.Answer[aLen-1].Header().Rrtype == dns.TypeCNAME)))
 }

--- a/random.go
+++ b/random.go
@@ -39,6 +39,9 @@ type RandomOptions struct {
 // NewRandom returns a new instance of a random resolver group.
 func NewRandom(id string, opt RandomOptions, resolvers ...Resolver) *Random {
 	rand.Seed(time.Now().UnixNano())
+	if opt.ResetAfter == 0 {
+		opt.ResetAfter = time.Minute
+	}
 	return &Random{
 		id:        id,
 		resolvers: resolvers,
@@ -122,8 +125,13 @@ func (r *Random) reactivateLater(resolver Resolver) {
 
 // Returns true is the response is considered successful given the options.
 func (r *Random) isSuccessResponse(a *dns.Msg) bool {
-	aLen := len(a.Answer)
-	return a == nil || !(r.opt.ServfailError && a.Rcode == dns.RcodeServerFailure) &&
-	                   !(r.opt.EmptyError    && (aLen == 0 || a.Answer[0].Header().Rrtype == dns.TypeCNAME &&
-	                                            (aLen == 1 || a.Answer[aLen-1].Header().Rrtype == dns.TypeCNAME)))
+	if a == nil || r.opt.ServfailError && a.Rcode == dns.RcodeServerFailure { return false }
+	if r.opt.EmptyError {
+		switch aLen := len(a.Answer); aLen {
+			case 0:  return false
+			case 1:  if a.Answer[0].Header().Rrtype == dns.TypeCNAME { return false }
+			default: if a.Answer[0].Header().Rrtype == dns.TypeCNAME && a.Answer[aLen-1].Header().Rrtype == dns.TypeCNAME { return false }
+		}
+	}
+	return true
 }

--- a/random.go
+++ b/random.go
@@ -136,7 +136,11 @@ func (r *Random) isSuccessResponse(a *dns.Msg) bool {
 				break
 			}
 		}
-		if onlyCNAME {
+		// The answer may be blank because it was blocked by a filter.
+		// If so (as determined by the presence of an EDE option), we
+		// consider it "successful" as we shouldn't retry or fail-over
+		// in that case.
+		if onlyCNAME && !hasExtendedErrorBlocked(a) {
 			return false
 		}
 	}

--- a/random.go
+++ b/random.go
@@ -31,8 +31,8 @@ type RandomOptions struct {
 	// error response and cause the resolver to be removed from the group temporarily.
 	ServfailError bool
 
-	// Determines if an empty reponse (that isn't NXDOMAIN) returned by a resolver
-	// should be considered an error respone and trigger a failover.
+	// Determines if an empty reponse returned by a resolver should be considered an
+	// error respone and trigger a failover.
 	EmptyError bool
 }
 
@@ -123,6 +123,5 @@ func (r *Random) reactivateLater(resolver Resolver) {
 // Returns true is the response is considered successful given the options.
 func (r *Random) isSuccessResponse(a *dns.Msg) bool {
 	return a == nil || !(r.opt.ServfailError && a.Rcode == dns.RcodeServerFailure) &&
-	                   !(r.opt.EmptyError    && a.Rcode == dns.RcodeSuccess   && len(a.Answer) == 0 ||
-	       	                                    a.Rcode == dns.RcodeNameError && len(a.Answer) == 1 && a.Answer[0].Header().Rrtype == dns.TypeCNAME)
+	                   !(r.opt.EmptyError    && (len(a.Answer) == 0 || len(a.Answer) == 1 && a.Answer[0].Header().Rrtype == dns.TypeCNAME))
 }


### PR DESCRIPTION
Based on https://github.com/folbricht/routedns/pull/444/

- If `reset-after` is set to 0 in the config, the `failback` and `random` groups will reset immediately
- A new `empty-error` flag to specify if empty (or all CNAME) responses should be considered errors. Supported by `failback`, `random`, and `fail-rotate`

TODO: Update the docs
