### PR TITLE
Randomize upstream DNS transaction IDs in the pipeline

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -230,26 +230,31 @@ func (r *request) markDone(a *dns.Msg, err error) {
 // Queue to manage requests that are in flight. Used to asynchronously match received
 // responses with their requests.
 type inFlightQueue struct {
-	requests  map[uint16]*request
-	mu        sync.Mutex
-	idCounter uint16
-	maxLen    int
+	requests map[uint16]*request
+	mu       sync.Mutex
+	maxLen   int
 }
 
 // Add a request to the queue and return an updated DNS query with a new ID. The ID needs
 // to be unique per connection, and we could be receiving multiple queries with the same
-// ID. So make up a new ID, used that in the query upstream, then map it back to the
-// request and replace the ID with the original one.
+// ID. So pick a random ID that isn't currently in flight, use that in the query upstream,
+// then map it back to the request and replace the ID with the original one.
 func (q *inFlightQueue) add(r *request) *dns.Msg {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if q.requests == nil {
 		q.requests = make(map[uint16]*request)
 	}
-	q.idCounter++
-	q.requests[q.idCounter] = r
+	var id uint16
+	for {
+		id = dns.Id()
+		if _, inUse := q.requests[id]; !inUse {
+			break
+		}
+	}
+	q.requests[id] = r
 	query := r.q.Copy()
-	query.Id = q.idCounter
+	query.Id = id
 	if len(q.requests) > q.maxLen {
 		q.maxLen = len(q.requests)
 	}


### PR DESCRIPTION
## Summary

The pipeline rewrote outgoing query IDs with a monotonic counter (`q.idCounter++`), so the transaction IDs of forwarded queries advanced predictably as `1, 2, 3, ...` for the lifetime of an upstream connection. On plain UDP forwarding paths this materially reduces the off-path spoofing entropy — observing one ID lets an attacker predict subsequent ones, and combined with a fixed source port (the pipeline reuses one connection per upstream) the backend leg has noticeably less entropy than a typical DNS forwarder.

This was reported as #519 against the DoQ-to-UDP forwarding path, but it applies to any UDP upstream because the predictable-ID behavior lives in the shared pipeline, not in DoQ.

## Change

Pick a random ID via `dns.Id()` and retry on collision against the in-flight map. The map is bounded by concurrent in-flight queries (typically tens, occasionally hundreds), so the retry loop almost always exits on the first iteration and the hot path stays effectively O(1). The pipelining model and single-connection behavior are unchanged.

Closes #519 for the TXID half. The fixed-source-port half is left as-is — much harder to exploit on its own without TXID predictability.