### PR TITLE
Note CAP_NET_RAW for bind-if is only needed on Linux <5.7

### DIFF
--- a/cmd/routedns/routedns.service
+++ b/cmd/routedns/routedns.service
@@ -16,7 +16,9 @@ WorkingDirectory=/opt/routedns
 #   CAP_NET_ADMIN        - required by the `fwmark` option (SO_MARK) on
 #                          listeners/resolvers.
 #   CAP_NET_RAW          - required by the `bind-if` option (SO_BINDTODEVICE)
-#                          on listeners/resolvers.
+#                          on listeners/resolvers when running on Linux
+#                          kernels older than 5.7. Since 5.7 it is not
+#                          needed for the initial bind to an interface.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 ExecStart=/opt/routedns/routedns config.toml
 Restart=on-failure


### PR DESCRIPTION
## Summary
- Follow-up to #521 addressing [@alpominth's comment](https://github.com/folbricht/routedns/pull/521#issuecomment-4323288794).
- Linux kernel commit [c427bfec18f2](https://github.com/torvalds/linux/commit/c427bfec18f2190b8f4718785ee8ed2db4f84ee6) ("net: core: enable SO_BINDTODEVICE for non-root users"), released in v5.7, removed the `CAP_NET_RAW` requirement for the initial bind to an interface (changing an already-bound socket still needs it).
- routedns only sets `SO_BINDTODEVICE` once on a fresh socket (`sockopts_linux.go`), so on 5.7+ kernels no capability is required for `bind-if`.
- Updates the comment in `routedns.service` to reflect this; active capabilities are unchanged.