### PR TITLE
Fix network-selection in DoT listener

### DIFF
--- a/cmd/routedns/example-config/dot-client.toml
+++ b/cmd/routedns/example-config/dot-client.toml
@@ -1,0 +1,12 @@
+# This config starts a UDP  resolver on the loopback interface for plain DNS.
+# All queries are forwarded to a local DNS-over-DOT server.
+
+[resolvers.local-dot]
+address = "127.0.0.1:853"
+protocol = "dot"
+ca = "example-config/server.crt"
+
+[listeners.local-udp]
+address = "127.0.0.1:53"
+protocol = "udp"
+resolver = "local-dot"

--- a/cmd/routedns/example-config/dot-server.toml
+++ b/cmd/routedns/example-config/dot-server.toml
@@ -1,0 +1,12 @@
+# Server-side of a simple DNS-over-TLS proxy.
+
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[listeners.local-dot]
+address = "127.0.0.1:853"
+protocol = "dot"
+resolver = "cloudflare-dot"
+server-crt = "example-config/server.crt"
+server-key = "example-config/server.key"

--- a/dotlistener.go
+++ b/dotlistener.go
@@ -23,8 +23,13 @@ type DoTListenerOptions struct {
 
 // NewDoTListener returns an instance of a DNS-over-TLS listener.
 func NewDoTListener(id, addr, network string, opt DoTListenerOptions, resolver Resolver) *DoTListener {
-	if network == "" {
+	switch network {
+	case "", "tcp":
 		network = "tcp-tls"
+	case "tcp4":
+		network = "tcp4-tls"
+	case "tcp6":
+		network = "tcp6-tls"
 	}
 	return &DoTListener{
 		id: id,


### PR DESCRIPTION
Fixes a bug with the wrong network ("tcp" vs "tcp-tls") being selected in the DoT listener, leading to it only accepting plain TCP connections.

Fixes #397 