### PR TITLE
Fix IPv6 URL parsing adding duplicate brackets

### DIFF
--- a/static_default_ports.go
+++ b/static_default_ports.go
@@ -34,7 +34,7 @@ func AddressWithDefault(addr, defaultPort string) string {
 			return addr
 		}
 		if u.Port() == "" {
-			u.Host = net.JoinHostPort(u.Host, defaultPort)
+			u.Host = net.JoinHostPort(u.Hostname(), defaultPort)
 		}
 		return u.String() + templatePart
 	}

--- a/static_default_ports_test.go
+++ b/static_default_ports_test.go
@@ -23,6 +23,11 @@ func TestDefaultPort(t *testing.T) {
 		{"https://localhost/dns-query{?dns}", DoHPort, "https://localhost:443/dns-query{?dns}"},
 		{"https://1.1.1.1:443/dns-query{?dns}", DoHPort, "https://1.1.1.1:443/dns-query{?dns}"},
 
+		// IPv6 addresses
+		{"https://[2620:fe::fe:11]/dns-query", DoHPort, "https://[2620:fe::fe:11]:443/dns-query"},
+		{"https://[2620:fe::fe:11]:443/dns-query", DoHPort, "https://[2620:fe::fe:11]:443/dns-query"},
+		{"https://[::1]/dns-query{?dns}", DoHPort, "https://[::1]:443/dns-query{?dns}"},
+
 		// Invalid endpoints should ideally not be changed
 		{"localhost:", DoTPort, "localhost:"},
 		{"localhost::123", DoTPort, "localhost::123"},


### PR DESCRIPTION
When adding a default port to IPv6 URLs like `https://[2620:fe::fe:11]/dns-query` (Quad9 DNS with ECS support), the code used `u.Host` (which includes brackets) with `net.JoinHostPort`, resulting in `[[2620:fe::fe:11]]:443`.

Use `u.Hostname()` instead, which strips brackets before `JoinHostPort` adds them back correctly.
