### PR TITLE
request-dedup: include DO/CD/qclass in key and restore caller's transaction ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/folbricht/routedns
 
-go 1.24.4
-
-toolchain go1.24.7
+go 1.25.0
 
 require (
 	github.com/0xERR0R/expiration-cache v0.1.0

--- a/request-dedup.go
+++ b/request-dedup.go
@@ -2,6 +2,7 @@ package rdns
 
 import (
 	"encoding/binary"
+	"strings"
 	"sync"
 
 	"github.com/miekg/dns"
@@ -10,6 +11,9 @@ import (
 type dedupKey struct {
 	name        string
 	qtype       uint16
+	qclass      uint16
+	do          bool
+	cd          bool
 	ecs_ipv4    uint32
 	ecs_ipv6_hi uint64
 	ecs_ipv6_lo uint64
@@ -49,10 +53,12 @@ func (r *requestDedup) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		ecsIPv4              uint32
 		ecsIPv6Lo, ecsIPv6Hi uint64
 		ecsMask              uint8
+		do                   bool
 	)
 
 	edns0 := q.IsEdns0()
 	if edns0 != nil {
+		do = edns0.Do()
 		// Find the ECS option
 		for _, opt := range edns0.Option {
 			ecs, ok := opt.(*dns.EDNS0_SUBNET)
@@ -71,8 +77,11 @@ func (r *requestDedup) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		}
 	}
 	k := dedupKey{
-		name:        q.Question[0].Name,
+		name:        strings.ToLower(q.Question[0].Name),
 		qtype:       q.Question[0].Qtype,
+		qclass:      q.Question[0].Qclass,
+		do:          do,
+		cd:          q.CheckingDisabled,
 		ecs_ipv4:    ecsIPv4,
 		ecs_ipv6_hi: ecsIPv6Hi,
 		ecs_ipv6_lo: ecsIPv6Lo,
@@ -96,9 +105,12 @@ func (r *requestDedup) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		log.Debug("duplicated request, waiting for first answer")
 		<-req.done
 		a, err := req.answer, req.err
-		// Return a copy of the answer as other elements might be modifying it
+		// Return a copy of the answer as other elements might be modifying it,
+		// and restore this caller's transaction ID and Question section.
 		if a != nil {
 			a = a.Copy()
+			a.Id = q.Id
+			a.Question = q.Question
 		}
 		return a, err
 	}
@@ -118,7 +130,10 @@ func (r *requestDedup) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	// Return a copy since it could be modified in the chain (i.e. in the listener)
 	// but it's also stored for other goroutines which need to copy it.
 	if a != nil {
-		return a.Copy(), err
+		a = a.Copy()
+		a.Id = q.Id
+		a.Question = q.Question
+		return a, err
 	}
 	return a, err
 }

--- a/request-dedup_test.go
+++ b/request-dedup_test.go
@@ -3,6 +3,7 @@ package rdns
 import (
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/miekg/dns"
@@ -10,30 +11,119 @@ import (
 )
 
 func TestRequestDedup(t *testing.T) {
-	var ci ClientInfo
-	r := &TestResolver{
-		ResolveFunc: func(*dns.Msg, ClientInfo) (*dns.Msg, error) {
-			time.Sleep(time.Second) // need to slow down to guarantee duplicates
-			return nil, nil
-		},
-	}
+	synctest.Test(t, func(t *testing.T) {
+		var ci ClientInfo
+		r := &TestResolver{
+			ResolveFunc: func(*dns.Msg, ClientInfo) (*dns.Msg, error) {
+				time.Sleep(time.Second)
+				return nil, nil
+			},
+		}
 
-	g := NewRequestDedup("test-dedup", r)
-	q := new(dns.Msg)
-	q.SetQuestion("example.com.", dns.TypeA)
+		g := NewRequestDedup("test-dedup", r)
+		q := new(dns.Msg)
+		q.SetQuestion("example.com.", dns.TypeA)
 
-	// Send a batch of queries
-	var wg sync.WaitGroup
-	for range 10 {
+		// Send a batch of queries
+		var wg sync.WaitGroup
+		for range 10 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := g.Resolve(q, ci)
+				require.NoError(t, err)
+			}()
+		}
+		wg.Wait()
+
+		// Only one request should have hit the resolver
+		require.Equal(t, 1, r.HitCount())
+	})
+}
+
+func TestRequestDedupDOBitNotCoalesced(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var ci ClientInfo
+		r := &TestResolver{
+			ResolveFunc: func(q *dns.Msg, _ ClientInfo) (*dns.Msg, error) {
+				time.Sleep(time.Second)
+				a := new(dns.Msg)
+				a.SetReply(q)
+				return a, nil
+			},
+		}
+		g := NewRequestDedup("test-dedup", r)
+
+		var wg sync.WaitGroup
+
+		// Query 1: DO=0
+		q1 := new(dns.Msg)
+		q1.SetQuestion("example.com.", dns.TypeA)
 		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_, err := g.Resolve(q, ci)
-			require.NoError(t, err)
-		}()
-	}
-	wg.Wait()
+		go func() { defer wg.Done(); g.Resolve(q1, ci) }()
+		synctest.Wait() // q1 is now in-flight upstream
 
-	// Only one request should have hit the resolver
-	require.Equal(t, 1, r.HitCount())
+		// Query 2: same name/type but DO=1 — must NOT coalesce with q1
+		q2 := new(dns.Msg)
+		q2.SetQuestion("example.com.", dns.TypeA)
+		q2.SetEdns0(4096, true)
+		wg.Add(1)
+		go func() { defer wg.Done(); g.Resolve(q2, ci) }()
+		synctest.Wait()
+
+		// Both queries must have reached the upstream resolver independently.
+		// If q2 had coalesced onto q1 it would be parked on req.done and the
+		// hit count would be 1.
+		require.Equal(t, 2, r.HitCount(), "DO=1 query was coalesced onto in-flight DO=0 query")
+
+		wg.Wait()
+	})
+}
+
+func TestRequestDedupRestoresIdAndQuestion(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var ci ClientInfo
+		r := &TestResolver{
+			ResolveFunc: func(q *dns.Msg, _ ClientInfo) (*dns.Msg, error) {
+				time.Sleep(time.Second)
+				a := new(dns.Msg)
+				a.SetReply(q)
+				return a, nil
+			},
+		}
+		g := NewRequestDedup("test-dedup", r)
+
+		type result struct {
+			a   *dns.Msg
+			err error
+		}
+		c1, c2 := make(chan result, 1), make(chan result, 1)
+
+		// Query 1: Id=100, mixed-case name
+		q1 := new(dns.Msg)
+		q1.SetQuestion("Example.COM.", dns.TypeA)
+		q1.Id = 100
+		go func() { a, err := g.Resolve(q1, ci); c1 <- result{a, err} }()
+		synctest.Wait() // q1 is the leader, now blocked upstream
+
+		// Query 2: Id=200, different case — must coalesce onto q1
+		q2 := new(dns.Msg)
+		q2.SetQuestion("example.com.", dns.TypeA)
+		q2.Id = 200
+		go func() { a, err := g.Resolve(q2, ci); c2 <- result{a, err} }()
+		synctest.Wait() // q2 is parked on req.done
+
+		// Only the leader hit upstream
+		require.Equal(t, 1, r.HitCount())
+
+		r1, r2 := <-c1, <-c2
+		require.NoError(t, r1.err)
+		require.NoError(t, r2.err)
+
+		// Each caller gets its own transaction ID and Question section back
+		require.Equal(t, uint16(100), r1.a.Id)
+		require.Equal(t, "Example.COM.", r1.a.Question[0].Name)
+		require.Equal(t, uint16(200), r2.a.Id)
+		require.Equal(t, "example.com.", r2.a.Question[0].Name)
+	})
 }


### PR DESCRIPTION
## Problem

The `request-dedup` group coalesces concurrent identical queries onto a single upstream request, but its dedup key was too coarse and the shared response was returned verbatim to every waiter. Two bugs:

**1. DNSSEC stripping via key collision.** The key was `{Name, Qtype, ECS}` only. It omitted `Qclass`, the EDNS0 DO bit, and the CD header bit, and the name was compared case-sensitively. A DO=0 query that arrived just before a DO=1 query for the same name would absorb it, and the validating client would receive the upstream's RRSIG-less response. An on-path client of the same routedns instance can exploit this by racing DO=0 lookups against a victim's DO=1 lookups.

**2. Wrong transaction ID returned to coalesced clients.** Every waiting client received `req.answer.Copy()`, which carries the *first* caller's `Msg.Id` and `Question` section. The second client's stub resolver sees a response whose ID doesn't match its query, discards it as a potential spoof, and times out.

## Fix

- Extend `dedupKey` with `qclass`, `do`, `cd` and lower-case the name, so only queries that are guaranteed to produce the same upstream response are merged.
- After copying the shared answer, restore each caller's own `Id` and `Question` (same pattern as `cache-memory.go` / `cache-redis.go`).

## Tests

Rewrote `request-dedup_test.go` to use `testing/synctest` for deterministic, instant concurrency tests:

- `TestRequestDedup` — existing 10-way fan-in, now runs in virtual time instead of sleeping 1s.
- `TestRequestDedupDOBitNotCoalesced` — DO=0 and DO=1 for the same name must both reach upstream while the first is in flight.
- `TestRequestDedupRestoresIdAndQuestion` — two queries differing only in Id and name case coalesce to one upstream hit, but each caller gets its own Id and original question case back.

Bumps the module to **Go 1.25** since `testing/synctest` became stable in that release.
