### PR TITLE
Lazy-start listeners when network namespace is missing

### DIFF
--- a/adminlistener.go
+++ b/adminlistener.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/quic-go/quic-go"
@@ -18,6 +19,7 @@ const adminServerTimeout = 10 * time.Second
 
 // AdminListener is a DNS listener/server for admin services.
 type AdminListener struct {
+	mu         sync.Mutex
 	httpServer *http.Server
 	quicServer *http3.Server
 
@@ -76,20 +78,23 @@ func (s *AdminListener) Start() error {
 
 // Start the admin server with TCP transport.
 func (s *AdminListener) startTCP() error {
-	s.httpServer = &http.Server{
+	httpServer := &http.Server{
 		Addr:         s.addr,
 		TLSConfig:    s.opt.TLSConfig,
 		Handler:      s.mux,
 		ReadTimeout:  adminServerTimeout,
 		WriteTimeout: adminServerTimeout,
 	}
+	s.mu.Lock()
+	s.httpServer = httpServer
+	s.mu.Unlock()
 
 	ln, err := ListenInNetNS(context.Background(), s.opt.NetNS, "tcp", s.addr, s.opt.SocketOptions)
 	if err != nil {
 		return err
 	}
 	defer ln.Close()
-	return s.httpServer.ServeTLS(ln, "", "")
+	return httpServer.ServeTLS(ln, "", "")
 }
 
 // Start the admin server with QUIC transport.
@@ -109,12 +114,15 @@ func (s *AdminListener) startQUIC() error {
 		udpConn.Close()
 		return err
 	}
-	s.quicServer = &http3.Server{
+	quicServer := &http3.Server{
 		TLSConfig:  s.opt.TLSConfig,
 		Handler:    s.mux,
 		QUICConfig: &quic.Config{},
 	}
-	return s.quicServer.ServeListener(quicLn)
+	s.mu.Lock()
+	s.quicServer = quicServer
+	s.mu.Unlock()
+	return quicServer.ServeListener(quicLn)
 }
 
 // Stop the server.
@@ -123,10 +131,19 @@ func (s *AdminListener) Stop() error {
 		"id", s.id,
 		"protocol", s.opt.Transport,
 		"addr", s.addr)
+	s.mu.Lock()
+	httpServer, quicServer := s.httpServer, s.quicServer
+	s.mu.Unlock()
 	if s.opt.Transport == "quic" {
-		return s.quicServer.Close()
+		if quicServer == nil {
+			return nil
+		}
+		return quicServer.Close()
 	}
-	return s.httpServer.Shutdown(context.Background())
+	if httpServer == nil {
+		return nil
+	}
+	return httpServer.Shutdown(context.Background())
 }
 
 func (s *AdminListener) String() string {

--- a/adminlistener.go
+++ b/adminlistener.go
@@ -22,6 +22,10 @@ type AdminListener struct {
 	mu         sync.Mutex
 	httpServer *http.Server
 	quicServer *http3.Server
+	// quicTransport/quicConn back quicServer. quic-go does not close a
+	// caller-supplied PacketConn, so they are closed explicitly in Stop().
+	quicTransport *quic.Transport
+	quicConn      *net.UDPConn
 
 	id   string
 	addr string
@@ -121,6 +125,8 @@ func (s *AdminListener) startQUIC() error {
 	}
 	s.mu.Lock()
 	s.quicServer = quicServer
+	s.quicTransport = transport
+	s.quicConn = udpConn
 	s.mu.Unlock()
 	return quicServer.ServeListener(quicLn)
 }
@@ -133,12 +139,19 @@ func (s *AdminListener) Stop() error {
 		"addr", s.addr)
 	s.mu.Lock()
 	httpServer, quicServer := s.httpServer, s.quicServer
+	quicTransport, quicConn := s.quicTransport, s.quicConn
 	s.mu.Unlock()
 	if s.opt.Transport == "quic" {
 		if quicServer == nil {
 			return nil
 		}
-		return quicServer.Close()
+		err := quicServer.Close()
+		// quic-go's Transport.Close does not close a caller-supplied
+		// PacketConn, so close both explicitly to avoid leaking the socket
+		// on each rebuild.
+		quicTransport.Close()
+		quicConn.Close()
+		return err
 	}
 	if httpServer == nil {
 		return nil

--- a/adminlistener_test.go
+++ b/adminlistener_test.go
@@ -1,0 +1,25 @@
+package rdns
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdminListenerStopBeforeStart verifies Stop() is a no-op rather than a
+// nil-panic when called before Start() has assigned the server, mirroring the
+// netns supervisor stopping a listener whose namespace flapped before it bound.
+func TestAdminListenerStopBeforeStart(t *testing.T) {
+	tlsServerConfig, err := TLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+	require.NoError(t, err)
+
+	for _, transport := range []string{"tcp", "quic"} {
+		t.Run(transport, func(t *testing.T) {
+			s, err := NewAdminListener("test-admin", "127.0.0.1:0", AdminListenerOptions{TLSConfig: tlsServerConfig, Transport: transport})
+			require.NoError(t, err)
+			require.NotPanics(t, func() {
+				require.NoError(t, s.Stop())
+			})
+		})
+	}
+}

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -202,7 +202,13 @@ func start(opt options, args []string) error {
 	}
 
 	// Build the Listeners last as they can point to routers, groups or resolvers directly.
-	var listeners []rdns.Listener
+	type pendingListener struct {
+		id     string
+		nsName string // empty unless the listener is bound to a netns
+		build  func() (rdns.Listener, error)
+		ln     rdns.Listener // pre-built for non-netns listeners
+	}
+	var listeners []pendingListener
 	for id, l := range config.Listeners {
 		resolver, ok := resolvers[l.Resolver]
 		// All Listeners should route queries (except the admin service).
@@ -229,30 +235,33 @@ func start(opt options, args []string) error {
 			SocketOptions: rdns.SocketOptions{FWMark: l.FWMark, BindInterface: l.BindInterface},
 		}
 
+		var build func() (rdns.Listener, error)
 		switch l.Protocol {
 		case "tcp":
 			network := networkForIPVersion("tcp", l.IPVersion)
 			l.Address = rdns.AddressWithDefault(l.Address, rdns.PlainDNSPort)
-			listeners = append(listeners, rdns.NewDNSListener(id, l.Address, network, opt, resolver))
+			build = func() (rdns.Listener, error) {
+				return rdns.NewDNSListener(id, l.Address, network, opt, resolver), nil
+			}
 		case "udp":
 			network := networkForIPVersion("udp", l.IPVersion)
 			l.Address = rdns.AddressWithDefault(l.Address, rdns.PlainDNSPort)
-			listeners = append(listeners, rdns.NewDNSListener(id, l.Address, network, opt, resolver))
+			build = func() (rdns.Listener, error) {
+				return rdns.NewDNSListener(id, l.Address, network, opt, resolver), nil
+			}
 		case "admin":
 			tlsConfig, err := rdns.TLSServerConfig(l.CA, l.ServerCrt, l.ServerKey, l.MutualTLS)
 			if err != nil {
 				return err
 			}
-			opt := rdns.AdminListenerOptions{
+			adminOpt := rdns.AdminListenerOptions{
 				TLSConfig:     tlsConfig,
 				ListenOptions: opt,
 				Transport:     l.Transport,
 			}
-			ln, err := rdns.NewAdminListener(id, l.Address, opt)
-			if err != nil {
-				return err
+			build = func() (rdns.Listener, error) {
+				return rdns.NewAdminListener(id, l.Address, adminOpt)
 			}
-			listeners = append(listeners, ln)
 		case "dot":
 			network := networkForIPVersion("tcp", l.IPVersion)
 			l.Address = rdns.AddressWithDefault(l.Address, rdns.DoTPort)
@@ -260,16 +269,18 @@ func start(opt options, args []string) error {
 			if err != nil {
 				return err
 			}
-			ln := rdns.NewDoTListener(id, l.Address, network, rdns.DoTListenerOptions{TLSConfig: tlsConfig, ListenOptions: opt}, resolver)
-			listeners = append(listeners, ln)
+			build = func() (rdns.Listener, error) {
+				return rdns.NewDoTListener(id, l.Address, network, rdns.DoTListenerOptions{TLSConfig: tlsConfig, ListenOptions: opt}, resolver), nil
+			}
 		case "dtls":
 			l.Address = rdns.AddressWithDefault(l.Address, rdns.DTLSPort)
 			dtlsConfig, err := rdns.DTLSServerConfig(l.CA, l.ServerCrt, l.ServerKey, l.MutualTLS)
 			if err != nil {
 				return err
 			}
-			ln := rdns.NewDTLSListener(id, l.Address, rdns.DTLSListenerOptions{DTLSConfig: dtlsConfig, ListenOptions: opt}, resolver)
-			listeners = append(listeners, ln)
+			build = func() (rdns.Listener, error) {
+				return rdns.NewDTLSListener(id, l.Address, rdns.DTLSListenerOptions{DTLSConfig: dtlsConfig, ListenOptions: opt}, resolver), nil
+			}
 		case "doh":
 			if l.Transport != "quic" {
 				l.Address = rdns.AddressWithDefault(l.Address, rdns.DoHPort)
@@ -294,18 +305,16 @@ func start(opt options, args []string) error {
 					return fmt.Errorf("listener '%s' trusted-proxy '%s': %v", id, l.Frontend.HTTPProxyNet, err)
 				}
 			}
-			opt := rdns.DoHListenerOptions{
+			dohOpt := rdns.DoHListenerOptions{
 				TLSConfig:     tlsConfig,
 				ListenOptions: opt,
 				Transport:     l.Transport,
 				HTTPProxyNet:  httpProxyNet,
 				NoTLS:         l.NoTLS,
 			}
-			ln, err := rdns.NewDoHListener(id, l.Address, opt, resolver)
-			if err != nil {
-				return err
+			build = func() (rdns.Listener, error) {
+				return rdns.NewDoHListener(id, l.Address, dohOpt, resolver)
 			}
-			listeners = append(listeners, ln)
 		case "doq":
 			l.Address = rdns.AddressWithDefault(l.Address, rdns.DoQPort)
 
@@ -313,41 +322,55 @@ func start(opt options, args []string) error {
 			if err != nil {
 				return err
 			}
-			ln := rdns.NewQUICListener(id, l.Address, rdns.DoQListenerOptions{TLSConfig: tlsConfig, ListenOptions: opt}, resolver)
-			listeners = append(listeners, ln)
+			build = func() (rdns.Listener, error) {
+				return rdns.NewQUICListener(id, l.Address, rdns.DoQListenerOptions{TLSConfig: tlsConfig, ListenOptions: opt}, resolver), nil
+			}
 		case "odoh":
 			l.Address = rdns.AddressWithDefault(l.Address, rdns.DoHPort)
 			tlsConfig, err := rdns.TLSServerConfig(l.CA, l.ServerCrt, l.ServerKey, l.MutualTLS)
 			if err != nil {
 				return err
 			}
-			opt := rdns.ODoHListenerOptions{
+			odohOpt := rdns.ODoHListenerOptions{
 				TLSConfig:     tlsConfig,
 				KeySeed:       l.KeySeed,
 				OdohMode:      l.OdohMode,
 				AllowDoH:      l.AllowDoH,
 				ListenOptions: opt,
 			}
-			ln, err := rdns.NewODoHListener(id, l.Address, opt, resolver)
-			if err != nil {
-				return err
+			build = func() (rdns.Listener, error) {
+				return rdns.NewODoHListener(id, l.Address, odohOpt, resolver)
 			}
-			listeners = append(listeners, ln)
 		default:
 			return fmt.Errorf("unsupported protocol '%s' for listener '%s'", l.Protocol, id)
 		}
+
+		pl := pendingListener{id: id, nsName: l.NetNS, build: build}
+		if pl.nsName == "" {
+			pl.ln, err = build()
+			if err != nil {
+				return err
+			}
+		}
+		listeners = append(listeners, pl)
 	}
 
-	// Start the listeners
-	for _, l := range listeners {
-		go func(l rdns.Listener) {
-			for {
-				err := l.Start()
-				rdns.Log.Error("listener failed",
-					"error", err)
-				time.Sleep(time.Second)
-			}
-		}(l)
+	// Start the listeners. Listeners bound to a netns are run through a
+	// supervisor that watches /var/run/netns/ via inotify and gates the
+	// inner listener on namespace presence: warn-and-wait when absent,
+	// build+Start when present, Stop when removed.
+	for _, pl := range listeners {
+		if pl.nsName == "" {
+			go func(l rdns.Listener) {
+				for {
+					err := l.Start()
+					rdns.Log.Error("listener failed", "error", err)
+					time.Sleep(time.Second)
+				}
+			}(pl.ln)
+			continue
+		}
+		go superviseNetNSListener(pl.id, pl.nsName, pl.build)
 	}
 
 	// Graceful shutdown
@@ -1080,6 +1103,69 @@ func networkForIPVersion(base string, ipVersion int) string {
 		return base
 	}
 	return base + strconv.Itoa(ipVersion)
+}
+
+// superviseNetNSListener gates a listener on the presence of a network
+// namespace. When the namespace appears, build is called and the resulting
+// listener is started; when it disappears, the listener is stopped. A fresh
+// instance is constructed on each cycle because some listener types
+// (http.Server-backed) cannot be restarted after Shutdown.
+func superviseNetNSListener(id, nsName string, build func() (rdns.Listener, error)) {
+	events, cancel, err := rdns.SubscribeNetNS(nsName)
+	if err != nil {
+		rdns.Log.Error("netns watcher unavailable, listener disabled", "id", id, "error", err)
+		return
+	}
+	defer cancel()
+
+	var (
+		ln       rdns.Listener
+		startErr chan error
+	)
+
+	for {
+		select {
+		case state, ok := <-events:
+			if !ok {
+				return
+			}
+			switch state {
+			case rdns.NetNSPresent:
+				if ln != nil {
+					continue
+				}
+				rdns.Log.Info("netns present, starting listener", "netns", nsName, "id", id)
+				inner, err := build()
+				if err != nil {
+					rdns.Log.Warn("failed to build listener", "id", id, "error", err)
+					continue
+				}
+				ln = inner
+				startErr = make(chan error, 1)
+				go func(l rdns.Listener, done chan error) {
+					done <- l.Start()
+				}(ln, startErr)
+			case rdns.NetNSAbsent:
+				if ln == nil {
+					rdns.Log.Warn("netns not present, waiting", "netns", nsName, "id", id)
+					continue
+				}
+				rdns.Log.Warn("netns gone, stopping listener", "netns", nsName, "id", id)
+				if err := ln.Stop(); err != nil {
+					rdns.Log.Warn("error stopping listener", "id", id, "error", err)
+				}
+				<-startErr
+				ln = nil
+				startErr = nil
+			}
+		case err := <-startErr:
+			startErr = nil
+			ln = nil
+			if err != nil {
+				rdns.Log.Warn("listener exited, will retry on next netns event", "id", id, "error", err)
+			}
+		}
+	}
 }
 
 func printVersion() {

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -345,7 +346,15 @@ func start(opt options, args []string) error {
 			return fmt.Errorf("unsupported protocol '%s' for listener '%s'", l.Protocol, id)
 		}
 
-		pl := pendingListener{id: id, nsName: l.NetNS, build: build}
+		// The lazy supervisor watches /var/run/netns by name and can't track
+		// an absolute namespace path (e.g. /proc/<pid>/ns/net). Those fall
+		// back to eager start + retry, which binds via NetNS.nsPath() exactly
+		// as before this feature.
+		nsName := l.NetNS
+		if filepath.IsAbs(nsName) {
+			nsName = ""
+		}
+		pl := pendingListener{id: id, nsName: nsName, build: build}
 		if pl.nsName == "" {
 			pl.ln, err = build()
 			if err != nil {

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -1151,10 +1151,7 @@ func superviseNetNSListener(id, nsName string, build func() (rdns.Listener, erro
 					continue
 				}
 				rdns.Log.Warn("netns gone, stopping listener", "netns", nsName, "id", id)
-				if err := ln.Stop(); err != nil {
-					rdns.Log.Warn("error stopping listener", "id", id, "error", err)
-				}
-				<-startErr
+				stopNetNSListener(id, ln, startErr)
 				ln = nil
 				startErr = nil
 			}
@@ -1163,6 +1160,35 @@ func superviseNetNSListener(id, nsName string, build func() (rdns.Listener, erro
 			ln = nil
 			if err != nil {
 				rdns.Log.Warn("listener exited, will retry on next netns event", "id", id, "error", err)
+			}
+		}
+	}
+}
+
+// stopNetNSListener stops a running listener and waits for its Start
+// goroutine to return. Stop is retried on a short interval because for some
+// listener types it is a no-op until the listener is actually serving: a
+// dns.Server's Shutdown returns "server not started" before it begins
+// serving, and a freshly-built DoQ listener isn't bound yet. A single early
+// Stop would then leave Start serving forever and this call blocking on its
+// result. Gives up after a few seconds so a listener that refuses to stop
+// can't wedge the supervisor permanently.
+func stopNetNSListener(id string, ln rdns.Listener, startErr <-chan error) {
+	const (
+		retryInterval = 100 * time.Millisecond
+		maxAttempts   = 30
+	)
+	for attempt := 0; ; attempt++ {
+		if err := ln.Stop(); err != nil {
+			rdns.Log.Warn("error stopping listener", "id", id, "error", err)
+		}
+		select {
+		case <-startErr:
+			return
+		case <-time.After(retryInterval):
+			if attempt >= maxAttempts {
+				rdns.Log.Error("listener did not stop, abandoning", "id", id)
+				return
 			}
 		}
 	}

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -1105,6 +1105,12 @@ func networkForIPVersion(base string, ipVersion int) string {
 	return base + strconv.Itoa(ipVersion)
 }
 
+// netnsRetryInterval is how long the supervisor waits before retrying a
+// listener that failed to build or start while its namespace is present. It
+// matches the retry cadence used for listeners that aren't bound to a
+// namespace. It is a var so tests can shorten it.
+var netnsRetryInterval = time.Second
+
 // superviseNetNSListener gates a listener on the presence of a network
 // namespace. When the namespace appears, build is called and the resulting
 // listener is started; when it disappears, the listener is stopped. A fresh
@@ -1117,11 +1123,37 @@ func superviseNetNSListener(id, nsName string, build func() (rdns.Listener, erro
 		return
 	}
 	defer cancel()
+	runNetNSSupervisor(id, nsName, events, build)
+}
 
+// runNetNSSupervisor drives the listener lifecycle off namespace state events.
+// It builds and starts the listener when the namespace is present, stops it
+// when the namespace goes away, and retries on a timer when a build or start
+// fails (or the listener exits) while the namespace is still present, so a
+// transient failure such as a temporarily-bound address doesn't leave the
+// listener down until the namespace happens to flap.
+func runNetNSSupervisor(id, nsName string, events <-chan rdns.NetNSState, build func() (rdns.Listener, error)) {
 	var (
 		ln       rdns.Listener
 		startErr chan error
+		present  bool
+		retryC   <-chan time.Time // non-nil while a (re)start is pending
 	)
+
+	launch := func() {
+		retryC = nil
+		inner, err := build()
+		if err != nil {
+			rdns.Log.Warn("failed to build listener, retrying", "id", id, "error", err)
+			retryC = time.After(netnsRetryInterval)
+			return
+		}
+		ln = inner
+		startErr = make(chan error, 1)
+		go func(l rdns.Listener, done chan error) {
+			done <- l.Start()
+		}(ln, startErr)
+	}
 
 	for {
 		select {
@@ -1131,21 +1163,15 @@ func superviseNetNSListener(id, nsName string, build func() (rdns.Listener, erro
 			}
 			switch state {
 			case rdns.NetNSPresent:
+				present = true
 				if ln != nil {
 					continue
 				}
 				rdns.Log.Info("netns present, starting listener", "netns", nsName, "id", id)
-				inner, err := build()
-				if err != nil {
-					rdns.Log.Warn("failed to build listener", "id", id, "error", err)
-					continue
-				}
-				ln = inner
-				startErr = make(chan error, 1)
-				go func(l rdns.Listener, done chan error) {
-					done <- l.Start()
-				}(ln, startErr)
+				launch()
 			case rdns.NetNSAbsent:
+				present = false
+				retryC = nil // namespace is gone; cancel any pending retry
 				if ln == nil {
 					rdns.Log.Warn("netns not present, waiting", "netns", nsName, "id", id)
 					continue
@@ -1159,7 +1185,18 @@ func superviseNetNSListener(id, nsName string, build func() (rdns.Listener, erro
 			startErr = nil
 			ln = nil
 			if err != nil {
-				rdns.Log.Warn("listener exited, will retry on next netns event", "id", id, "error", err)
+				rdns.Log.Warn("listener exited", "id", id, "error", err)
+			}
+			// The listener stopped on its own while the namespace is still
+			// present (crash or transient bind failure); retry on a timer.
+			if present {
+				retryC = time.After(netnsRetryInterval)
+			}
+		case <-retryC:
+			retryC = nil
+			if present && ln == nil {
+				rdns.Log.Info("retrying listener start", "netns", nsName, "id", id)
+				launch()
 			}
 		}
 	}

--- a/cmd/routedns/netns_supervisor_test.go
+++ b/cmd/routedns/netns_supervisor_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeNetNSListener simulates a listener whose Stop() is a no-op for its first
+// failFirstN calls, mirroring the real race the supervisor must tolerate: a
+// dns.Server's Shutdown returns "server not started" before it begins serving,
+// and a freshly-built DoQ listener isn't bound yet. Start() blocks until an
+// effective Stop() releases it.
+type fakeNetNSListener struct {
+	mu         sync.Mutex
+	stopCalls  int
+	failFirstN int
+	stop       chan struct{}
+}
+
+func newFakeNetNSListener(failFirstN int) *fakeNetNSListener {
+	return &fakeNetNSListener{failFirstN: failFirstN, stop: make(chan struct{})}
+}
+
+func (f *fakeNetNSListener) Start() error {
+	<-f.stop
+	return nil
+}
+
+func (f *fakeNetNSListener) Stop() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopCalls++
+	if f.stopCalls <= f.failFirstN {
+		return errors.New("server not started")
+	}
+	select {
+	case <-f.stop:
+	default:
+		close(f.stop)
+	}
+	return nil
+}
+
+func (f *fakeNetNSListener) String() string { return "fake" }
+
+func (f *fakeNetNSListener) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.stopCalls
+}
+
+// A Stop() that is a no-op until the listener is serving must be retried until
+// Start() actually returns, rather than blocking on its result forever.
+func TestStopNetNSListenerRetriesUntilStopped(t *testing.T) {
+	f := newFakeNetNSListener(1) // first Stop is a no-op, second takes effect
+
+	startErr := make(chan error, 1)
+	go func() { startErr <- f.Start() }()
+
+	done := make(chan struct{})
+	go func() {
+		stopNetNSListener("test", f, startErr)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stopNetNSListener deadlocked: Stop was a no-op and Start never returned")
+	}
+	if c := f.calls(); c < 2 {
+		t.Fatalf("expected Stop() to be retried, got %d call(s)", c)
+	}
+}
+
+// When Stop() works on the first try the supervisor must not retry needlessly.
+func TestStopNetNSListenerStopsImmediately(t *testing.T) {
+	f := newFakeNetNSListener(0)
+
+	startErr := make(chan error, 1)
+	go func() { startErr <- f.Start() }()
+
+	done := make(chan struct{})
+	go func() {
+		stopNetNSListener("test", f, startErr)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stopNetNSListener did not return")
+	}
+	if c := f.calls(); c != 1 {
+		t.Fatalf("expected exactly 1 Stop() call, got %d", c)
+	}
+}

--- a/cmd/routedns/netns_supervisor_test.go
+++ b/cmd/routedns/netns_supervisor_test.go
@@ -5,6 +5,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	rdns "github.com/folbricht/routedns"
+	"github.com/stretchr/testify/require"
 )
 
 // fakeNetNSListener simulates a listener whose Stop() is a no-op for its first
@@ -95,5 +98,54 @@ func TestStopNetNSListenerStopsImmediately(t *testing.T) {
 	}
 	if c := f.calls(); c != 1 {
 		t.Fatalf("expected exactly 1 Stop() call, got %d", c)
+	}
+}
+
+// A listener that fails to build while its namespace is present must be retried
+// on a timer rather than waiting for the next namespace event.
+func TestNetNSSupervisorRetriesBuildFailure(t *testing.T) {
+	old := netnsRetryInterval
+	netnsRetryInterval = 10 * time.Millisecond
+	defer func() { netnsRetryInterval = old }()
+
+	var (
+		mu       sync.Mutex
+		attempts int
+		started  *fakeNetNSListener
+	)
+	build := func() (rdns.Listener, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		attempts++
+		if attempts < 3 {
+			return nil, errors.New("address already in use")
+		}
+		started = newFakeNetNSListener(0)
+		return started, nil
+	}
+
+	events := make(chan rdns.NetNSState, 1)
+	done := make(chan struct{})
+	go func() {
+		runNetNSSupervisor("test", "ns", events, build)
+		close(done)
+	}()
+
+	// Namespace is present but the first two builds fail; the supervisor must
+	// keep retrying on the timer until the third build succeeds.
+	events <- rdns.NetNSPresent
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return attempts >= 3 && started != nil
+	}, 2*time.Second, 5*time.Millisecond, "build was not retried until it succeeded")
+
+	// Tear down: namespace goes away (stops the listener), then end the loop.
+	events <- rdns.NetNSAbsent
+	close(events)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not exit")
 	}
 }

--- a/dnslistener.go
+++ b/dnslistener.go
@@ -72,6 +72,10 @@ func (s DNSListener) startWithSocketSetup() error {
 	return s.ActivateAndServe()
 }
 
+func (s DNSListener) Stop() error {
+	return s.Server.Shutdown()
+}
+
 func (s DNSListener) String() string {
 	return s.id
 }

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"log/slog"
@@ -31,6 +32,7 @@ const maxDoHRequestSize = 65535
 
 // DoHListener is a DNS listener/server for DNS-over-HTTPS.
 type DoHListener struct {
+	mu         sync.Mutex
 	httpServer *http.Server
 	quicServer *http3.Server
 
@@ -121,13 +123,16 @@ func (s *DoHListener) Start() error {
 
 // Start the DoH server with TCP transport.
 func (s *DoHListener) startTCP() error {
-	s.httpServer = &http.Server{
+	httpServer := &http.Server{
 		Addr:         s.addr,
 		TLSConfig:    s.opt.TLSConfig,
 		ReadTimeout:  dohServerTimeout,
 		WriteTimeout: dohServerTimeout,
 		Handler:      s.opt.customMux,
 	}
+	s.mu.Lock()
+	s.httpServer = httpServer
+	s.mu.Unlock()
 
 	ln, err := ListenInNetNS(context.Background(), s.opt.NetNS, "tcp", s.addr, s.opt.SocketOptions)
 	if err != nil {
@@ -135,9 +140,9 @@ func (s *DoHListener) startTCP() error {
 	}
 	defer ln.Close()
 	if s.opt.NoTLS {
-		return s.httpServer.Serve(ln)
+		return httpServer.Serve(ln)
 	}
-	return s.httpServer.ServeTLS(ln, "", "")
+	return httpServer.ServeTLS(ln, "", "")
 }
 
 // Start the DoH server with QUIC transport.
@@ -160,7 +165,7 @@ func (s *DoHListener) startQUIC() error {
 		udpConn.Close()
 		return err
 	}
-	s.quicServer = &http3.Server{
+	quicServer := &http3.Server{
 		TLSConfig: s.opt.TLSConfig,
 		QUICConfig: &quic.Config{
 			Allow0RTT:      true,
@@ -168,16 +173,28 @@ func (s *DoHListener) startQUIC() error {
 		},
 		Handler: s.opt.customMux,
 	}
-	return s.quicServer.ServeListener(quicLn)
+	s.mu.Lock()
+	s.quicServer = quicServer
+	s.mu.Unlock()
+	return quicServer.ServeListener(quicLn)
 }
 
 // Stop the server.
 func (s *DoHListener) Stop() error {
 	Log.Info("stopping listener", slog.Group("details", slog.String("id", s.id), slog.String("protocol", "doh"), slog.String("transport", s.opt.Transport), slog.String("addr", s.addr)))
+	s.mu.Lock()
+	httpServer, quicServer := s.httpServer, s.quicServer
+	s.mu.Unlock()
 	if s.opt.Transport == "quic" {
-		return s.quicServer.Close()
+		if quicServer == nil {
+			return nil
+		}
+		return quicServer.Close()
 	}
-	return s.httpServer.Shutdown(context.Background())
+	if httpServer == nil {
+		return nil
+	}
+	return httpServer.Shutdown(context.Background())
 }
 
 func (s *DoHListener) String() string {

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -35,6 +35,10 @@ type DoHListener struct {
 	mu         sync.Mutex
 	httpServer *http.Server
 	quicServer *http3.Server
+	// quicTransport/quicConn back quicServer. quic-go does not close a
+	// caller-supplied PacketConn, so they are closed explicitly in Stop().
+	quicTransport *quic.Transport
+	quicConn      *net.UDPConn
 
 	id   string
 	addr string
@@ -175,6 +179,8 @@ func (s *DoHListener) startQUIC() error {
 	}
 	s.mu.Lock()
 	s.quicServer = quicServer
+	s.quicTransport = transport
+	s.quicConn = udpConn
 	s.mu.Unlock()
 	return quicServer.ServeListener(quicLn)
 }
@@ -184,12 +190,19 @@ func (s *DoHListener) Stop() error {
 	Log.Info("stopping listener", slog.Group("details", slog.String("id", s.id), slog.String("protocol", "doh"), slog.String("transport", s.opt.Transport), slog.String("addr", s.addr)))
 	s.mu.Lock()
 	httpServer, quicServer := s.httpServer, s.quicServer
+	quicTransport, quicConn := s.quicTransport, s.quicConn
 	s.mu.Unlock()
 	if s.opt.Transport == "quic" {
 		if quicServer == nil {
 			return nil
 		}
-		return quicServer.Close()
+		err := quicServer.Close()
+		// quic-go's Transport.Close does not close a caller-supplied
+		// PacketConn, so close both explicitly to avoid leaking the socket
+		// on each rebuild.
+		quicTransport.Close()
+		quicConn.Close()
+		return err
 	}
 	if httpServer == nil {
 		return nil

--- a/dohlistener_test.go
+++ b/dohlistener_test.go
@@ -321,3 +321,21 @@ func TestDoHListenerPostBodySizeLimit(t *testing.T) {
 		require.Equal(t, int64(1), v.(*expvar.Int).Value())
 	})
 }
+
+// TestDoHListenerStopBeforeStart verifies Stop() is a no-op rather than a
+// nil-panic when called before Start() has assigned the server. The netns
+// supervisor can call Stop() this early when a namespace flaps.
+func TestDoHListenerStopBeforeStart(t *testing.T) {
+	tlsServerConfig, err := TLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+	require.NoError(t, err)
+
+	for _, transport := range []string{"tcp", "quic"} {
+		t.Run(transport, func(t *testing.T) {
+			s, err := NewDoHListener("test-doh", "127.0.0.1:0", DoHListenerOptions{TLSConfig: tlsServerConfig, Transport: transport}, new(TestResolver))
+			require.NoError(t, err)
+			require.NotPanics(t, func() {
+				require.NoError(t, s.Stop())
+			})
+		})
+	}
+}

--- a/doqlistener.go
+++ b/doqlistener.go
@@ -8,6 +8,7 @@ import (
 	"expvar"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"log/slog"
@@ -18,13 +19,16 @@ import (
 
 // DoQListener is a DNS listener/server for QUIC.
 type DoQListener struct {
-	id      string
-	addr    string
-	r       Resolver
-	opt     DoQListenerOptions
-	ln      *quic.EarlyListener
-	log     *slog.Logger
-	metrics *DoQListenerMetrics
+	id        string
+	addr      string
+	r         Resolver
+	opt       DoQListenerOptions
+	mu        sync.Mutex
+	ln        *quic.EarlyListener
+	transport *quic.Transport
+	conn      *net.UDPConn
+	log       *slog.Logger
+	metrics   *DoQListenerMetrics
 }
 
 var _ Listener = &DoQListener{}
@@ -77,7 +81,6 @@ func NewQUICListener(id, addr string, opt DoQListenerOptions, resolver Resolver)
 
 // Start the QUIC server.
 func (s *DoQListener) Start() error {
-	var err error
 	udpAddr, err := net.ResolveUDPAddr("udp", s.addr)
 	if err != nil {
 		return err
@@ -87,7 +90,7 @@ func (s *DoQListener) Start() error {
 		return err
 	}
 	transport := &quic.Transport{Conn: udpConn}
-	s.ln, err = transport.ListenEarly(s.opt.TLSConfig, &quic.Config{
+	ln, err := transport.ListenEarly(s.opt.TLSConfig, &quic.Config{
 		Allow0RTT:      true,
 		MaxIdleTimeout: 5 * time.Minute,
 	})
@@ -95,10 +98,17 @@ func (s *DoQListener) Start() error {
 		udpConn.Close()
 		return err
 	}
+	// Publish the handles under the lock; Stop() runs on another goroutine
+	// and reads them to tear the listener down.
+	s.mu.Lock()
+	s.conn = udpConn
+	s.transport = transport
+	s.ln = ln
+	s.mu.Unlock()
 	s.log.Info("starting listener")
 
 	for {
-		connection, err := s.ln.Accept(context.Background())
+		connection, err := ln.Accept(context.Background())
 		if err != nil {
 			// The listener was closed by Stop(); return cleanly so the
 			// caller's Start() unblocks instead of spinning on Accept.
@@ -116,10 +126,20 @@ func (s *DoQListener) Start() error {
 // Stop the server.
 func (s *DoQListener) Stop() error {
 	s.log.Info("stopping listener", slog.Group("details", slog.String("protocol", "quic"), slog.String("addr", s.addr)))
-	if s.ln == nil {
+	s.mu.Lock()
+	ln, transport, conn := s.ln, s.transport, s.conn
+	s.mu.Unlock()
+	if ln == nil {
+		// Start() hasn't bound yet; nothing to stop. The supervisor retries
+		// Stop() until Start() has published its handles.
 		return nil
 	}
-	return s.ln.Close()
+	err := ln.Close()
+	// quic-go's Transport.Close does not close a caller-supplied PacketConn,
+	// so close both explicitly to avoid leaking the socket on each rebuild.
+	transport.Close()
+	conn.Close()
+	return err
 }
 
 func (s *DoQListener) handleConnection(connection *quic.Conn) {

--- a/doqlistener.go
+++ b/doqlistener.go
@@ -75,7 +75,7 @@ func NewQUICListener(id, addr string, opt DoQListenerOptions, resolver Resolver)
 }
 
 // Start the QUIC server.
-func (s DoQListener) Start() error {
+func (s *DoQListener) Start() error {
 	var err error
 	udpAddr, err := net.ResolveUDPAddr("udp", s.addr)
 	if err != nil {
@@ -108,12 +108,15 @@ func (s DoQListener) Start() error {
 }
 
 // Stop the server.
-func (s DoQListener) Stop() error {
+func (s *DoQListener) Stop() error {
 	s.log.Info("stopping listener", slog.Group("details", slog.String("protocol", "quic"), slog.String("addr", s.addr)))
+	if s.ln == nil {
+		return nil
+	}
 	return s.ln.Close()
 }
 
-func (s DoQListener) handleConnection(connection *quic.Conn) {
+func (s *DoQListener) handleConnection(connection *quic.Conn) {
 	tlsServerName := connection.ConnectionState().TLS.ServerName
 
 	ci := ClientInfo{
@@ -149,7 +152,7 @@ func (s DoQListener) handleConnection(connection *quic.Conn) {
 	}
 }
 
-func (s DoQListener) handleStream(stream *quic.Stream, log *slog.Logger, ci ClientInfo) {
+func (s *DoQListener) handleStream(stream *quic.Stream, log *slog.Logger, ci ClientInfo) {
 	// DNS over QUIC uses one stream per query/response.
 	defer stream.Close()
 	s.metrics.stream.Add(1)
@@ -231,6 +234,6 @@ func (s DoQListener) handleStream(stream *quic.Stream, log *slog.Logger, ci Clie
 	s.metrics.response.Add(rCode(a), 1)
 }
 
-func (s DoQListener) String() string {
+func (s *DoQListener) String() string {
 	return s.id
 }

--- a/doqlistener.go
+++ b/doqlistener.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"errors"
 	"expvar"
 	"io"
 	"net"
@@ -99,6 +100,11 @@ func (s *DoQListener) Start() error {
 	for {
 		connection, err := s.ln.Accept(context.Background())
 		if err != nil {
+			// The listener was closed by Stop(); return cleanly so the
+			// caller's Start() unblocks instead of spinning on Accept.
+			if errors.Is(err, quic.ErrServerClosed) {
+				return nil
+			}
 			s.log.Warn("failed to accept", "error", err)
 			continue
 		}

--- a/doqlistener_test.go
+++ b/doqlistener_test.go
@@ -1,0 +1,39 @@
+package rdns
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDoQListenerStartStop verifies that Stop() unblocks Start(). This guards
+// two bugs: the value-receiver bug (where the listener bound in Start() was
+// invisible to Stop()) and the Accept loop spinning on ErrServerClosed after
+// the listener is closed. Either one leaves Start() running forever.
+func TestDoQListenerStartStop(t *testing.T) {
+	upstream := new(TestResolver)
+
+	addr, err := getUDPLnAddress()
+	require.NoError(t, err)
+
+	tlsServerConfig, err := TLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+	require.NoError(t, err)
+
+	s := NewQUICListener("test-doq", addr, DoQListenerOptions{TLSConfig: tlsServerConfig}, upstream)
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- s.Start() }()
+
+	// Give the listener a moment to bind and start accepting.
+	time.Sleep(500 * time.Millisecond)
+
+	require.NoError(t, s.Stop())
+
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after Stop; listener is spinning on Accept")
+	}
+}

--- a/doqlistener_test.go
+++ b/doqlistener_test.go
@@ -37,3 +37,37 @@ func TestDoQListenerStartStop(t *testing.T) {
 		t.Fatal("Start did not return after Stop; listener is spinning on Accept")
 	}
 }
+
+// TestDoQListenerStopRaceDuringStart calls Stop() concurrently with Start()
+// binding the socket (the scenario the netns supervisor creates). It must be
+// race-free under -race (s.ln is written by Start and read by Stop) and Start()
+// must return. No queries are sent, so TestResolver is not touched.
+func TestDoQListenerStopRaceDuringStart(t *testing.T) {
+	upstream := new(TestResolver)
+
+	addr, err := getUDPLnAddress()
+	require.NoError(t, err)
+
+	tlsServerConfig, err := TLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+	require.NoError(t, err)
+
+	s := NewQUICListener("test-doq", addr, DoQListenerOptions{TLSConfig: tlsServerConfig}, upstream)
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- s.Start() }()
+
+	// Hammer Stop() (racing Start's bind) and retry until Start returns; Stop
+	// is a no-op until the listener is published.
+	deadline := time.After(5 * time.Second)
+	for {
+		_ = s.Stop()
+		select {
+		case err := <-stopped:
+			require.NoError(t, err)
+			return
+		case <-time.After(20 * time.Millisecond):
+		case <-deadline:
+			t.Fatal("Start did not return while Stop was retried")
+		}
+	}
+}

--- a/listener.go
+++ b/listener.go
@@ -9,6 +9,7 @@ import (
 // Listener is an interface for a DNS listener.
 type Listener interface {
 	Start() error
+	Stop() error
 	fmt.Stringer
 }
 

--- a/netns_watch_linux.go
+++ b/netns_watch_linux.go
@@ -1,0 +1,190 @@
+//go:build linux
+
+package rdns
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const netnsDir = "/var/run/netns"
+
+// NetNSState represents whether a Linux network namespace is currently
+// present in the filesystem.
+type NetNSState int
+
+const (
+	NetNSAbsent NetNSState = iota
+	NetNSPresent
+)
+
+type netnsSubscriber struct {
+	name string
+	ch   chan NetNSState
+}
+
+type netnsWatcher struct {
+	mu          sync.Mutex
+	fd          int
+	watchActive bool
+	subs        []*netnsSubscriber
+}
+
+var (
+	nsWatcherOnce sync.Once
+	nsWatcher     *netnsWatcher
+	nsWatcherErr  error
+)
+
+// SubscribeNetNS returns a channel that receives state changes for the named
+// network namespace, plus a cancel function to unsubscribe. The first value
+// sent reflects the current state once the watcher is established.
+func SubscribeNetNS(name string) (<-chan NetNSState, func(), error) {
+	nsWatcherOnce.Do(func() {
+		nsWatcher, nsWatcherErr = newNetNSWatcher()
+	})
+	if nsWatcherErr != nil {
+		return nil, nil, nsWatcherErr
+	}
+	ch, cancel := nsWatcher.subscribe(name)
+	return ch, cancel, nil
+}
+
+func newNetNSWatcher() (*netnsWatcher, error) {
+	fd, err := unix.InotifyInit1(unix.IN_CLOEXEC)
+	if err != nil {
+		return nil, err
+	}
+	w := &netnsWatcher{fd: fd}
+	go w.read()
+	go w.ensureWatch()
+	return w, nil
+}
+
+// ensureWatch installs the inotify watch on the netns directory, retrying
+// with a slow backoff if the directory does not yet exist.
+func (w *netnsWatcher) ensureWatch() {
+	const mask = unix.IN_CREATE | unix.IN_DELETE | unix.IN_MOVED_TO | unix.IN_MOVED_FROM
+	for {
+		if _, err := unix.InotifyAddWatch(w.fd, netnsDir, mask); err == nil {
+			w.mu.Lock()
+			w.watchActive = true
+			subs := append([]*netnsSubscriber(nil), w.subs...)
+			w.mu.Unlock()
+			for _, s := range subs {
+				sendState(s.ch, currentNetNSState(s.name))
+			}
+			return
+		} else if !errors.Is(err, unix.ENOENT) {
+			Log.Warn("netns watcher: inotify_add_watch failed", "dir", netnsDir, "error", err)
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
+
+// read pulls events from the inotify fd and dispatches them to subscribers.
+func (w *netnsWatcher) read() {
+	var buf [4096]byte
+	for {
+		n, err := unix.Read(w.fd, buf[:])
+		if err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			Log.Warn("netns watcher: read failed", "error", err)
+			return
+		}
+		offset := 0
+		for offset+unix.SizeofInotifyEvent <= n {
+			ev := (*unix.InotifyEvent)(unsafe.Pointer(&buf[offset]))
+			nameLen := int(ev.Len)
+			var name string
+			if nameLen > 0 {
+				start := offset + unix.SizeofInotifyEvent
+				nameBytes := buf[start : start+nameLen]
+				if i := indexZero(nameBytes); i >= 0 {
+					nameBytes = nameBytes[:i]
+				}
+				name = string(nameBytes)
+			}
+			offset += unix.SizeofInotifyEvent + nameLen
+
+			var state NetNSState
+			switch {
+			case ev.Mask&(unix.IN_CREATE|unix.IN_MOVED_TO) != 0:
+				state = NetNSPresent
+			case ev.Mask&(unix.IN_DELETE|unix.IN_MOVED_FROM) != 0:
+				state = NetNSAbsent
+			default:
+				continue
+			}
+			if name == "" {
+				continue
+			}
+			w.dispatch(name, state)
+		}
+	}
+}
+
+func (w *netnsWatcher) dispatch(name string, state NetNSState) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, s := range w.subs {
+		if s.name == name {
+			sendState(s.ch, state)
+		}
+	}
+}
+
+func (w *netnsWatcher) subscribe(name string) (<-chan NetNSState, func()) {
+	s := &netnsSubscriber{name: name, ch: make(chan NetNSState, 16)}
+	w.mu.Lock()
+	w.subs = append(w.subs, s)
+	active := w.watchActive
+	w.mu.Unlock()
+
+	if active {
+		sendState(s.ch, currentNetNSState(name))
+	}
+
+	cancel := func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		for i, ss := range w.subs {
+			if ss == s {
+				w.subs = append(w.subs[:i], w.subs[i+1:]...)
+				return
+			}
+		}
+	}
+	return s.ch, cancel
+}
+
+func currentNetNSState(name string) NetNSState {
+	if _, err := os.Stat(filepath.Join(netnsDir, name)); err == nil {
+		return NetNSPresent
+	}
+	return NetNSAbsent
+}
+
+func sendState(ch chan NetNSState, s NetNSState) {
+	select {
+	case ch <- s:
+	default:
+	}
+}
+
+func indexZero(b []byte) int {
+	for i, c := range b {
+		if c == 0 {
+			return i
+		}
+	}
+	return -1
+}

--- a/netns_watch_linux.go
+++ b/netns_watch_linux.go
@@ -3,6 +3,7 @@
 package rdns
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -97,7 +98,7 @@ func (w *netnsWatcher) read() {
 			if errors.Is(err, unix.EINTR) {
 				continue
 			}
-			Log.Warn("netns watcher: read failed", "error", err)
+			Log.Error("netns watcher: read failed, watcher disabled", "error", err)
 			return
 		}
 		offset := 0
@@ -108,7 +109,7 @@ func (w *netnsWatcher) read() {
 			if nameLen > 0 {
 				start := offset + unix.SizeofInotifyEvent
 				nameBytes := buf[start : start+nameLen]
-				if i := indexZero(nameBytes); i >= 0 {
+				if i := bytes.IndexByte(nameBytes, 0); i >= 0 {
 					nameBytes = nameBytes[:i]
 				}
 				name = string(nameBytes)
@@ -178,13 +179,4 @@ func sendState(ch chan NetNSState, s NetNSState) {
 	case ch <- s:
 	default:
 	}
-}
-
-func indexZero(b []byte) int {
-	for i, c := range b {
-		if c == 0 {
-			return i
-		}
-	}
-	return -1
 }

--- a/netns_watch_linux.go
+++ b/netns_watch_linux.go
@@ -45,7 +45,8 @@ var (
 )
 
 // SubscribeNetNS returns a channel that receives state changes for the named
-// network namespace, plus a cancel function to unsubscribe. The current state
+// network namespace, plus a cancel function to unsubscribe. name must be a
+// namespace name under /var/run/netns, not an absolute path. The current state
 // is delivered immediately on subscription, even if /var/run/netns does not
 // exist yet; subsequent values reflect changes.
 func SubscribeNetNS(name string) (<-chan NetNSState, func(), error) {

--- a/netns_watch_linux.go
+++ b/netns_watch_linux.go
@@ -26,15 +26,16 @@ const (
 )
 
 type netnsSubscriber struct {
-	name string
-	ch   chan NetNSState
+	name    string
+	ch      chan NetNSState
+	last    NetNSState
+	hasLast bool
 }
 
 type netnsWatcher struct {
-	mu          sync.Mutex
-	fd          int
-	watchActive bool
-	subs        []*netnsSubscriber
+	mu   sync.Mutex
+	fd   int
+	subs []*netnsSubscriber
 }
 
 var (
@@ -44,8 +45,9 @@ var (
 )
 
 // SubscribeNetNS returns a channel that receives state changes for the named
-// network namespace, plus a cancel function to unsubscribe. The first value
-// sent reflects the current state once the watcher is established.
+// network namespace, plus a cancel function to unsubscribe. The current state
+// is delivered immediately on subscription, even if /var/run/netns does not
+// exist yet; subsequent values reflect changes.
 func SubscribeNetNS(name string) (<-chan NetNSState, func(), error) {
 	nsWatcherOnce.Do(func() {
 		nsWatcher, nsWatcherErr = newNetNSWatcher()
@@ -74,13 +76,16 @@ func (w *netnsWatcher) ensureWatch() {
 	const mask = unix.IN_CREATE | unix.IN_DELETE | unix.IN_MOVED_TO | unix.IN_MOVED_FROM
 	for {
 		if _, err := unix.InotifyAddWatch(w.fd, netnsDir, mask); err == nil {
+			// Re-sync every subscriber: events that occurred before the
+			// watch was installed (e.g. while the directory didn't exist
+			// yet) were missed. notifyLocked drops any state that hasn't
+			// actually changed, so this won't re-warn for an unchanged
+			// namespace.
 			w.mu.Lock()
-			w.watchActive = true
-			subs := append([]*netnsSubscriber(nil), w.subs...)
-			w.mu.Unlock()
-			for _, s := range subs {
-				sendState(s.ch, currentNetNSState(s.name))
+			for _, s := range w.subs {
+				w.notifyLocked(s, currentNetNSState(s.name))
 			}
+			w.mu.Unlock()
 			return
 		} else if !errors.Is(err, unix.ENOENT) {
 			Log.Warn("netns watcher: inotify_add_watch failed", "dir", netnsDir, "error", err)
@@ -138,21 +143,22 @@ func (w *netnsWatcher) dispatch(name string, state NetNSState) {
 	defer w.mu.Unlock()
 	for _, s := range w.subs {
 		if s.name == name {
-			sendState(s.ch, state)
+			w.notifyLocked(s, state)
 		}
 	}
 }
 
 func (w *netnsWatcher) subscribe(name string) (<-chan NetNSState, func()) {
 	s := &netnsSubscriber{name: name, ch: make(chan NetNSState, 16)}
+	state := currentNetNSState(name)
+
 	w.mu.Lock()
 	w.subs = append(w.subs, s)
-	active := w.watchActive
+	// Deliver the current state immediately so the caller learns the
+	// namespace is absent even when /var/run/netns doesn't exist yet and the
+	// inotify watch hasn't been installed.
+	w.notifyLocked(s, state)
 	w.mu.Unlock()
-
-	if active {
-		sendState(s.ch, currentNetNSState(name))
-	}
 
 	cancel := func() {
 		w.mu.Lock()
@@ -174,9 +180,19 @@ func currentNetNSState(name string) NetNSState {
 	return NetNSAbsent
 }
 
-func sendState(ch chan NetNSState, s NetNSState) {
+// notifyLocked delivers a state change to a subscriber, skipping it if the
+// subscriber's last delivered state is identical. The send is non-blocking; if
+// the channel buffer is full the state is dropped without being recorded, so
+// it is retried on the next event rather than being deduplicated away. Must be
+// called with w.mu held.
+func (w *netnsWatcher) notifyLocked(s *netnsSubscriber, state NetNSState) {
+	if s.hasLast && s.last == state {
+		return
+	}
 	select {
-	case ch <- s:
+	case s.ch <- state:
+		s.last = state
+		s.hasLast = true
 	default:
 	}
 }

--- a/netns_watch_linux_test.go
+++ b/netns_watch_linux_test.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package rdns
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testNonexistentNS = "rdns-test-nonexistent-namespace"
+
+// Subscribing must deliver the current state immediately, without waiting for
+// the inotify watch to be installed. This is the case that previously logged
+// nothing at startup when /var/run/netns did not exist yet: the watch never
+// became active, so no initial state was ever delivered.
+func TestNetNSWatcherSubscribeDeliversInitialState(t *testing.T) {
+	w := &netnsWatcher{} // no read/ensureWatch goroutines started
+
+	ch, cancel := w.subscribe(testNonexistentNS)
+	defer cancel()
+
+	select {
+	case state := <-ch:
+		require.Equal(t, NetNSAbsent, state)
+	case <-time.After(time.Second):
+		t.Fatal("expected initial state on subscribe, got none")
+	}
+}
+
+// A re-sync or repeated event with an unchanged state must not be delivered
+// again, so the supervisor doesn't log a duplicate "waiting" warning.
+func TestNetNSWatcherDeduplicatesState(t *testing.T) {
+	w := &netnsWatcher{}
+
+	ch, cancel := w.subscribe(testNonexistentNS)
+	defer cancel()
+
+	// Drain the initial Absent.
+	require.Equal(t, NetNSAbsent, <-ch)
+
+	// A duplicate Absent (e.g. ensureWatch's re-sync) must be deduplicated.
+	w.dispatch(testNonexistentNS, NetNSAbsent)
+	select {
+	case <-ch:
+		t.Fatal("duplicate Absent should have been deduplicated")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// A genuine change must be delivered.
+	w.dispatch(testNonexistentNS, NetNSPresent)
+	select {
+	case state := <-ch:
+		require.Equal(t, NetNSPresent, state)
+	case <-time.After(time.Second):
+		t.Fatal("expected NetNSPresent to be delivered")
+	}
+}

--- a/netns_watch_other.go
+++ b/netns_watch_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package rdns
+
+import "fmt"
+
+type NetNSState int
+
+const (
+	NetNSAbsent NetNSState = iota
+	NetNSPresent
+)
+
+func SubscribeNetNS(name string) (<-chan NetNSState, func(), error) {
+	return nil, nil, fmt.Errorf("network namespaces are only supported on Linux")
+}


### PR DESCRIPTION
## Summary
Closes the journal-spam complaint in #516. A listener configured with `netns = "<name>"` no longer retries `Start()` once per second when the namespace is absent. Instead, it warns once, watches `/var/run/netns/` via inotify, and starts the listener as soon as the namespace appears. If the namespace is later removed the listener is stopped cleanly; when it returns the listener is rebuilt and started again.

## Approach
- `Listener` gains `Stop() error`. Six of seven implementations already had one; only `DNSListener` needed adding (one-liner wrapping `dns.Server.Shutdown()`).
- New internal `netnsWatcher` (`netns_watch_linux.go`) — process-wide inotify watch on `/var/run/netns/`, demuxed per namespace name. Exported `SubscribeNetNS` / `NetNSState` API. Stub on non-Linux returns "not supported". No new module deps; uses `golang.org/x/sys/unix` already in `go.mod`.
- The startup loop in `cmd/routedns/main.go` is split: each `case` of the protocol switch produces a `build` closure that constructs a fresh listener instance. Listeners without `netns` are built once and run through the existing retry loop. Listeners with `netns` go through a new `superviseNetNSListener` helper that drives the lifecycle off `SubscribeNetNS` events.
- A fresh instance is built on each namespace-present event, because some listener types (DoH/Admin/ODoH wrap `http.Server`) cannot be restarted after `Shutdown` — `ListenAndServe` returns `ErrServerClosed` permanently.
- Resolvers/clients with `netns` are out of scope: they fail at dial time and don't cause spam.

## Behavior
- `netns "foo"` configured, namespace absent at startup → single `WARN netns "foo" not present, waiting`. No further log activity until state changes.
- `ip netns add foo` → `INFO netns present, starting listener` and the listener binds.
- `ip netns delete foo` → `WARN netns "foo" gone, stopping listener`, listener stopped cleanly.
- Re-create the namespace → listener rebuilt and started automatically.
- Multiple listeners sharing one namespace share a single inotify watch.

## Notes
- Listeners without `netns` are unaffected.
- Non-Linux build paths return the existing "namespaces only supported on Linux" error.