### PR TITLE
Add release workflow for prebuilt binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,76 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: linux
+            goarch: arm
+            goarm: "7"
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+          - goos: freebsd
+            goarch: amd64
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          GOARM: ${{ matrix.goarm }}
+        run: |
+          EXT=""
+          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
+          SUFFIX="${GOOS}-${GOARCH}"
+          if [ -n "$GOARM" ]; then SUFFIX="${SUFFIX}v${GOARM}"; fi
+          go build -trimpath -o "routedns-${SUFFIX}${EXT}" ./cmd/routedns
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: routedns-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goarm && format('v{0}', matrix.goarm) || '' }}
+          path: routedns-*
+
+  publish:
+    name: Publish Release
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*


### PR DESCRIPTION
## Summary

- Adds a new `release.yaml` workflow triggered on tag pushes (`v*`)
- Cross-compiles `routedns` binaries for 7 platform/arch combinations:
  - linux: amd64, arm64, armv7
  - darwin: amd64, arm64
  - windows: amd64
  - freebsd: amd64
- Creates a GitHub Release with auto-generated release notes and all binaries attached
- Uses `softprops/action-gh-release@v2` for release publishing