### PR TITLE
Expose BuildVersion to Lua scripts

### DIFF
--- a/cmd/routedns/example-config/lua-version.toml
+++ b/cmd/routedns/example-config/lua-version.toml
@@ -1,0 +1,35 @@
+# Responds with the RouteDNS version for CH TXT queries to "version.routedns.",
+# similar to BIND's version.bind. All other queries are forwarded upstream.
+
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[groups.version]
+type = "lua"
+lua-script = """
+function Resolve(msg, ci)
+    local a = Message.new():set_reply(msg)
+    a.answer = {
+        RR.new({
+            rtype = TypeTXT,
+            class = ClassCH,
+            name  = msg.questions[1].name,
+            ttl   = 0,
+            txt   = {BuildVersion},
+        })
+    }
+    return a, nil
+end
+"""
+
+[routers.router]
+routes = [
+  { resolver = "version", type = "TXT", class = "CH", name = '(?i)^version\.routedns\.$' },
+  { resolver = "cloudflare-dot" },
+]
+
+[listeners.local-udp]
+address = "127.0.0.1:53"
+protocol = "udp"
+resolver = "router"

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1653,7 +1653,8 @@ Scripts have access to the following types and globals:
 - **ClientInfo** - Client information passed as the second argument (`ci`) to `Resolve(msg, ci)`. Read-only fields: `source_ip` (string or nil), `doh_path` (string), `tls_server_name` (string), `listener` (string).
 - **Error** - Error value. Create with `Error.new("message")`. Methods: `error()`.
 - **Resolvers** - Table of upstream resolvers. Each resolver has a `resolve(msg, ci)` method that returns `(response, error)`.
-- **DNS constants** - Type constants (`TypeA`, `TypeAAAA`, `TypeMX`, ...), class constants (`ClassIN`, ...), rcode constants (`RcodeNOERROR`, `RcodeNXDOMAIN`, ...).
+- **DNS constants** - Type constants (`TypeA`, `TypeAAAA`, `TypeMX`, ...), class constants (`ClassIN`, `ClassCH`, ...), rcode constants (`RcodeNOERROR`, `RcodeNXDOMAIN`, ...).
+- **BuildVersion** - String constant containing the RouteDNS build version (e.g. `"v0.1.138"`).
 - **EDNS0 option constants** - `EDNS0SUBNET`, `EDNS0COOKIE`, `EDNS0EDE`, `EDNS0PADDING`, etc.
 - **EDNS0 types** - `EDNS0_SUBNET`, `EDNS0_COOKIE`, `EDNS0_EDE`, `EDNS0_PADDING`, `EDNS0_NSID`, `EDNS0_LOCAL`, and others. Each has a `new(...)` constructor and field accessors.
 

--- a/lua-types.go
+++ b/lua-types.go
@@ -8,6 +8,9 @@ import (
 func (s *LuaScript) RegisterConstants() {
 	L := s.L
 
+	// Register build version
+	L.SetGlobal("BuildVersion", lua.LString(BuildVersion))
+
 	// Register TypeA, TypeAAAA, etc
 	for value, name := range dns.TypeToString {
 		L.SetGlobal("Type"+name, lua.LNumber(value))

--- a/lua_test.go
+++ b/lua_test.go
@@ -977,3 +977,37 @@ end`,
 	_, err = r.Resolve(q, ci)
 	require.NoError(t, err)
 }
+
+func TestLuaBuildVersionConstant(t *testing.T) {
+	opt := LuaOptions{
+		Script: `
+function Resolve(msg, ci)
+	if BuildVersion == nil or BuildVersion == "" then
+		return nil, Error.new("BuildVersion is not set")
+	end
+	local answer = Message.new():set_reply(msg)
+	answer.answer = {
+		RR.new({rtype = TypeTXT, class = ClassCH, name = msg.questions[1].name, ttl = 0, txt = {BuildVersion}})
+	}
+	return answer, nil
+end`,
+	}
+
+	var ci ClientInfo
+	resolver := new(TestResolver)
+
+	r, err := NewLua("test-lua", opt, resolver)
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("version.routedns.", dns.TypeTXT)
+	q.Question[0].Qclass = dns.ClassCHAOS
+
+	answer, err := r.Resolve(q, ci)
+	require.NoError(t, err)
+	require.Len(t, answer.Answer, 1)
+	txt, ok := answer.Answer[0].(*dns.TXT)
+	require.True(t, ok)
+	require.Equal(t, uint16(dns.ClassCHAOS), txt.Hdr.Class)
+	require.Equal(t, []string{BuildVersion}, txt.Txt)
+}


### PR DESCRIPTION
## Summary
- Registers `BuildVersion` as a Lua string global in `RegisterConstants()`, so scripts can access the RouteDNS version without `io.popen` or disabling the sandbox
- Documents `BuildVersion` and `ClassCH` in the Lua section of `doc/configuration.md`
- Adds `lua-version.toml` example config implementing a `version.routedns.` CH TXT responder (similar to BIND's `version.bind`)
- Adds `TestLuaBuildVersionConstant` test

## Context
Requested in https://github.com/folbricht/routedns/pull/453#issuecomment-4008947011 — the commenter wanted a `version.bind`-style responder. This was already possible with `lua-no-sandbox = true` and `io.popen`, but exposing `BuildVersion` directly makes it work safely within the sandbox.

## Test plan
- [x] `go test -run TestLuaBuildVersionConstant` passes
- [x] All existing Lua tests pass (`go test -run TestLua`)
- [x] `go build ./...` succeeds