### PR TITLE
Remove NXDOMAIN special-case from isSuccessResponse()

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -563,7 +563,7 @@ Options:
 
 - `resolvers` - An array of upstream resolvers or modifiers.
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure triggering a switch to the next resolver. This can happen when DNSSEC validation fails for example. Default `false`.
-- `empty-error` - If `true`, an empty response from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
+- `empty-error` - If `true`, an empty response (including NXDOMAIN) from an upstream resolver is considered a failure triggering a switch to the next resolver. Responses with EDE codes Blocked/Censored/Filtered are still considered successful. Default `false`.
 
 #### Examples
 
@@ -586,7 +586,7 @@ Options:
 - `resolvers` - An array of upstream resolvers or modifiers. The first in the array is the preferred resolver.
 - `reset-after` - Non-zero time in seconds before switching from an alternative resolver back to the preferred resolver (first in the list), or a negative number to switch back immediately, default 60. Note: This is not a timeout argument. After a failure of the preferred resolver, this defines the amount of time to use alternative/failover resolvers before switching back to the preferred. You can have as many resolvers in the array as the time limit allows.
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure triggering a failover. This can happen when DNSSEC validation fails for example. Default `false`.
-- `empty-error` - If `true`, an empty response from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
+- `empty-error` - If `true`, an empty response (including NXDOMAIN) from an upstream resolver is considered a failure triggering a switch to the next resolver. Responses with EDE codes Blocked/Censored/Filtered are still considered successful. Default `false`.
 
 #### Examples
 
@@ -609,7 +609,7 @@ Options:
 - `resolvers` - An array of upstream resolvers or modifiers.
 - `reset-after` - Non-zero time in seconds to disable a failed resolver, or a negative number to disable only for a single request, default 60.
 - `servfail-error` - If `true`, a SERVFAIL response from an upstream resolver is considered a failure which will take the resolver temporarily out of the group. This can happen when DNSSEC validation fails for example. Default `false`.
-- `empty-error` - If `true`, an empty response from an upstream resolver is considered a failure triggering a switch to the next resolver. Default `false`.
+- `empty-error` - If `true`, an empty response (including NXDOMAIN) from an upstream resolver is considered a failure triggering a switch to the next resolver. Responses with EDE codes Blocked/Censored/Filtered are still considered successful. Default `false`.
 
 #### Examples
 

--- a/failback.go
+++ b/failback.go
@@ -175,9 +175,6 @@ func (r *FailBack) isSuccessResponse(a *dns.Msg) bool {
 	if a.Rcode == dns.RcodeServerFailure && r.opt.ServfailError || a.Rcode == dns.RcodeRefused || a.Rcode == dns.RcodeNotImplemented {
 		return false
 	}
-	if a.Rcode == dns.RcodeNameError {
-		return true
-	}
 	if !r.opt.EmptyError {
 		return true
 	}

--- a/failback_test.go
+++ b/failback_test.go
@@ -218,6 +218,13 @@ func TestFailBackIsSuccessResponse(t *testing.T) {
 	t.Run("NXDomainWithEmptyError", func(t *testing.T) {
 		fb := newFB(FailBackOptions{EmptyError: true})
 		msg := newMsg(dns.TypeA, dns.RcodeNameError)
+		require.False(t, fb.isSuccessResponse(msg))
+	})
+
+	t.Run("NXDomainWithEmptyErrorAndEDE", func(t *testing.T) {
+		fb := newFB(FailBackOptions{EmptyError: true})
+		msg := newMsg(dns.TypeA, dns.RcodeNameError)
+		addEDE(msg, dns.ExtendedErrorCodeBlocked)
 		require.True(t, fb.isSuccessResponse(msg))
 	})
 

--- a/failrotate.go
+++ b/failrotate.go
@@ -104,9 +104,6 @@ func (r *FailRotate) isSuccessResponse(a *dns.Msg) bool {
 	if a.Rcode == dns.RcodeServerFailure && r.opt.ServfailError || a.Rcode == dns.RcodeRefused || a.Rcode == dns.RcodeNotImplemented {
 		return false
 	}
-	if a.Rcode == dns.RcodeNameError {
-		return true
-	}
 	if !r.opt.EmptyError {
 		return true
 	}

--- a/random.go
+++ b/random.go
@@ -127,9 +127,6 @@ func (r *Random) isSuccessResponse(a *dns.Msg) bool {
 	if a.Rcode == dns.RcodeServerFailure && r.opt.ServfailError || a.Rcode == dns.RcodeRefused || a.Rcode == dns.RcodeNotImplemented {
 		return false
 	}
-	if a.Rcode == dns.RcodeNameError {
-		return true
-	}
 	if !r.opt.EmptyError {
 		return true
 	}


### PR DESCRIPTION
## Summary

- Reverts the NXDOMAIN bypass (commit `05d7790`) from `isSuccessResponse()` in failback, failrotate, and random groups. NXDOMAIN now flows through the normal `EmptyError` logic instead of being unconditionally treated as success.
- When `EmptyError=false` (default): no behavior change — NXDOMAIN still returns success via the `!r.opt.EmptyError` fallback.
- When `EmptyError=true`: NXDOMAIN now triggers rotation, unless an EDE code (Blocked/Censored/Filtered) indicates intentional blocking.
- Updates `empty-error` documentation to clarify NXDOMAIN and EDE behavior.
- Adds test for NXDOMAIN + EmptyError + EDE Blocked.

Addresses feedback from #500.