### PR TITLE
Expose authoritative field in Lua Message type

### DIFF
--- a/cmd/routedns/example-config/lua-version.toml
+++ b/cmd/routedns/example-config/lua-version.toml
@@ -10,6 +10,7 @@ type = "lua"
 lua-script = """
 function Resolve(msg, ci)
     local a = Message.new():set_reply(msg)
+    a.authoritative = true
     a.answer = {
         RR.new({
             rtype = TypeTXT,

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1646,13 +1646,13 @@ Set `lua-no-sandbox = true` to disable the sandbox and allow full access to all 
 
 Scripts have access to the following types and globals:
 
-- **Message** - DNS message. Create with `Message.new()`. Fields: `id`, `response`, `rcode`, `recursion_desired`, `recursion_available`, `authenticated_data`, `questions`, `answer`, `ns`, `extra`. Methods: `set_reply(request)`, `set_question(name, type)`, `is_edns0()`, `set_edns0(udpsize, do)`.
+- **Message** - DNS message. Create with `Message.new()`. Fields: `id`, `response`, `rcode`, `authoritative`, `recursion_desired`, `recursion_available`, `authenticated_data`, `questions`, `answer`, `ns`, `extra`. Methods: `:set_reply(request)`, `:set_question(name, type)`, `:is_edns0()`, `:set_edns0(udpsize, do)`. Note: methods use Lua colon syntax (e.g. `msg:set_reply(request)`).
 - **Question** - DNS question. Create with `Question.new(name, qtype, qclass)`. Fields: `name`, `qtype`, `qclass`.
 - **RR** - Resource record. Create with `RR.new({rtype = TypeA, name = "example.com.", class = ClassIN, ttl = 300, a = "1.2.3.4"})`. Header fields: `name`, `rtype`, `class`, `ttl`, `rdlength`. Data fields are type-specific and use lowercase names (e.g., `a`, `aaaa`, `ns`, `cname`, `mx`, `preference`, `target`, etc.).
 - **OPT** - EDNS0 OPT pseudo-record. Create with `OPT.new(udp_size, do_bit)`. Fields: `udp_size`, `do_bit`, `version`, `extended_rcode`, `option` (array of EDNS0 options), `name`, `rtype`. Also returned by `Message:is_edns0()` and created implicitly by `Message:set_edns0(udp_size, do_bit)`.
 - **ClientInfo** - Client information passed as the second argument (`ci`) to `Resolve(msg, ci)`. Read-only fields: `source_ip` (string or nil), `doh_path` (string), `tls_server_name` (string), `listener` (string).
 - **Error** - Error value. Create with `Error.new("message")`. Methods: `error()`.
-- **Resolvers** - Table of upstream resolvers. Each resolver has a `resolve(msg, ci)` method that returns `(response, error)`.
+- **Resolvers** - Table of upstream resolvers. Each resolver has a `:resolve(msg, ci)` method that returns `(response, error)` (e.g. `Resolvers[1]:resolve(msg, ci)`).
 - **DNS constants** - Type constants (`TypeA`, `TypeAAAA`, `TypeMX`, ...), class constants (`ClassIN`, `ClassCH`, ...), rcode constants (`RcodeNOERROR`, `RcodeNXDOMAIN`, ...).
 - **BuildVersion** - String constant containing the RouteDNS build version (e.g. `"v0.1.138"`).
 - **EDNS0 option constants** - `EDNS0SUBNET`, `EDNS0COOKIE`, `EDNS0EDE`, `EDNS0PADDING`, etc.

--- a/lua-message.go
+++ b/lua-message.go
@@ -46,6 +46,8 @@ func (s *LuaScript) RegisterMessageType() {
 				L.Push(lua.LBool(msg.RecursionDesired))
 			case "recursion_available":
 				L.Push(lua.LBool(msg.RecursionAvailable))
+			case "authoritative":
+				L.Push(lua.LBool(msg.Authoritative))
 			case "authenticated_data":
 				L.Push(lua.LBool(msg.AuthenticatedData))
 			case "answer":
@@ -137,6 +139,8 @@ func (s *LuaScript) RegisterMessageType() {
 				msg.RecursionDesired = L.CheckBool(3)
 			case "recursion_available":
 				msg.RecursionAvailable = L.CheckBool(3)
+			case "authoritative":
+				msg.Authoritative = L.CheckBool(3)
 			case "authenticated_data":
 				msg.AuthenticatedData = L.CheckBool(3)
 			case "answer":

--- a/lua_test.go
+++ b/lua_test.go
@@ -1011,3 +1011,30 @@ end`,
 	require.Equal(t, uint16(dns.ClassCHAOS), txt.Hdr.Class)
 	require.Equal(t, []string{BuildVersion}, txt.Txt)
 }
+
+func TestLuaAuthoritativeField(t *testing.T) {
+	opt := LuaOptions{
+		Script: `
+function Resolve(msg, ci)
+	local answer = Message.new():set_reply(msg)
+	answer.authoritative = true
+	if not answer.authoritative then
+		return nil, Error.new("authoritative not set")
+	end
+	return answer, nil
+end`,
+	}
+
+	var ci ClientInfo
+	resolver := new(TestResolver)
+
+	r, err := NewLua("test-lua", opt, resolver)
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	answer, err := r.Resolve(q, ci)
+	require.NoError(t, err)
+	require.True(t, answer.Authoritative)
+}


### PR DESCRIPTION
## Summary
- Add read/write support for the `authoritative` (aa) bit on Lua Message, so scripts can set `answer.authoritative = true`
- Fix Lua API docs to use colon syntax for methods (`:set_reply`, `:set_question`, `:resolve`, etc.) to prevent confusion with dot syntax
- Set the authoritative bit in the `lua-version.toml` example config

Addresses feedback from https://github.com/folbricht/routedns/pull/453#issuecomment-4013550805

## Test plan
- [x] `TestLuaAuthoritativeField` passes
- [x] All existing Lua tests pass
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)