### PR TITLE
Add configurable idle-timeout for DoH connections

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -73,7 +73,8 @@ type resolver struct {
 
 // DoH-specific resolver options
 type doh struct {
-	Method string
+	Method      string
+	IdleTimeout int `toml:"idle-timeout"` // Idle connection timeout in seconds. TCP default: 30s. QUIC: uses library default if not set.
 }
 
 // Cache backend options

--- a/cmd/routedns/resolver.go
+++ b/cmd/routedns/resolver.go
@@ -81,6 +81,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			Transport:     r.Transport,
 			LocalAddr:     net.ParseIP(r.LocalAddr),
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
+			IdleTimeout:   time.Duration(r.DoH.IdleTimeout) * time.Second,
 			Dialer:        socks5DialerFromConfig(r),
 			Use0RTT:       r.Use0RTT,
 		}
@@ -100,6 +101,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			Transport:     r.Transport,
 			LocalAddr:     net.ParseIP(r.LocalAddr),
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
+			IdleTimeout:   time.Duration(r.DoH.IdleTimeout) * time.Second,
 		}
 		resolvers[id], err = rdns.NewODoHClient(id, r.Address, r.Target, r.TargetConfig, opt)
 		if err != nil {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1740,6 +1740,7 @@ Example config files: [well-known.toml](../cmd/routedns/example-config/well-know
 
 DNS resolvers using the HTTPS protocol are configured with `protocol = "doh"`. By default, DoH uses TCP as transport, but it can also be run over QUIC (UDP) by providing the option `transport = "quic"`. DoH supports two HTTP methods, GET and POST. By default RouteDNS uses the POST method, but can be configured to use GET as well using the option `doh = { method = "GET" }`.
 DoH with QUIC supports 0-RTT. The DoH resolver will try to use 0-RTT connection establishment if `transport = "quic"` and `enable-0rtt = true` are configured. When 0-RTT is enabled, the resolver will disregard the configured method and always use GET instead. This means the configured address nees to contain a URL template (with the `{?dns}` part).
+The idle connection timeout can be configured with `doh = { idle-timeout = 60 }` (in seconds). This controls how long idle HTTP connections are kept open before being closed. For TCP transport, the default is 30 seconds. For QUIC transport, the default is determined by the quic-go library. Note that for QUIC, the actual idle timeout is the minimum of the client and server values.
 
 Examples:
 
@@ -1768,6 +1769,15 @@ address = "https://cloudflare-dns.com/dns-query{?dns}"
 protocol = "doh"
 transport = "quic"
 enable-0rtt = true
+```
+
+DoH resolver with extended idle timeout.
+
+```toml
+[resolvers.cloudflare-doh-long-idle]
+address = "https://1.1.1.1/dns-query"
+protocol = "doh"
+doh = { idle-timeout = 60 }
 ```
 
 Example config files: [well-known.toml](../cmd/routedns/example-config/well-known.toml), [simple-doh.toml](../cmd/routedns/example-config/simple-doh.toml), [mutual-tls-doh-client.toml](../cmd/routedns/example-config/mutual-tls-doh-client.toml)

--- a/dohclient_test.go
+++ b/dohclient_test.go
@@ -1,9 +1,12 @@
 package rdns
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
+	"github.com/quic-go/quic-go/http3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,4 +28,40 @@ func TestDoHClientSimpleGET(t *testing.T) {
 	r, err := d.Resolve(q, ClientInfo{})
 	require.NoError(t, err)
 	require.NotEmpty(t, r.Answer)
+}
+
+func TestDoHTcpTransportIdleTimeoutDefault(t *testing.T) {
+	tr, err := dohTcpTransport(DoHClientOptions{})
+	require.NoError(t, err)
+	httpTransport := tr.(*http.Transport)
+	require.Equal(t, defaultDoHIdleTimeout, httpTransport.IdleConnTimeout)
+}
+
+func TestDoHTcpTransportIdleTimeoutConfigured(t *testing.T) {
+	tr, err := dohTcpTransport(DoHClientOptions{IdleTimeout: 2 * time.Minute})
+	require.NoError(t, err)
+	httpTransport := tr.(*http.Transport)
+	require.Equal(t, 2*time.Minute, httpTransport.IdleConnTimeout)
+}
+
+func TestDoHQuicTransportIdleTimeoutDefault(t *testing.T) {
+	tr, err := dohQuicTransport("https://example.com/dns-query", DoHClientOptions{})
+	require.NoError(t, err)
+	http3Transport := tr.(*http3.Transport)
+	// When not configured, MaxIdleTimeout should not be set (zero value)
+	// The quic-go library will use its own default
+	require.Equal(t, time.Duration(0), http3Transport.QUICConfig.MaxIdleTimeout)
+}
+
+func TestDoHQuicTransportIdleTimeoutConfigured(t *testing.T) {
+	tr, err := dohQuicTransport("https://example.com/dns-query", DoHClientOptions{IdleTimeout: 2 * time.Minute})
+	require.NoError(t, err)
+	http3Transport := tr.(*http3.Transport)
+	require.Equal(t, 2*time.Minute, http3Transport.QUICConfig.MaxIdleTimeout)
+}
+
+func TestDoHClientIdleTimeoutNegative(t *testing.T) {
+	_, err := NewDoHClient("test-doh", "https://example.com/dns-query", DoHClientOptions{IdleTimeout: -1 * time.Second})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "idle-timeout must not be negative")
 }


### PR DESCRIPTION
This PR adds support for configuring the DoH idle timeout, which wasn't previously configurable. I found it helpful for low-volume query scenarios—keeping an existing connection open for 60 seconds performed slightly better than letting it expire at the default 30 seconds and opening a new one.

* TCP transport: defaults to 30 seconds
* QUIC transport: uses quic-go library default unless explicitly configured (actual timeout is min of client/server values)

PS: Feel free to make changes to this PR as you see fit should you need to.