### PR TITLE
Save memory in domain blocklists by re-using specific nodes

### DIFF
--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"maps"
 	"net"
-	"reflect"
-	"slices"
 	"strings"
 
 	"github.com/miekg/dns"
@@ -45,14 +43,15 @@ func NewDomainSubdomainDB(name string, loader BlocklistLoader) (*DomainDB, error
 }
 
 func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainDB, error) {
-	emptyNode := make(node)
-	dotNode := node{"": emptyNode}
-	starNode := node{"*": emptyNode}
-	memorySavingNodes := []uintptr{
-		reflect.ValueOf(emptyNode).Pointer(),
-		reflect.ValueOf(dotNode).Pointer(),
-		reflect.ValueOf(starNode).Pointer(),
-	}
+	// Large lists (e.g. hagezi NRD) produce huge numbers of identical
+	// terminal nodes: empty leaves, "{"": empty}" (.X.tld), and
+	// "{"*": empty}" (*.X.tld). Empty leaves are represented as the nil
+	// node so they cost zero allocations. The two depth-1 shapes share
+	// a single map instance per build. Any later rule that descends
+	// through one of them clones first so it doesn't corrupt sibling
+	// paths that share the same instance.
+	dotNode := node{"": nil}
+	starNode := node{"*": nil}
 
 	rules, err := loader.Load()
 	if err != nil {
@@ -91,7 +90,7 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 			if !ok {
 				switch {
 				case i == 0:
-					subNode = emptyNode
+					subNode = nil
 				case i == 1 && parts[0] == "":
 					subNode = dotNode
 				case i == 1 && parts[0] == "*":
@@ -100,14 +99,39 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 					subNode = make(node)
 				}
 				n[part] = subNode
-			} else if i != 0 && slices.Contains(memorySavingNodes, reflect.ValueOf(subNode).Pointer()) {
-				subNode = maps.Clone(subNode)
+			} else if i != 0 && isSharedShape(subNode) {
+				if subNode == nil {
+					subNode = make(node)
+				} else {
+					subNode = maps.Clone(subNode)
+				}
 				n[part] = subNode
 			}
 			n = subNode
 		}
 	}
 	return &DomainDB{name, root, loader, includeSubdomains}, nil
+}
+
+// isSharedShape reports whether n looks like one of the build-time
+// sentinels: a nil empty leaf, {"": nil} (the .X dot-sentinel), or
+// {"*": nil} (the *.X star-sentinel). The build path never produces
+// nodes of these shapes outside the sentinel paths, so a shape match
+// safely identifies a (possibly shared) instance that must be cloned
+// before mutation.
+func isSharedShape(n node) bool {
+	switch len(n) {
+	case 0:
+		return n == nil
+	case 1:
+		if v, ok := n[""]; ok {
+			return v == nil
+		}
+		if v, ok := n["*"]; ok {
+			return v == nil
+		}
+	}
+	return false
 }
 
 func (m *DomainDB) Reload() (BlocklistDB, error) {

--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -2,7 +2,10 @@ package rdns
 
 import (
 	"fmt"
+	"maps"
 	"net"
+	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/miekg/dns"
@@ -42,6 +45,15 @@ func NewDomainSubdomainDB(name string, loader BlocklistLoader) (*DomainDB, error
 }
 
 func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainDB, error) {
+	emptyNode := make(node)
+	dotNode := node{"": emptyNode}
+	starNode := node{"*": emptyNode}
+	memorySavingNodes := []uintptr{
+		reflect.ValueOf(emptyNode).Pointer(),
+		reflect.ValueOf(dotNode).Pointer(),
+		reflect.ValueOf(starNode).Pointer(),
+	}
+
 	rules, err := loader.Load()
 	if err != nil {
 		return nil, err
@@ -77,7 +89,19 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 
 			subNode, ok := n[part]
 			if !ok {
-				subNode = make(node)
+				switch {
+				case i == 0:
+					subNode = emptyNode
+				case i == 1 && parts[0] == "":
+					subNode = dotNode
+				case i == 1 && parts[0] == "*":
+					subNode = starNode
+				default:
+					subNode = make(node)
+				}
+				n[part] = subNode
+			} else if i != 0 && slices.Contains(memorySavingNodes, reflect.ValueOf(subNode).Pointer()) {
+				subNode = maps.Clone(subNode)
 				n[part] = subNode
 			}
 			n = subNode


### PR DESCRIPTION
Saves memory in domain & domain-subdomain blocklists by re-using nodes for empty ending nodes and second-to-last wildcard nodes (both `.` & `*.`).

This is especially significant for large lists. A minimal routedns config with just the [newly registered domains](https://github.com/hagezi/dns-blocklists#nrd) domain-subdomain list goes from using ~1.1GiB to ~300MiB with this change (resting memory usage after list loading; `GOMEMLIMIT` was used to encourage as much garbage collection as possible).

While the change-size is fairly small & the tests pass, this is my first time working with Go, so some adjustments might be necessary.