### PR TITLE
Fix release workflow not triggering on version bump

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -34,6 +39,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -72,5 +79,6 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: artifacts/*

--- a/.github/workflows/version_bump.yaml
+++ b/.github/workflows/version_bump.yaml
@@ -17,6 +17,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -30,6 +32,7 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script
+        id: version
         run: |
           echo $PWD
 
@@ -67,3 +70,14 @@ jobs:
           # PUSH
           git push origin HEAD:master
           git push origin --follow-tags
+
+          # Output tag for release workflow
+          echo "tag=$CHANGE_BUILD_VERSION" >> "$GITHUB_OUTPUT"
+
+  release:
+    needs: build
+    uses: ./.github/workflows/release.yaml
+    with:
+      tag: ${{ needs.build.outputs.tag }}
+    permissions:
+      contents: write


### PR DESCRIPTION
## Summary

- Tags pushed by `GITHUB_TOKEN` don't trigger other workflows (GitHub limitation to prevent recursive triggers)
- The version_bump workflow now calls the release workflow directly via `workflow_call`, passing the tag name as an input
- The release workflow accepts an optional `tag` input for checkout and release creation, falling back to `github.ref` for direct tag-push triggers