### PR TITLE
Expose ClientInfo fields to Lua scripts

### DIFF
--- a/lua-clientinfo.go
+++ b/lua-clientinfo.go
@@ -1,0 +1,42 @@
+package rdns
+
+import (
+	"fmt"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+const luaClientInfoMetatableName = "ClientInfo"
+
+func (s *LuaScript) RegisterClientInfoType() {
+	L := s.L
+	mt := L.NewTypeMetatable(luaClientInfoMetatableName)
+	L.SetGlobal(luaClientInfoMetatableName, mt)
+	// methods and fields
+	L.SetField(mt, "__index", L.NewFunction(
+		func(L *lua.LState) int {
+			ci, ok := getUserDataArg[ClientInfo](L, 1)
+			if !ok {
+				return 0
+			}
+			fieldName := L.CheckString(2)
+			switch fieldName {
+			case "source_ip":
+				if ci.SourceIP != nil {
+					L.Push(lua.LString(ci.SourceIP.String()))
+				} else {
+					L.Push(lua.LNil)
+				}
+			case "doh_path":
+				L.Push(lua.LString(ci.DoHPath))
+			case "tls_server_name":
+				L.Push(lua.LString(ci.TLSServerName))
+			case "listener":
+				L.Push(lua.LString(ci.Listener))
+			default:
+				L.ArgError(2, fmt.Sprintf("clientinfo does not have field %q", fieldName))
+				return 0
+			}
+			return 1
+		}))
+}

--- a/lua-script.go
+++ b/lua-script.go
@@ -77,7 +77,7 @@ func (s *LuaScript) HasFunction(name string) bool {
 func (s *LuaScript) Call(fnName string, nret int, params ...any) ([]any, error) {
 	args := []lua.LValue{
 		userDataWithMetatable(s.L, luaMessageMetatableName, params[0]),
-		userDataWithMetatable(s.L, "", params[1]),
+		userDataWithMetatable(s.L, luaClientInfoMetatableName, params[1]),
 	}
 
 	// Call the resolve() function in the lua script

--- a/lua.go
+++ b/lua.go
@@ -111,6 +111,7 @@ func (r *Lua) newScript() (*LuaScript, error) {
 	s.RegisterOPTType()
 	s.RegisterEDNS0Types()
 	s.RegisterErrorType()
+	s.RegisterClientInfoType()
 
 	// Inject the resolvers into the state (so they can be used in the script)
 	s.InjectResolvers(r.resolvers)


### PR DESCRIPTION
## Summary

- Add a `ClientInfo` metatable so Lua scripts can read `ci.source_ip`, `ci.doh_path`, `ci.tls_server_name`, and `ci.listener` fields for routing decisions and custom logic
- Previously, the `ci` parameter in `Resolve(msg, ci)` could only be passed opaquely to `resolver:resolve(msg, ci)` — fields were not accessible
- Add documentation and usage examples for the new ClientInfo API

## Test plan

- [x] `TestLuaClientInfoAccess` — verifies all four fields are readable with populated values
- [x] `TestLuaClientInfoNilSourceIP` — verifies nil SourceIP returns `nil` and empty strings work correctly
- [x] All existing Lua tests continue to pass (`go test -run TestLua ./...`)