### PR TITLE
Document required capabilities in routedns.service

### DIFF
--- a/cmd/routedns/routedns.service
+++ b/cmd/routedns/routedns.service
@@ -7,6 +7,16 @@ Type=simple
 DynamicUser=true
 NoNewPrivileges=true
 WorkingDirectory=/opt/routedns
+# Add capabilities below as needed by the configuration. Append them to the
+# AmbientCapabilities line, separated by spaces.
+#   CAP_NET_BIND_SERVICE - bind to ports < 1024 (already set)
+#   CAP_SYS_ADMIN        - required by the `netns` option on listeners/
+#                          resolvers; setns(CLONE_NEWNET) needs it to enter
+#                          a Linux network namespace.
+#   CAP_NET_ADMIN        - required by the `fwmark` option (SO_MARK) on
+#                          listeners/resolvers.
+#   CAP_NET_RAW          - required by the `bind-if` option (SO_BINDTODEVICE)
+#                          on listeners/resolvers.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 ExecStart=/opt/routedns/routedns config.toml
 Restart=on-failure


### PR DESCRIPTION
## Summary
- Add a comment block above `AmbientCapabilities` in `cmd/routedns/routedns.service` listing the capabilities needed for optional features.
- Covers `CAP_SYS_ADMIN` (required by the `netns` option — `setns(CLONE_NEWNET)`), `CAP_NET_ADMIN` (required by `fwmark` / `SO_MARK`), and `CAP_NET_RAW` (required by `bind-if` / `SO_BINDTODEVICE`).
- Active capabilities are unchanged; users append the others to the `AmbientCapabilities` line as their config requires.

Addresses the P.S. ask in #516.