### PR TITLE
Avoid leaking pipeline conns

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -116,6 +116,7 @@ func (c *Pipeline) start() {
 						return
 					}
 				case <-done: // the reader ran into an error and we want to stop using this connection
+					conn.Close()
 					wg.Done()
 					return
 				}


### PR DESCRIPTION
The pipeline reader can return due to timeouts or other errors. The writer then needs to close the connection in the "done" case, otherwise the conn is never closed.