### PR TITLE
Apply Go modernize fixes

### DIFF
--- a/cache-redis_test.go
+++ b/cache-redis_test.go
@@ -150,7 +150,7 @@ func TestEncodeDecodePooling(t *testing.T) {
 	}
 
 	// Encode multiple times to test pool reuse
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		encoded, err := encodeCacheAnswer(item)
 		if err != nil {
 			t.Fatalf("iteration %d: encodeCacheAnswer failed: %v", i, err)
@@ -244,7 +244,7 @@ func TestEncodeConcurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(numGoroutines)
 
-	for g := 0; g < numGoroutines; g++ {
+	for g := range numGoroutines {
 		go func(gid int) {
 			defer wg.Done()
 
@@ -264,7 +264,7 @@ func TestEncodeConcurrent(t *testing.T) {
 				Msg:              msg,
 			}
 
-			for i := 0; i < numIterations; i++ {
+			for i := range numIterations {
 				encoded, err := encodeCacheAnswer(item)
 				if err != nil {
 					errs <- err

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -65,7 +65,7 @@ arguments.
 
 type Node struct {
 	id    string
-	value interface{}
+	value any
 }
 
 var _ dag.IDInterface = Node{}

--- a/dohclient.go
+++ b/dohclient.go
@@ -184,7 +184,7 @@ func (d *DoHClient) do(req *http.Request) (*http.Response, error) {
 
 func (d *DoHClient) buildPostRequest(ctx context.Context, msg []byte) (*http.Request, error) {
 	// The URL could be a template. Process it without values since POST doesn't use variables in the URL.
-	u, err := d.template.Expand(map[string]interface{}{})
+	u, err := d.template.Expand(map[string]any{})
 	if err != nil {
 		d.metrics.err.Add("template", 1)
 		return nil, err
@@ -205,7 +205,7 @@ func (d *DoHClient) buildGetRequest(ctx context.Context, msg []byte) (*http.Requ
 	b64 := base64.RawURLEncoding.EncodeToString(msg)
 
 	// The URL must be a template. Process it with the "dns" param containing the encoded query.
-	u, err := d.template.Expand(map[string]interface{}{"dns": b64})
+	u, err := d.template.Expand(map[string]any{"dns": b64})
 	if err != nil {
 		d.metrics.err.Add("template", 1)
 		return nil, err

--- a/fastest-tcp.go
+++ b/fastest-tcp.go
@@ -136,7 +136,7 @@ func (r *FastestTCP) probeFastest(log *slog.Logger, rrs []dns.RR) ([]dns.RR, err
 		// Re-order the list in-place to put the fastest at the top
 		rr := res.rr
 		err := res.err
-		for i := 0; i < len(rrs); i++ {
+		for i := range rrs {
 			if rrs[i] == rr {
 				return rrs, err
 			}
@@ -155,7 +155,7 @@ func (r *FastestTCP) probeAll(log *slog.Logger, rrs []dns.RR) ([]dns.RR, error) 
 	defer cancel()
 	resultCh := r.probe(ctx, log, rrs)
 	results := make([]dns.RR, 0, len(rrs))
-	for i := 0; i < len(rrs); i++ {
+	for range rrs {
 		select {
 		case res := <-resultCh:
 			if res.err != nil {

--- a/fastest.go
+++ b/fastest.go
@@ -37,7 +37,6 @@ func (r *Fastest) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 
 	// Send the query to all resolvers. The responses are collected in a buffered channel
 	for _, resolver := range r.resolvers {
-		resolver := resolver
 		go func() {
 			a, err := resolver.Resolve(q, ci)
 			responseCh <- response{resolver, a, err}

--- a/ip-blocklist-trie.go
+++ b/ip-blocklist-trie.go
@@ -24,7 +24,7 @@ func (t *ipBlocklistTrie) add(n *net.IPNet) {
 	}
 	prefix, _ := n.Mask.Size()
 	p := t.root
-	for i := 0; i < prefix; i++ {
+	for i := range prefix {
 		if p.leaf { // stop if we already have a shorter prefix than this
 			break
 		}

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -146,7 +146,7 @@ func (c *lruCache) resize() {
 		return
 	}
 	drop := len(c.items) - c.maxItems
-	for i := 0; i < drop; i++ {
+	for range drop {
 		item := c.tail.prev
 		item.prev.next = c.tail
 		c.tail.prev = item.prev

--- a/lru-cache_test.go
+++ b/lru-cache_test.go
@@ -18,7 +18,7 @@ func TestLRUAddGet(t *testing.T) {
 	}
 	var items []item
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		msg := new(dns.Msg)
 		msg.SetQuestion(fmt.Sprintf("test%d.com.", i), dns.TypeA)
 		msg.Answer = []dns.RR{

--- a/mac-db.go
+++ b/mac-db.go
@@ -105,7 +105,7 @@ func parseMAC(addr string) ([]byte, error) {
 		return nil, fmt.Errorf("unable to parse mac address %q, expected format 01:23:45:ab:cd:ef", addr)
 	}
 	// Check the format, we need 6 parts with 5 separator characters (:) in it
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if b[(i*3)+2] != ':' {
 			return nil, fmt.Errorf("unable to parse mac address %q, expected format 01:23:45:ab:cd:ef", addr)
 		}

--- a/padding.go
+++ b/padding.go
@@ -2,10 +2,10 @@ package rdns
 
 import "github.com/miekg/dns"
 
-//  QueryPaddingBlockSize is used to pad queries sent over DoT and DoH according to rfc8467
+// QueryPaddingBlockSize is used to pad queries sent over DoT and DoH according to rfc8467
 const QueryPaddingBlockSize = 128
 
-//  ResponsePaddingBlockSize is used to pad responses over DoT and DoH according to rfc8467
+// ResponsePaddingBlockSize is used to pad responses over DoT and DoH according to rfc8467
 const ResponsePaddingBlockSize = 468
 
 // Fixed buffers to draw on for padding (rather than allocate every time)
@@ -49,10 +49,9 @@ func padAnswer(q, a *dns.Msg) {
 	// If padding would make the packet larger than the request EDNS0 allows, we need
 	// to truncate it.
 	if len+padLen > int(edns0q.UDPSize()) {
-		padLen = int(edns0q.UDPSize()) - len
-		if padLen < 0 { // Still doesn't fit? Give up on padding
-			padLen = 0
-		}
+		padLen = max(int(edns0q.UDPSize())-len,
+			// Still doesn't fit? Give up on padding
+			0)
 	}
 	paddingOpt.Padding = respPadBuf[0:padLen]
 }

--- a/request-dedup_test.go
+++ b/request-dedup_test.go
@@ -24,7 +24,7 @@ func TestRequestDedup(t *testing.T) {
 
 	// Send a batch of queries
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/roundrobin_test.go
+++ b/roundrobin_test.go
@@ -17,7 +17,7 @@ func TestRoundRobin(t *testing.T) {
 	q.SetQuestion("test.com.", dns.TypeA)
 
 	// Send 10 queries
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		_, err := g.Resolve(q, ClientInfo{})
 		require.NoError(t, err)
 	}

--- a/route.go
+++ b/route.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -118,7 +119,7 @@ func (r *route) match(q *dns.Msg, ci ClientInfo) bool {
 		opt := q.IsEdns0()
 		if opt != nil {
 			// According to RFC 7871, there should be only one EDNS0_SUBNET option per query.
-            // This code checks only the first found EDNS0_SUBNET option.
+			// This code checks only the first found EDNS0_SUBNET option.
 			for _, s := range opt.Option {
 				if e, ok := s.(*dns.EDNS0_SUBNET); ok {
 					ecsIP = e.Address
@@ -146,11 +147,8 @@ func (r *route) match(q *dns.Msg, ci ClientInfo) bool {
 		if len(r.weekdays) > 0 {
 			weekday := now.Weekday()
 			var weekdayMatch bool
-			for _, wd := range r.weekdays {
-				if weekday == wd {
-					weekdayMatch = true
-					break
-				}
+			if slices.Contains(r.weekdays, weekday) {
+				weekdayMatch = true
 			}
 			if !weekdayMatch {
 				return r.inverted
@@ -227,12 +225,7 @@ func (r *route) matchType(typ uint16) bool {
 	if len(r.types) == 0 {
 		return true
 	}
-	for _, t := range r.types {
-		if t == typ {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(r.types, typ)
 }
 
 // Convert DNS type strings into the numerical type, for example "A" -> 1.


### PR DESCRIPTION
## Summary

- Use integer range loops (`for i := range N`) instead of C-style loops
- Use `any` type alias instead of `interface{}`
- Remove unnecessary loop variable captures (Go 1.22+)
- Use `slices.Contains()` instead of manual search loops
- Use `max()` builtin instead of manual clamping
- Fix comment whitespace

All fixes are behavior-preserving and were applied by the `golang.org/x/tools/go/analysis/passes/modernize` analyzer.