### PR TITLE
Add domain-subdomain blocklist format (#515)

### DIFF
--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -13,18 +13,35 @@ import (
 // domain.com: matches just domain.com and not subdomains
 // .domain.com: matches domain.com and all subdomains
 // *.domain.com: matches all subdomains but not domain.com
+//
+// When includeSubdomains is true, bare entries like "domain.com" are treated as
+// ".domain.com" (apex and all sub-domains). Entries that already use a leading
+// "." or "*." prefix keep their original semantics. This is intended for
+// blocklists where every line is meant to block both the apex and sub-domains
+// (e.g. hagezi's "Wildcard Domains" lists).
 type DomainDB struct {
-	name   string
-	root   node
-	loader BlocklistLoader
+	name              string
+	root              node
+	loader            BlocklistLoader
+	includeSubdomains bool
 }
 
 type node map[string]node
 
 var _ BlocklistDB = &DomainDB{}
 
-// NewDomainDB returns a new instance of a matcher for a list of regular expressions.
+// NewDomainDB returns a new instance of a matcher for a list of domain rules.
 func NewDomainDB(name string, loader BlocklistLoader) (*DomainDB, error) {
+	return newDomainDB(name, loader, false)
+}
+
+// NewDomainSubdomainDB is like NewDomainDB but treats bare entries as matching
+// the apex and all sub-domains. See DomainDB for details.
+func NewDomainSubdomainDB(name string, loader BlocklistLoader) (*DomainDB, error) {
+	return newDomainDB(name, loader, true)
+}
+
+func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainDB, error) {
 	rules, err := loader.Load()
 	if err != nil {
 		return nil, err
@@ -38,6 +55,13 @@ func NewDomainDB(name string, loader BlocklistLoader) (*DomainDB, error) {
 
 		// Force all domain names to lower case
 		r = strings.ToLower(r)
+
+		// In subdomain-matching mode, treat bare entries as ".entry" so they
+		// match the apex and all sub-domains. Leave entries that already
+		// start with "." or "*." alone.
+		if includeSubdomains && r != "" && !strings.HasPrefix(r, ".") && !strings.HasPrefix(r, "*.") {
+			r = "." + r
+		}
 
 		// Break up the domain into its parts and iterate backwards over them, building
 		// a graph of maps
@@ -59,11 +83,11 @@ func NewDomainDB(name string, loader BlocklistLoader) (*DomainDB, error) {
 			n = subNode
 		}
 	}
-	return &DomainDB{name, root, loader}, nil
+	return &DomainDB{name, root, loader, includeSubdomains}, nil
 }
 
 func (m *DomainDB) Reload() (BlocklistDB, error) {
-	return NewDomainDB(m.name, m.loader)
+	return newDomainDB(m.name, m.loader, m.includeSubdomains)
 }
 
 func (m *DomainDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -61,6 +61,73 @@ func TestDomainDB(t *testing.T) {
 	}
 }
 
+func TestDomainSubdomainDB(t *testing.T) {
+	loader := NewStaticLoader([]string{
+		"domain1.com",     // bare entry: apex + subdomains
+		".domain2.com",    // explicit dot: apex + subdomains (unchanged)
+		"*.domain3.com",   // explicit wildcard: subdomains-only opt-out
+		"DOMAIN4.com",     // capitalized bare entry
+		"trailing.dot.com.",
+	})
+
+	m, err := NewDomainSubdomainDB("testlist", loader)
+	require.NoError(t, err)
+
+	tests := []struct {
+		q     string
+		match bool
+	}{
+		// bare entry matches apex and subdomains
+		{"domain1.com.", true},
+		{"sub.domain1.com.", true},
+		{"deep.sub.domain1.com.", true},
+
+		// leading-dot entry behaves identically
+		{"domain2.com.", true},
+		{"sub.domain2.com.", true},
+
+		// wildcard entry remains subdomains-only (opt-out)
+		{"domain3.com.", false},
+		{"sub.domain3.com.", true},
+
+		// capitalized blocklist entry, lowercase query
+		{"domain4.com.", true},
+		{"sub.domain4.com.", true},
+
+		// trailing-dot entry handled
+		{"trailing.dot.com.", true},
+		{"sub.trailing.dot.com.", true},
+
+		// non-matching
+		{"unblocked.test.", false},
+		{"com.", false},
+
+		// capitalized query
+		{"Domain1.com.", true},
+	}
+	for _, test := range tests {
+		msg := new(dns.Msg)
+		msg.SetQuestion(test.q, dns.TypeA)
+
+		_, _, _, ok := m.Match(msg)
+		require.Equal(t, test.match, ok, "query: %s", test.q)
+	}
+}
+
+func TestDomainSubdomainDBError(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{"sub.*.com"},
+		{"*domain.com"},
+	}
+	for _, test := range tests {
+		loader := NewStaticLoader([]string{test.name})
+		_, err := NewDomainSubdomainDB("testlist", loader)
+		require.Error(t, err)
+	}
+}
+
 func TestDomainDBError(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/routedns/example-config/blocklist-domain-subdomain.toml
+++ b/cmd/routedns/example-config/blocklist-domain-subdomain.toml
@@ -1,0 +1,34 @@
+# Demonstrates the "domain-subdomain" blocklist format. Bare entries match
+# the apex AND all sub-domains, so a single line such as `evil.com` blocks
+# `evil.com`, `www.evil.com`, `cdn.tracking.evil.com`, etc.
+#
+# This is intended for blocklists where every line is meant to apply to
+# apex + sub-domains, e.g. hagezi's "Wildcard Domains" lists:
+#   https://github.com/hagezi/dns-blocklists
+#
+# A `*.example.com` entry can still be used as a per-entry opt-out, matching
+# only sub-domains and leaving the apex unblocked.
+
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[groups.cloudflare-blocklist]
+type             = "blocklist-v2"
+resolvers        = ["cloudflare-dot"]
+blocklist-format = "domain-subdomain"
+blocklist        = [
+  'evil.com',         # blocks evil.com and all sub-domains
+  'facebook.com',     # blocks facebook.com and all sub-domains
+  '*.opt-out.com',    # blocks sub-domains only; apex still resolves
+]
+
+[listeners.local-udp]
+address = ":53"
+protocol = "udp"
+resolver = "cloudflare-blocklist"
+
+[listeners.local-tcp]
+address = ":53"
+protocol = "tcp"
+resolver = "cloudflare-blocklist"

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -1022,6 +1022,8 @@ func newBlocklistDB(l list, rules []string) (rdns.BlocklistDB, error) {
 		return rdns.NewRegexpDB(name, loader)
 	case "domain":
 		return rdns.NewDomainDB(name, loader)
+	case "domain-subdomain":
+		return rdns.NewDomainSubdomainDB(name, loader)
 	case "hosts":
 		return rdns.NewHostsDB(name, loader)
 	case "mac":

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -679,13 +679,14 @@ This replacer could be used where the company has multiple environment behind VP
 
 Query blocklists can be added to resolver-chains to prevent further processing of queries (return NXDOMAIN or spoofed IP) or to send queries to different resolvers if the query name matches a rule on the blocklist. A blocklist can have multiple rule-sets, with different formats. In its simplest form, the blocklist has just one upstream resolver and forwards anything that does not match its rules. If a query matches, it'll be answered with NXDOMAIN or a spoofed IP, depending on what blocklist format is used.
 
-The blocklist group supports 4 types of blocklist formats:
+The blocklist group supports 5 types of blocklist formats:
 
 - `regexp` - The entire query string is matched against a list of regular expressions and NXDOMAIN returned if a match is found. See [Syntax](https://github.com/google/re2/wiki/Syntax) for details on what is supported.
 - `domain` - A list of domains with some wildcard capabilities. Also results in an NXDOMAIN. Entries in the list are matched as follows:
   - `domain.com` matches just domain.com and no sub-domains.
   - `.domain.com` matches domain.com and all sub-domains.
   - `*.domain.com` matches all subdomains but not domain.com. Only one wildcard (at the start of the string) is allowed.
+- `domain-subdomain` - Like `domain`, but bare entries (e.g. `domain.com`) match the apex *and* all sub-domains. `.domain.com` is unchanged. `*.domain.com` still matches sub-domains only and can be used as a per-entry opt-out. Designed for blocklists such as hagezi's "Wildcard Domains" lists where every line is meant to block apex + sub-domains.
 - `hosts` - A blocklist in hosts-file format. If a non-zero IP address is provided for a record, the response is spoofed rather than returning NXDOMAIN.
 - `mac` - A blocklist of MAC addresses in the form `01:23:34:ab:bc:de` representing the MAC address of a client. The query is expected to contain the value of the client's MAC in EDNS0 option 65001.
 
@@ -701,11 +702,11 @@ Options:
 
 - `resolvers` - Array of upstream resolvers, only one is supported.
 - `blocklist-resolver` - Alternative resolver for queries matching the blocklist, rather than responding with NXDOMAIN. Optional.
-- `blocklist-format` - The format the blocklist is provided in. Only used if `blocklist-source` is not provided. Can be `regexp`, `domain`, or `hosts`. Defaults to `regexp`.
+- `blocklist-format` - The format the blocklist is provided in. Only used if `blocklist-source` is not provided. Can be `regexp`, `domain`, `domain-subdomain`, or `hosts`. Defaults to `regexp`.
 - `blocklist-refresh` - Time interval (in seconds) in which external (remote or local) blocklists are reloaded. Optional.
 - `blocklist-source` - An array of blocklists, each with `format`, `source` and optionally `name`.
 - `allowlist-resolver` - Alternative resolver for queries matching the allowlist, rather than forwarding to the default resolver.
-- `allowlist-format` - The format the allowlist is provided in. Only used if `allowlist-source` is not provided. Can be `regexp`, `domain`, or `hosts`. Defaults to `regexp`.
+- `allowlist-format` - The format the allowlist is provided in. Only used if `allowlist-source` is not provided. Can be `regexp`, `domain`, `domain-subdomain`, or `hosts`. Defaults to `regexp`.
 - `allowlist-refresh` - Time interval (in seconds) in which external allowlists are reloaded. Optional.
 - `allowlist-source` - An array of allowlists, each with `format`, `source`, and optionally `cache-dir` or `allow-failure`.
 - `edns0-ede` - Optional, include an extended error code in the response if it's blocked. Only used when the response is blocked, not when it's spoofed. The value is a struct with two keys, `code` (number) and `text` (string). Possible values for `code` are defined in [rfc8914](https://datatracker.ietf.org/doc/html/rfc8914) while `text` can carry additional information that is displayed by `dig` for example. The `text` value is a template that has access to a number of fields of query to allow customizing the response based on data in the query. See [Templates](#templates) for details. Simple placeholders in `text` would be `{{ .Question }}` for the question in the query or `{{ .ID }}` to be replaced with the query ID.
@@ -741,6 +742,20 @@ blocklist = [
   'domain1.com',               # Exact match
   '.domain2.com',              # Exact match and all sub-domains
   '*.domain3.com',             # Only match sub-domains
+]
+```
+
+Blocklist using the `domain-subdomain` format. Bare entries match the apex *and* all sub-domains, so a single line such as `evil.com` blocks `evil.com`, `www.evil.com`, etc. A `*.opt-out.com` entry can still be used to block sub-domains only and leave the apex resolvable. Useful for lists like hagezi's "Wildcard Domains" where every line is meant to apply to apex + sub-domains.
+
+```toml
+[groups.my-blocklist]
+type             = "blocklist-v2"
+resolvers        = ["upstream-resolver"]
+blocklist-format = "domain-subdomain"
+blocklist = [
+  'evil.com',         # Blocks evil.com and all sub-domains
+  'facebook.com',     # Blocks facebook.com and all sub-domains
+  '*.opt-out.com',    # Blocks sub-domains only; apex still resolves
 ]
 ```
 


### PR DESCRIPTION
## Summary

Adds a new `domain-subdomain` blocklist format that treats bare entries (e.g. `example.com`) as matching the apex *and* all sub-domains — equivalent to a `.example.com` rule in the existing `domain` format. Entries that already use `*.` retain their sub-domain-only semantics and can be used as a per-entry opt-out.

This addresses #515: blocklists such as hagezi's "Wildcard Domains" lists, where every line is intended to block apex + sub-domains, can now be loaded as-is without rewriting each line or doubling memory by also loading the matching "Wildcard Asterisk" list.

## Behavior

| Entry            | `domain` format       | `domain-subdomain` format |
| ---------------- | --------------------- | ------------------------- |
| `example.com`    | apex only             | apex + sub-domains        |
| `.example.com`   | apex + sub-domains    | apex + sub-domains        |
| `*.example.com`  | sub-domains only      | sub-domains only          |

## Changes

- `blocklistdb-domain.go` — refactor rule ingestion into a private helper, add `NewDomainSubdomainDB`, preserve the flag on `Reload()`.
- `cmd/routedns/main.go` — wire `"domain-subdomain"` into the format dispatcher used by blocklist, allowlist, and `response-blocklist-name`.
- `blocklistdb-domain_test.go` — `TestDomainSubdomainDB` and `TestDomainSubdomainDBError`.
- `cmd/routedns/example-config/blocklist-domain-subdomain.toml` — new example.
- `doc/configuration.md` — describe the new format, extend the `blocklist-format` / `allowlist-format` enumerations, add an example.

## Backward compatibility

Zero impact on existing configs. The `domain` format and any config using it behave exactly as before; users opt in by changing one string value.

Closes #515