### PR TITLE
Implement DNS64 support (RFC 6147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Listeners receive queries over any supported protocol. Routers, groups and modif
 
 **Query Processing**
 - DNSSEC validation with IANA trust anchor support
+- DNS64 for NAT64 networks ([RFC 6147](https://datatracker.ietf.org/doc/html/rfc6147)) — synthesize AAAA from A records
 - Blocklists — domain, regex, hosts-file, wildcard formats with auto-refresh from HTTP/file sources
 - Response blocklists — filter by response name, IP/CIDR, GeoIP country, or ASN
 - MAC address filtering via EDNS0

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -215,6 +215,9 @@ type group struct {
 	DNSSECTrustAnchors   []trustAnchor `toml:"dnssec-trust-anchors"`
 	DNSSECTrustAnchorURL string        `toml:"dnssec-trust-anchor-url"`
 	DNSSECLogOnly        bool          `toml:"dnssec-log-only"`
+
+	// DNS64 options
+	DNS64Prefix []string `toml:"dns64-prefix"`
 }
 
 type trustAnchor struct {

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -948,6 +948,17 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 		if err != nil {
 			return err
 		}
+	case "dns64":
+		if len(gr) != 1 {
+			return fmt.Errorf("type dns64 only supports one resolver in '%s'", id)
+		}
+		opt := rdns.DNS64Options{
+			Prefixes: g.DNS64Prefix,
+		}
+		resolvers[id], err = rdns.NewDNS64(id, gr[0], opt)
+		if err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("unsupported group type '%s' for group '%s'", g.Type, id)
 	}

--- a/dns64.go
+++ b/dns64.go
@@ -1,0 +1,255 @@
+package rdns
+
+import (
+	"expvar"
+	"fmt"
+	"net"
+
+	"github.com/miekg/dns"
+)
+
+// DNS64 is a resolver that synthesizes AAAA records from A records for
+// IPv6-only clients using NAT64 (RFC 6147). When an AAAA query returns
+// no AAAA answers, it falls back to an A query and embeds the IPv4
+// addresses into configurable IPv6 prefixes per RFC 6052.
+type DNS64 struct {
+	id       string
+	resolver Resolver
+	DNS64Options
+	prefixes []dns64Prefix
+	metrics  *dns64Metrics
+}
+
+// DNS64Options contains configuration for the DNS64 modifier.
+type DNS64Options struct {
+	// IPv6 prefixes used for address synthesis per RFC 6052.
+	// Each string is a CIDR like "64:ff9b::/96".
+	// Only prefix lengths /32, /40, /48, /56, /64, /96 are allowed.
+	// Default: ["64:ff9b::/96"] (well-known prefix)
+	Prefixes []string
+}
+
+type dns64Prefix struct {
+	ip        net.IP // 16-byte IPv6 network address
+	prefixLen int    // one of 32, 40, 48, 56, 64, 96
+}
+
+type dns64Metrics struct {
+	query    *expvar.Int
+	synth    *expvar.Int
+	passthru *expvar.Int
+	err      *expvar.Int
+}
+
+var _ Resolver = &DNS64{}
+
+// NewDNS64 returns a new DNS64 modifier instance.
+func NewDNS64(id string, resolver Resolver, opt DNS64Options) (*DNS64, error) {
+	if len(opt.Prefixes) == 0 {
+		opt.Prefixes = []string{"64:ff9b::/96"}
+	}
+	prefixes, err := parseDNS64Prefixes(opt.Prefixes)
+	if err != nil {
+		return nil, err
+	}
+	return &DNS64{
+		id:           id,
+		resolver:     resolver,
+		DNS64Options: opt,
+		prefixes:     prefixes,
+		metrics: &dns64Metrics{
+			query:    getVarInt("dns64", id, "query"),
+			synth:    getVarInt("dns64", id, "synth"),
+			passthru: getVarInt("dns64", id, "passthru"),
+			err:      getVarInt("dns64", id, "err"),
+		},
+	}, nil
+}
+
+// Resolve a DNS query. For AAAA queries without native AAAA answers,
+// synthesizes AAAA records from A records using the configured prefixes.
+func (r *DNS64) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+	question := q.Question[0]
+
+	// Non-AAAA queries pass through unchanged
+	if question.Qtype != dns.TypeAAAA {
+		r.metrics.passthru.Add(1)
+		return r.resolver.Resolve(q, ci)
+	}
+
+	r.metrics.query.Add(1)
+	log := logger(r.id, q, ci)
+
+	// Forward the AAAA query upstream
+	answer, err := r.resolver.Resolve(q, ci)
+	if err != nil {
+		r.metrics.err.Add(1)
+		return answer, err
+	}
+	if answer == nil {
+		return answer, nil
+	}
+
+	// Non-success responses (including NXDOMAIN) pass through
+	if answer.Rcode != dns.RcodeSuccess {
+		r.metrics.passthru.Add(1)
+		return answer, nil
+	}
+
+	// If upstream returned AAAA records, pass through
+	if hasAAAARecords(answer) {
+		r.metrics.passthru.Add(1)
+		log.Debug("upstream has native AAAA records, passing through")
+		return answer, nil
+	}
+
+	// No AAAA records — query for A records and synthesize
+	log.Debug("no AAAA records from upstream, querying for A records")
+
+	aQuery := q.Copy()
+	aQuery.Question[0].Qtype = dns.TypeA
+
+	aAnswer, err := r.resolver.Resolve(aQuery, ci)
+	if err != nil {
+		r.metrics.err.Add(1)
+		return answer, nil // Return original NODATA on error
+	}
+	if aAnswer == nil || aAnswer.Rcode != dns.RcodeSuccess {
+		r.metrics.passthru.Add(1)
+		return answer, nil // Return original NODATA
+	}
+
+	// Synthesize AAAA records from A records
+	synthesized := r.synthesizeAAAA(aAnswer, question)
+	if len(synthesized) == 0 {
+		r.metrics.passthru.Add(1)
+		return answer, nil
+	}
+
+	r.metrics.synth.Add(1)
+	log.Debug("synthesized AAAA records from A records", "count", len(synthesized))
+
+	resp := new(dns.Msg)
+	resp.SetReply(q)
+	resp.RecursionAvailable = answer.RecursionAvailable
+	resp.Answer = synthesized
+	resp.Ns = aAnswer.Ns
+	resp.Extra = aAnswer.Extra
+	return resp, nil
+}
+
+func (r *DNS64) String() string {
+	return r.id
+}
+
+// synthesizeAAAA creates AAAA records from A records in the response.
+func (r *DNS64) synthesizeAAAA(aAnswer *dns.Msg, question dns.Question) []dns.RR {
+	var result []dns.RR
+	for _, rr := range aAnswer.Answer {
+		aRecord, ok := rr.(*dns.A)
+		if !ok {
+			continue
+		}
+		ipv4 := aRecord.A.To4()
+		if ipv4 == nil {
+			continue
+		}
+		for _, prefix := range r.prefixes {
+			ipv6 := synthesizeIPv6(prefix, ipv4)
+			result = append(result, &dns.AAAA{
+				Hdr: dns.RR_Header{
+					Name:   question.Name,
+					Rrtype: dns.TypeAAAA,
+					Class:  question.Qclass,
+					Ttl:    aRecord.Hdr.Ttl,
+				},
+				AAAA: ipv6,
+			})
+		}
+	}
+	return result
+}
+
+// hasAAAARecords returns true if the message contains any AAAA answer records.
+func hasAAAARecords(msg *dns.Msg) bool {
+	for _, rr := range msg.Answer {
+		if rr.Header().Rrtype == dns.TypeAAAA {
+			return true
+		}
+	}
+	return false
+}
+
+// synthesizeIPv6 embeds an IPv4 address into an IPv6 prefix per RFC 6052
+// Section 2.2. Bits 64-71 (byte index 8) are always zero for prefix
+// lengths shorter than /96.
+func synthesizeIPv6(prefix dns64Prefix, ipv4 net.IP) net.IP {
+	ipv4 = ipv4.To4()
+	ipv6 := make(net.IP, net.IPv6len)
+	copy(ipv6, prefix.ip)
+
+	switch prefix.prefixLen {
+	case 96:
+		ipv6[12] = ipv4[0]
+		ipv6[13] = ipv4[1]
+		ipv6[14] = ipv4[2]
+		ipv6[15] = ipv4[3]
+	case 64:
+		ipv6[8] = 0
+		ipv6[9] = ipv4[0]
+		ipv6[10] = ipv4[1]
+		ipv6[11] = ipv4[2]
+		ipv6[12] = ipv4[3]
+	case 56:
+		ipv6[7] = ipv4[0]
+		ipv6[8] = 0
+		ipv6[9] = ipv4[1]
+		ipv6[10] = ipv4[2]
+		ipv6[11] = ipv4[3]
+	case 48:
+		ipv6[6] = ipv4[0]
+		ipv6[7] = ipv4[1]
+		ipv6[8] = 0
+		ipv6[9] = ipv4[2]
+		ipv6[10] = ipv4[3]
+	case 40:
+		ipv6[5] = ipv4[0]
+		ipv6[6] = ipv4[1]
+		ipv6[7] = ipv4[2]
+		ipv6[8] = 0
+		ipv6[9] = ipv4[3]
+	case 32:
+		ipv6[4] = ipv4[0]
+		ipv6[5] = ipv4[1]
+		ipv6[6] = ipv4[2]
+		ipv6[7] = ipv4[3]
+		ipv6[8] = 0
+	}
+
+	return ipv6
+}
+
+// parseDNS64Prefixes parses and validates DNS64 prefix strings.
+func parseDNS64Prefixes(prefixStrs []string) ([]dns64Prefix, error) {
+	validLengths := map[int]bool{32: true, 40: true, 48: true, 56: true, 64: true, 96: true}
+
+	var prefixes []dns64Prefix
+	for _, s := range prefixStrs {
+		_, ipNet, err := net.ParseCIDR(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid DNS64 prefix %q: %w", s, err)
+		}
+		ones, bits := ipNet.Mask.Size()
+		if bits != 128 {
+			return nil, fmt.Errorf("DNS64 prefix %q must be an IPv6 CIDR", s)
+		}
+		if !validLengths[ones] {
+			return nil, fmt.Errorf("DNS64 prefix %q has unsupported prefix length /%d; must be /32, /40, /48, /56, /64, or /96", s, ones)
+		}
+		prefixes = append(prefixes, dns64Prefix{
+			ip:        ipNet.IP.To16(),
+			prefixLen: ones,
+		})
+	}
+	return prefixes, nil
+}

--- a/dns64.go
+++ b/dns64.go
@@ -77,6 +77,13 @@ func (r *DNS64) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		return r.resolver.Resolve(q, ci)
 	}
 
+	// Per RFC 6147 Section 3: do not synthesize when the client sets the
+	// DO (DNSSEC OK) bit, as synthesized records cannot be validated.
+	if edns0 := q.IsEdns0(); edns0 != nil && edns0.Do() {
+		r.metrics.passthru.Add(1)
+		return r.resolver.Resolve(q, ci)
+	}
+
 	r.metrics.query.Add(1)
 	log := logger(r.id, q, ci)
 
@@ -143,31 +150,38 @@ func (r *DNS64) String() string {
 }
 
 // synthesizeAAAA creates AAAA records from A records in the response.
+// CNAME records from the A response are preserved and prepended to the
+// synthesized AAAA records to maintain the CNAME chain.
 func (r *DNS64) synthesizeAAAA(aAnswer *dns.Msg, question dns.Question) []dns.RR {
-	var result []dns.RR
+	var cnames []dns.RR
+	var aaaa []dns.RR
 	for _, rr := range aAnswer.Answer {
-		aRecord, ok := rr.(*dns.A)
-		if !ok {
-			continue
-		}
-		ipv4 := aRecord.A.To4()
-		if ipv4 == nil {
-			continue
-		}
-		for _, prefix := range r.prefixes {
-			ipv6 := synthesizeIPv6(prefix, ipv4)
-			result = append(result, &dns.AAAA{
-				Hdr: dns.RR_Header{
-					Name:   question.Name,
-					Rrtype: dns.TypeAAAA,
-					Class:  question.Qclass,
-					Ttl:    aRecord.Hdr.Ttl,
-				},
-				AAAA: ipv6,
-			})
+		switch rec := rr.(type) {
+		case *dns.CNAME:
+			cnames = append(cnames, rec)
+		case *dns.A:
+			ipv4 := rec.A.To4()
+			if ipv4 == nil {
+				continue
+			}
+			for _, prefix := range r.prefixes {
+				ipv6 := synthesizeIPv6(prefix, ipv4)
+				aaaa = append(aaaa, &dns.AAAA{
+					Hdr: dns.RR_Header{
+						Name:   question.Name,
+						Rrtype: dns.TypeAAAA,
+						Class:  question.Qclass,
+						Ttl:    rec.Hdr.Ttl,
+					},
+					AAAA: ipv6,
+				})
+			}
 		}
 	}
-	return result
+	if len(aaaa) == 0 {
+		return nil
+	}
+	return append(cnames, aaaa...)
 }
 
 // hasAAAARecords returns true if the message contains any AAAA answer records.

--- a/dns64_test.go
+++ b/dns64_test.go
@@ -1,0 +1,315 @@
+package rdns
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSynthesizeIPv6_96(t *testing.T) {
+	prefixes, err := parseDNS64Prefixes([]string{"64:ff9b::/96"})
+	require.NoError(t, err)
+	result := synthesizeIPv6(prefixes[0], net.IP{192, 0, 2, 33})
+	expected := net.ParseIP("64:ff9b::c000:221")
+	require.Equal(t, expected.To16(), result)
+}
+
+func TestSynthesizeIPv6_64(t *testing.T) {
+	prefixes, err := parseDNS64Prefixes([]string{"2001:db8:122:344::/64"})
+	require.NoError(t, err)
+	result := synthesizeIPv6(prefixes[0], net.IP{192, 0, 2, 33})
+	expected := net.ParseIP("2001:db8:122:344:00c0:0002:2100:0000")
+	require.Equal(t, expected.To16(), result)
+}
+
+func TestSynthesizeIPv6_56(t *testing.T) {
+	prefixes, err := parseDNS64Prefixes([]string{"2001:db8:122:300::/56"})
+	require.NoError(t, err)
+	result := synthesizeIPv6(prefixes[0], net.IP{192, 0, 2, 33})
+	expected := net.ParseIP("2001:db8:122:3c0:0:0221:0:0")
+	require.Equal(t, expected.To16(), result)
+}
+
+func TestSynthesizeIPv6_48(t *testing.T) {
+	prefixes, err := parseDNS64Prefixes([]string{"2001:db8:122::/48"})
+	require.NoError(t, err)
+	result := synthesizeIPv6(prefixes[0], net.IP{192, 0, 2, 33})
+	expected := net.ParseIP("2001:db8:122:c000:0002:2100::")
+	require.Equal(t, expected.To16(), result)
+}
+
+func TestSynthesizeIPv6_40(t *testing.T) {
+	prefixes, err := parseDNS64Prefixes([]string{"2001:db8:100::/40"})
+	require.NoError(t, err)
+	result := synthesizeIPv6(prefixes[0], net.IP{192, 0, 2, 33})
+	expected := net.ParseIP("2001:db8:1c0:0002:0021::")
+	require.Equal(t, expected.To16(), result)
+}
+
+func TestSynthesizeIPv6_32(t *testing.T) {
+	prefixes, err := parseDNS64Prefixes([]string{"2001:db8::/32"})
+	require.NoError(t, err)
+	result := synthesizeIPv6(prefixes[0], net.IP{192, 0, 2, 33})
+	expected := net.ParseIP("2001:db8:c000:0221::")
+	require.Equal(t, expected.To16(), result)
+}
+
+func TestParseDNS64Prefixes(t *testing.T) {
+	// Valid prefixes
+	for _, cidr := range []string{
+		"64:ff9b::/96",
+		"2001:db8::/32",
+		"2001:db8:100::/40",
+		"2001:db8:122::/48",
+		"2001:db8:122:300::/56",
+		"2001:db8:122:344::/64",
+	} {
+		_, err := parseDNS64Prefixes([]string{cidr})
+		require.NoError(t, err, "should accept %s", cidr)
+	}
+
+	// Invalid: bad CIDR
+	_, err := parseDNS64Prefixes([]string{"not-a-cidr"})
+	require.Error(t, err)
+
+	// Invalid: IPv4 CIDR
+	_, err = parseDNS64Prefixes([]string{"192.168.0.0/24"})
+	require.Error(t, err)
+
+	// Invalid: unsupported prefix length
+	_, err = parseDNS64Prefixes([]string{"2001:db8::/80"})
+	require.Error(t, err)
+}
+
+func TestDNS64PassthroughNonAAAA(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			a.Answer = []dns.RR{
+				&dns.A{
+					Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+					A:   net.IP{1, 2, 3, 4},
+				},
+			}
+			return a, nil
+		},
+	}
+	d, err := NewDNS64("test", upstream, DNS64Options{})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Len(t, a.Answer, 1)
+	require.Equal(t, dns.TypeA, a.Answer[0].Header().Rrtype)
+}
+
+func TestDNS64NativeAAAA(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			a.Answer = []dns.RR{
+				&dns.AAAA{
+					Hdr:  dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 300},
+					AAAA: net.ParseIP("2001:db8::1"),
+				},
+			}
+			return a, nil
+		},
+	}
+	d, err := NewDNS64("test", upstream, DNS64Options{})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeAAAA)
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Len(t, a.Answer, 1)
+	require.Equal(t, dns.TypeAAAA, a.Answer[0].Header().Rrtype)
+	require.Equal(t, net.ParseIP("2001:db8::1").To16(), a.Answer[0].(*dns.AAAA).AAAA.To16())
+}
+
+func TestDNS64Synthesize(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			if q.Question[0].Qtype == dns.TypeAAAA {
+				// No AAAA records
+				return a, nil
+			}
+			if q.Question[0].Qtype == dns.TypeA {
+				a.Answer = []dns.RR{
+					&dns.A{
+						Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+						A:   net.IP{192, 0, 2, 1},
+					},
+				}
+			}
+			return a, nil
+		},
+	}
+	d, err := NewDNS64("test", upstream, DNS64Options{
+		Prefixes: []string{"64:ff9b::/96"},
+	})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeAAAA)
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Len(t, a.Answer, 1)
+	require.Equal(t, dns.TypeAAAA, a.Answer[0].Header().Rrtype)
+	require.Equal(t, uint32(300), a.Answer[0].Header().Ttl)
+	require.Equal(t, net.ParseIP("64:ff9b::c000:201").To16(), a.Answer[0].(*dns.AAAA).AAAA.To16())
+}
+
+func TestDNS64SynthesizeMultipleARecords(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			if q.Question[0].Qtype == dns.TypeA {
+				a.Answer = []dns.RR{
+					&dns.A{
+						Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+						A:   net.IP{192, 0, 2, 1},
+					},
+					&dns.A{
+						Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 600},
+						A:   net.IP{192, 0, 2, 2},
+					},
+				}
+			}
+			return a, nil
+		},
+	}
+	d, err := NewDNS64("test", upstream, DNS64Options{})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeAAAA)
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Len(t, a.Answer, 2)
+	require.Equal(t, net.ParseIP("64:ff9b::c000:201").To16(), a.Answer[0].(*dns.AAAA).AAAA.To16())
+	require.Equal(t, net.ParseIP("64:ff9b::c000:202").To16(), a.Answer[1].(*dns.AAAA).AAAA.To16())
+}
+
+func TestDNS64SynthesizeMultiplePrefixes(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			if q.Question[0].Qtype == dns.TypeA {
+				a.Answer = []dns.RR{
+					&dns.A{
+						Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+						A:   net.IP{192, 0, 2, 1},
+					},
+				}
+			}
+			return a, nil
+		},
+	}
+	d, err := NewDNS64("test", upstream, DNS64Options{
+		Prefixes: []string{"64:ff9b::/96", "2001:db8::/32"},
+	})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeAAAA)
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Len(t, a.Answer, 2)
+	require.Equal(t, net.ParseIP("64:ff9b::c000:201").To16(), a.Answer[0].(*dns.AAAA).AAAA.To16())
+	require.Equal(t, net.ParseIP("2001:db8:c000:0201::").To16(), a.Answer[1].(*dns.AAAA).AAAA.To16())
+}
+
+func TestDNS64NXDOMAIN(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetRcode(q, dns.RcodeNameError)
+			return a, nil
+		},
+	}
+	d, err := NewDNS64("test", upstream, DNS64Options{})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("nonexistent.example.com.", dns.TypeAAAA)
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Equal(t, dns.RcodeNameError, a.Rcode)
+}
+
+func TestDNS64DefaultPrefix(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			if q.Question[0].Qtype == dns.TypeA {
+				a.Answer = []dns.RR{
+					&dns.A{
+						Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+						A:   net.IP{10, 0, 0, 1},
+					},
+				}
+			}
+			return a, nil
+		},
+	}
+	// Empty options should use default 64:ff9b::/96
+	d, err := NewDNS64("test", upstream, DNS64Options{})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeAAAA)
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Len(t, a.Answer, 1)
+	require.Equal(t, net.ParseIP("64:ff9b::a00:1").To16(), a.Answer[0].(*dns.AAAA).AAAA.To16())
+}
+
+func TestDNS64UpstreamError(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetRcode(q, dns.RcodeServerFailure)
+			return a, nil
+		},
+	}
+	d, err := NewDNS64("test", upstream, DNS64Options{})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeAAAA)
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Equal(t, dns.RcodeServerFailure, a.Rcode)
+}
+
+func TestDNS64NoARecordsEither(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			// Empty answer for both AAAA and A
+			return a, nil
+		},
+	}
+	d, err := NewDNS64("test", upstream, DNS64Options{})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeAAAA)
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Empty(t, a.Answer)
+}

--- a/dns64_test.go
+++ b/dns64_test.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"errors"
 	"net"
 	"testing"
 
@@ -293,6 +294,92 @@ func TestDNS64UpstreamError(t *testing.T) {
 	a, err := d.Resolve(q, ClientInfo{})
 	require.NoError(t, err)
 	require.Equal(t, dns.RcodeServerFailure, a.Rcode)
+}
+
+func TestDNS64SynthesizeWithCNAME(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			if q.Question[0].Qtype == dns.TypeAAAA {
+				return a, nil
+			}
+			if q.Question[0].Qtype == dns.TypeA {
+				a.Answer = []dns.RR{
+					&dns.CNAME{
+						Hdr:    dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+						Target: "cdn.example.com.",
+					},
+					&dns.A{
+						Hdr: dns.RR_Header{Name: "cdn.example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+						A:   net.IP{1, 2, 3, 4},
+					},
+				}
+			}
+			return a, nil
+		},
+	}
+	d, err := NewDNS64("test", upstream, DNS64Options{})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeAAAA)
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Len(t, a.Answer, 2)
+	// First record should be the CNAME
+	require.Equal(t, dns.TypeCNAME, a.Answer[0].Header().Rrtype)
+	require.Equal(t, "cdn.example.com.", a.Answer[0].(*dns.CNAME).Target)
+	// Second record should be the synthesized AAAA
+	require.Equal(t, dns.TypeAAAA, a.Answer[1].Header().Rrtype)
+}
+
+func TestDNS64PassthroughDNSSECDO(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			// Return empty AAAA — normally would trigger synthesis
+			return a, nil
+		},
+	}
+	d, err := NewDNS64("test", upstream, DNS64Options{})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeAAAA)
+	q.SetEdns0(4096, true) // Set DO bit
+
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	// Should pass through without synthesis — empty answer returned
+	require.Empty(t, a.Answer)
+	require.Equal(t, dns.TypeAAAA, a.Question[0].Qtype)
+}
+
+func TestDNS64AFallbackError(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			if q.Question[0].Qtype == dns.TypeAAAA {
+				a := new(dns.Msg)
+				a.SetReply(q)
+				return a, nil
+			}
+			// A fallback returns an error
+			return nil, errors.New("upstream failure")
+		},
+	}
+	d, err := NewDNS64("test", upstream, DNS64Options{})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeAAAA)
+	a, err := d.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	// Should return the original NODATA response, not an error
+	require.NotNil(t, a)
+	require.Equal(t, dns.RcodeSuccess, a.Rcode)
+	require.Empty(t, a.Answer)
 }
 
 func TestDNS64NoARecordsEither(t *testing.T) {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -42,6 +42,7 @@
   - [Query Log](#query-log)
   - [Lua](#lua)
   - [DNSSEC Validator](#dnssec-validator)
+  - [DNS64](#dns64)
 - [Resolvers](#resolvers)
   - [Plain DNS](#plain-dns-resolver)
   - [DNS-over-TLS](#dns-over-tls-resolver)
@@ -1857,6 +1858,43 @@ digest = "683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16"
 ```
 
 Example config files: [dnssec-validator.toml](../cmd/routedns/example-config/dnssec-validator.toml), [dnssec-validator-trust-anchors.toml](../cmd/routedns/example-config/dnssec-validator-trust-anchors.toml), [dnssec-validator-iana.toml](../cmd/routedns/example-config/dnssec-validator-iana.toml)
+
+### DNS64
+
+Synthesizes AAAA records from A records for IPv6-only clients using NAT64 ([RFC 6147](https://datatracker.ietf.org/doc/html/rfc6147)). When an AAAA query returns no AAAA answers from upstream, DNS64 falls back to an A query and embeds the IPv4 addresses into configurable IPv6 prefixes per [RFC 6052](https://datatracker.ietf.org/doc/html/rfc6052). Queries for non-AAAA types and responses that already contain AAAA records pass through unchanged.
+
+Options:
+
+- `resolvers` - Array of upstream resolvers (only one supported).
+- `dns64-prefix` - Array of IPv6 CIDR prefixes for address synthesis. Supported prefix lengths: `/32`, `/40`, `/48`, `/56`, `/64`, `/96`. Default: `["64:ff9b::/96"]` (well-known prefix from RFC 6052).
+
+Examples:
+
+Using the well-known prefix (default):
+
+```toml
+[groups.dns64]
+type = "dns64"
+resolvers = ["upstream-udp"]
+```
+
+Custom prefix:
+
+```toml
+[groups.dns64]
+type = "dns64"
+resolvers = ["upstream-udp"]
+dns64-prefix = ["2001:db8::/96"]
+```
+
+Multiple prefixes:
+
+```toml
+[groups.dns64]
+type = "dns64"
+resolvers = ["upstream-udp"]
+dns64-prefix = ["64:ff9b::/96", "2001:db8::/32"]
+```
 
 ## Resolvers
 


### PR DESCRIPTION
## Summary

- Add DNS64 group/modifier that synthesizes AAAA records from A records for IPv6-only clients using NAT64
- Implements RFC 6052 address embedding for all supported prefix lengths: /32, /40, /48, /56, /64, /96
- Defaults to the well-known prefix `64:ff9b::/96` when no prefix is configured
- Supports multiple prefixes, each producing a synthesized AAAA per A record

Closes #513