### PR TITLE
dnssec: bind DNSKEY self-signature to a DS-matched key

### DIFF
--- a/dnssec/validator.go
+++ b/dnssec/validator.go
@@ -151,7 +151,6 @@ func (v *Validator) buildChainOfTrust(zone string) (zsk, ksk []*dns.DNSKEY, err 
 		return nil, nil, fmt.Errorf("%w: no KSK for %s", ErrNoKey, zone)
 	}
 
-	// Find an RRSIG covering the DNSKEY RRset signed by this zone
 	allKeys := make([]dns.RR, 0, len(fetchedZSK)+len(fetchedKSK))
 	for _, k := range fetchedZSK {
 		allKeys = append(allKeys, k)
@@ -160,34 +159,17 @@ func (v *Validator) buildChainOfTrust(zone string) (zsk, ksk []*dns.DNSKEY, err 
 		allKeys = append(allKeys, k)
 	}
 
-	var dnsSig *dns.RRSIG
-	for _, sig := range dnsSigs {
-		if dns.CanonicalName(sig.SignerName) == zone && sig.TypeCovered == dns.TypeDNSKEY {
-			dnsSig = sig
-			break
-		}
-	}
-	if dnsSig == nil {
-		return nil, nil, fmt.Errorf("%w: no RRSIG covering DNSKEY for %s", ErrNoSignature, zone)
-	}
-
-	// Verify the DNSKEY RRset self-signature using a KSK
-	if err := verifyRRSIG(dnsSig, fetchedKSK, allKeys); err != nil {
-		return nil, nil, fmt.Errorf("DNSKEY self-signature verification failed for %s: %w", zone, err)
-	}
-
+	// Obtain authenticated DS records for this zone — from the configured
+	// trust anchor for the root, or by recursing into the parent otherwise.
+	var dsRecords []*dns.DS
 	if zone == "." {
-		// For the root zone, validate KSK against the trust anchor DS records
-		ds := v.ks.getDS(".")
-		if len(ds) == 0 {
+		dsRecords = v.ks.getDS(".")
+		if len(dsRecords) == 0 {
 			return nil, nil, ErrNoTrustAnchor
 		}
-		if err := verifyDNSKEYWithDS(fetchedKSK, ds); err != nil {
-			return nil, nil, fmt.Errorf("root KSK doesn't match trust anchor: %w", err)
-		}
 	} else {
-		// For non-root zones, look up DS from parent and validate
-		dsRecords, dsSigs, err := v.lookupDS(zone)
+		var dsSigs []*dns.RRSIG
+		dsRecords, dsSigs, err = v.lookupDS(zone)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to lookup DS for %s: %w", zone, err)
 		}
@@ -195,20 +177,17 @@ func (v *Validator) buildChainOfTrust(zone string) (zsk, ksk []*dns.DNSKEY, err 
 			return nil, nil, fmt.Errorf("%w: %s", ErrInsecureDelegation, zone)
 		}
 
-		// Recursively build chain of trust for the parent zone
 		parent := parentZone(zone)
 		parentZSK, _, err := v.buildChainOfTrust(parent)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to build chain of trust for parent %s: %w", parent, err)
 		}
 
-		// Verify the DS RRSIG with the parent's ZSK
 		if len(dsSigs) > 0 {
 			dsRRset := make([]dns.RR, len(dsRecords))
 			for i, d := range dsRecords {
 				dsRRset[i] = d
 			}
-			// Try each DS RRSIG
 			var verified bool
 			for _, dsSig := range dsSigs {
 				if err := verifyRRSIG(dsSig, parentZSK, dsRRset); err == nil {
@@ -220,11 +199,32 @@ func (v *Validator) buildChainOfTrust(zone string) (zsk, ksk []*dns.DNSKEY, err 
 				return nil, nil, fmt.Errorf("%w: DS RRSIG for %s", ErrSignatureInvalid, zone)
 			}
 		}
+	}
 
-		// Verify that a KSK matches a DS record
-		if err := verifyDNSKEYWithDS(fetchedKSK, dsRecords); err != nil {
-			return nil, nil, fmt.Errorf("KSK doesn't match DS for %s: %w", zone, err)
+	// RFC 4035 §5.2: the DNSKEY RRset must be signed by a key that itself
+	// chains to an authenticated DS. Restrict candidate signing keys to
+	// those matching a DS before accepting the self-signature.
+	trustedKSK := filterKeysByDS(fetchedKSK, dsRecords)
+	if len(trustedKSK) == 0 {
+		return nil, nil, fmt.Errorf("KSK doesn't match DS for %s: %w", zone, ErrDSMismatch)
+	}
+
+	var sigSeen, sigVerified bool
+	for _, sig := range dnsSigs {
+		if dns.CanonicalName(sig.SignerName) != zone || sig.TypeCovered != dns.TypeDNSKEY {
+			continue
 		}
+		sigSeen = true
+		if err := verifyRRSIG(sig, trustedKSK, allKeys); err == nil {
+			sigVerified = true
+			break
+		}
+	}
+	if !sigSeen {
+		return nil, nil, fmt.Errorf("%w: no RRSIG covering DNSKEY for %s", ErrNoSignature, zone)
+	}
+	if !sigVerified {
+		return nil, nil, fmt.Errorf("DNSKEY self-signature verification failed for %s: %w", zone, ErrSignatureInvalid)
 	}
 
 	// Cache the validated keys
@@ -339,22 +339,23 @@ func verifyRRSIG(sig *dns.RRSIG, keys []*dns.DNSKEY, rrset []dns.RR) error {
 	return fmt.Errorf("%w: %v", ErrSignatureInvalid, lastErr)
 }
 
-// verifyDNSKEYWithDS verifies that at least one of the provided KSKs
-// matches one of the DS records by computing the DS digest from the key
-// and comparing it.
-func verifyDNSKEYWithDS(ksk []*dns.DNSKEY, ds []*dns.DS) error {
-	for _, d := range ds {
-		for _, key := range ksk {
+// filterKeysByDS returns the subset of keys whose computed DS digest matches
+// one of the provided DS records.
+func filterKeysByDS(keys []*dns.DNSKEY, ds []*dns.DS) []*dns.DNSKEY {
+	var result []*dns.DNSKEY
+	for _, key := range keys {
+		for _, d := range ds {
 			computed := key.ToDS(d.DigestType)
 			if computed == nil {
 				continue
 			}
 			if strings.EqualFold(computed.Digest, d.Digest) {
-				return nil
+				result = append(result, key)
+				break
 			}
 		}
 	}
-	return ErrDSMismatch
+	return result
 }
 
 // rrsetKey identifies an RRset by name and type.

--- a/dnssec/validator_test.go
+++ b/dnssec/validator_test.go
@@ -42,7 +42,7 @@ func TestGroupRRsByTypeAndName(t *testing.T) {
 	require.Nil(t, sigs[aaaaKey])
 }
 
-func TestVerifyDNSKEYWithDS(t *testing.T) {
+func TestFilterKeysByDS(t *testing.T) {
 	// Use the real IANA root KSK for this test
 	rootKSKRR, err := dns.NewRR(". 172800 IN DNSKEY 257 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3 +/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kv ArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF 0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+e oZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfd RUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwN R1AkUTV74bU=")
 	require.NoError(t, err)
@@ -52,15 +52,16 @@ func TestVerifyDNSKEYWithDS(t *testing.T) {
 	ds := rootKSK.ToDS(dns.SHA256)
 	require.NotNil(t, ds)
 
-	// Matching should succeed
-	err = verifyDNSKEYWithDS([]*dns.DNSKEY{rootKSK}, []*dns.DS{ds})
-	require.NoError(t, err)
+	// Matching should return the key
+	matched := filterKeysByDS([]*dns.DNSKEY{rootKSK}, []*dns.DS{ds})
+	require.Len(t, matched, 1)
+	require.Same(t, rootKSK, matched[0])
 
-	// Wrong digest should fail
+	// Wrong digest should return nothing
 	badDS := *ds
 	badDS.Digest = "0000000000000000000000000000000000000000000000000000000000000000"
-	err = verifyDNSKEYWithDS([]*dns.DNSKEY{rootKSK}, []*dns.DS{&badDS})
-	require.ErrorIs(t, err, ErrDSMismatch)
+	matched = filterKeysByDS([]*dns.DNSKEY{rootKSK}, []*dns.DS{&badDS})
+	require.Empty(t, matched)
 }
 
 func TestValidateNoRRSIG(t *testing.T) {


### PR DESCRIPTION
### Problem

`buildChainOfTrust` performed two independent checks on the fetched KSK set:

1. The DNSKEY RRset self-signature was verified against *any* key in
   `fetchedKSK` whose tag/algorithm matched the RRSIG.
2. Separately, *some* key in `fetchedKSK` had to hash to *some* parent DS.

The signing key from (1) was never required to be the key that satisfied (2).
This violates RFC 4035 §5.2, which requires the DNSKEY RRset to be signed by
a key that itself authenticates against the parent DS.

### Fix

- Replace `verifyDNSKEYWithDS` with `filterKeysByDS`, which returns the
  subset of KSKs whose computed digest matches a DS record.
- Reorder `buildChainOfTrust` to obtain authenticated DS records first, then
  filter the fetched KSKs to the DS-matched subset and verify the DNSKEY
  self-signature against that subset only.
- Iterate over all candidate DNSKEY RRSIGs rather than the first one, so
  KSK rollovers with multiple signatures still validate under the stricter
  filter.

### Testing

`go test ./dnssec/` passes. `TestVerifyDNSKEYWithDS` was renamed to
`TestFilterKeysByDS` and updated to assert on the returned key slice.