### PR TITLE
dnssec: require authenticated denial before treating a zone as insecure

### DIFF
--- a/dnssec/denial.go
+++ b/dnssec/denial.go
@@ -1,0 +1,79 @@
+package dnssec
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/miekg/dns"
+)
+
+// ErrBogusDenial is returned when an empty DS response lacks an
+// authenticated NSEC/NSEC3 proof that the DS RRset does not exist.
+// Callers must treat this as a validation failure (bogus), never as an
+// insecure delegation.
+var ErrBogusDenial = errors.New("dnssec: unauthenticated denial of DS")
+
+// verifyDSDenial checks that resp's authority section carries NSEC or NSEC3
+// records, signed by one of the supplied parent-zone keys, that prove no DS
+// RRset exists at name. RFC 4035 §5.2 / RFC 5155 §8.
+func verifyDSDenial(resp *dns.Msg, name string, parentKeys []*dns.DNSKEY) error {
+	name = dns.CanonicalName(name)
+	rrsets, sigs := groupRRsByTypeAndName(resp.Ns)
+
+	for key, rrset := range rrsets {
+		if key.rrtype != dns.TypeNSEC && key.rrtype != dns.TypeNSEC3 {
+			continue
+		}
+		sig, ok := sigs[key]
+		if !ok {
+			continue
+		}
+		if err := verifyRRSIG(sig, parentKeys, rrset); err != nil {
+			continue
+		}
+		for _, rr := range rrset {
+			switch r := rr.(type) {
+			case *dns.NSEC:
+				if nsecDeniesDS(r, name) {
+					return nil
+				}
+			case *dns.NSEC3:
+				if nsec3DeniesDS(r, name) {
+					return nil
+				}
+			}
+		}
+	}
+	return fmt.Errorf("%w for %s", ErrBogusDenial, name)
+}
+
+// nsecDeniesDS reports whether the NSEC record proves an insecure delegation
+// at name: the name exists as a delegation (NS bit set) in the parent zone
+// but carries no DS. RFC 6840 §4.4.
+func nsecDeniesDS(r *dns.NSEC, name string) bool {
+	if dns.CanonicalName(r.Hdr.Name) != name {
+		return false
+	}
+	return bitmapProvesInsecureDelegation(r.TypeBitMap)
+}
+
+// nsec3DeniesDS reports whether the NSEC3 record proves an insecure
+// delegation at name, either by an exact hash match with NS-but-no-DS, or by
+// an opt-out span covering the hashed name (RFC 5155 §6, §8.6).
+func nsec3DeniesDS(r *dns.NSEC3, name string) bool {
+	if r.Match(name) {
+		return bitmapProvesInsecureDelegation(r.TypeBitMap)
+	}
+	return r.Flags&1 != 0 && r.Cover(name)
+}
+
+// bitmapProvesInsecureDelegation reports whether an NSEC/NSEC3 type bitmap at
+// a delegation point indicates an unsigned child: NS present, DS and SOA
+// absent. SOA present would mean we are at the child apex, not the parent
+// side of the cut.
+func bitmapProvesInsecureDelegation(bitmap []uint16) bool {
+	return slices.Contains(bitmap, dns.TypeNS) &&
+		!slices.Contains(bitmap, dns.TypeDS) &&
+		!slices.Contains(bitmap, dns.TypeSOA)
+}

--- a/dnssec/validator.go
+++ b/dnssec/validator.go
@@ -105,20 +105,54 @@ func (v *Validator) Validate(answer *dns.Msg) error {
 	return nil
 }
 
-// checkInsecureDelegation checks whether a zone is an insecure delegation
-// (i.e., the parent zone has no DS record for it).
-func (v *Validator) checkInsecureDelegation(zone string) error {
-	if zone == "." {
+// checkInsecureDelegation walks the delegation chain from the root toward
+// name, returning ErrInsecureDelegation at the first cut where the parent
+// authentically proves (via signed NSEC/NSEC3) that no DS record exists.
+// An empty DS response without such proof is bogus, not insecure
+// (RFC 4035 §5.2, RFC 6840 §5.2).
+func (v *Validator) checkInsecureDelegation(name string) error {
+	name = dns.CanonicalName(name)
+	if name == "." {
 		return nil
 	}
-	ds, _, err := v.lookupDS(zone)
-	if err != nil {
-		return err
-	}
-	if len(ds) == 0 {
-		return fmt.Errorf("%w: %s", ErrInsecureDelegation, zone)
+	labels := dns.SplitDomainName(name)
+	for i := len(labels) - 1; i >= 0; i-- {
+		zone := dns.Fqdn(strings.Join(labels[i:], "."))
+		insecure, err := v.proveNoDS(zone)
+		if err != nil {
+			return err
+		}
+		if insecure {
+			return fmt.Errorf("%w: %s", ErrInsecureDelegation, zone)
+		}
 	}
 	return nil
+}
+
+// proveNoDS returns true when zone has no DS RRset and that absence is
+// authenticated by the parent zone's signed NSEC/NSEC3. It returns false when
+// DS records are present, and an error when the absence cannot be
+// authenticated.
+func (v *Validator) proveNoDS(zone string) (bool, error) {
+	ds, _, resp, err := v.lookupDS(zone)
+	if err != nil {
+		return false, err
+	}
+	if len(ds) > 0 {
+		return false, nil
+	}
+	parent := parentZone(zone)
+	parentZSK, _, err := v.buildChainOfTrust(parent)
+	if err != nil {
+		if errors.Is(err, ErrInsecureDelegation) {
+			return true, nil
+		}
+		return false, err
+	}
+	if err := verifyDSDenial(resp, zone, parentZSK); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // validateRRset validates a set of RRs against the provided RRSIG by
@@ -168,22 +202,29 @@ func (v *Validator) buildChainOfTrust(zone string) (zsk, ksk []*dns.DNSKEY, err 
 			return nil, nil, ErrNoTrustAnchor
 		}
 	} else {
-		var dsSigs []*dns.RRSIG
-		dsRecords, dsSigs, err = v.lookupDS(zone)
+		var (
+			dsSigs []*dns.RRSIG
+			dsResp *dns.Msg
+		)
+		dsRecords, dsSigs, dsResp, err = v.lookupDS(zone)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to lookup DS for %s: %w", zone, err)
-		}
-		if len(dsRecords) == 0 {
-			return nil, nil, fmt.Errorf("%w: %s", ErrInsecureDelegation, zone)
-		}
-		if len(dsSigs) == 0 {
-			return nil, nil, fmt.Errorf("%w: DS for %s", ErrNoSignature, zone)
 		}
 
 		parent := parentZone(zone)
 		parentZSK, _, err := v.buildChainOfTrust(parent)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to build chain of trust for parent %s: %w", parent, err)
+		}
+
+		if len(dsRecords) == 0 {
+			if err := verifyDSDenial(dsResp, zone, parentZSK); err != nil {
+				return nil, nil, err
+			}
+			return nil, nil, fmt.Errorf("%w: %s", ErrInsecureDelegation, zone)
+		}
+		if len(dsSigs) == 0 {
+			return nil, nil, fmt.Errorf("%w: DS for %s", ErrNoSignature, zone)
 		}
 
 		dsRRset := make([]dns.RR, len(dsRecords))
@@ -265,36 +306,35 @@ func (v *Validator) lookupDNSKEY(name string) (zsk, ksk []*dns.DNSKEY, sigs []*d
 	return
 }
 
-// lookupDS queries for DS records for the given zone and returns
-// the DS records and their covering RRSIGs.
-func (v *Validator) lookupDS(name string) ([]*dns.DS, []*dns.RRSIG, error) {
+// lookupDS queries for DS records for the given zone and returns the DS
+// records, their covering RRSIGs, and the full response so callers can
+// inspect the authority section for NSEC/NSEC3 denial.
+func (v *Validator) lookupDS(name string) ([]*dns.DS, []*dns.RRSIG, *dns.Msg, error) {
 	q := new(dns.Msg)
 	q.SetQuestion(dns.CanonicalName(name), dns.TypeDS)
 	q.SetEdns0(4096, true)
 	q.MsgHdr.CheckingDisabled = true
 	a, err := v.resolver(q)
 	if err != nil {
-		return nil, nil, err
-	}
-	if a.Rcode != dns.RcodeSuccess {
-		// NXDOMAIN or other errors mean no DS — insecure delegation
-		return nil, nil, nil
+		return nil, nil, nil, err
 	}
 	var (
 		ds   []*dns.DS
 		sigs []*dns.RRSIG
 	)
-	for _, rr := range a.Answer {
-		switch r := rr.(type) {
-		case *dns.DS:
-			ds = append(ds, r)
-		case *dns.RRSIG:
-			if r.TypeCovered == dns.TypeDS {
-				sigs = append(sigs, r)
+	if a.Rcode == dns.RcodeSuccess {
+		for _, rr := range a.Answer {
+			switch r := rr.(type) {
+			case *dns.DS:
+				ds = append(ds, r)
+			case *dns.RRSIG:
+				if r.TypeCovered == dns.TypeDS {
+					sigs = append(sigs, r)
+				}
 			}
 		}
 	}
-	return ds, sigs, nil
+	return ds, sigs, a, nil
 }
 
 // parentZone returns the parent zone of the given zone name.

--- a/dnssec/validator_chain_test.go
+++ b/dnssec/validator_chain_test.go
@@ -2,6 +2,7 @@ package dnssec
 
 import (
 	"crypto"
+	"errors"
 	"testing"
 	"time"
 
@@ -119,6 +120,212 @@ func TestBuildChainOfTrustAcceptsSignedDS(t *testing.T) {
 	answer.Answer = []dns.RR{childA, childASig}
 
 	require.NoError(t, v.Validate(answer))
+}
+
+// TestValidateRejectsStrippedRRSIGWithEmptyDS reproduces the downgrade attack
+// where an on-path attacker strips the RRSIG from a signed zone's answer and
+// then replies NODATA to the validator's follow-up DS query. Without an
+// authenticated NSEC/NSEC3 denial, the empty DS response must be treated as
+// bogus, not as proof of an insecure delegation.
+func TestValidateRejectsStrippedRRSIGWithEmptyDS(t *testing.T) {
+	now := time.Now()
+
+	rootKSK, rootKSKpriv := genKey(t, ".", 257)
+	rootZSK, _ := genKey(t, ".", 256)
+	rootDNSKEYSig := signRRset(t, rootKSK, rootKSKpriv, now, []dns.RR{rootZSK, rootKSK})
+
+	// Forged answer for a zone that is actually signed. Attacker strips the
+	// covering RRSIG so the validator falls into checkInsecureDelegation.
+	forgedA, _ := dns.NewRR("signed. 300 IN A 6.6.6.6")
+
+	resolver := func(q *dns.Msg) (*dns.Msg, error) {
+		a := new(dns.Msg)
+		a.SetReply(q)
+		name := dns.CanonicalName(q.Question[0].Name)
+		switch q.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			if name == "." {
+				a.Answer = []dns.RR{rootZSK, rootKSK, rootDNSKEYSig}
+			}
+		case dns.TypeDS:
+			// Attacker returns empty NOERROR with no NSEC/NSEC3 in
+			// authority — an unauthenticated denial.
+		}
+		return a, nil
+	}
+
+	v := NewValidator(WithResolver(resolver), WithTime(func() time.Time { return now }))
+	rootAnchor := rootKSK.ToDS(dns.SHA256)
+	v.SetAnchor(".", rootAnchor.KeyTag, rootAnchor.Algorithm, rootAnchor.DigestType, rootAnchor.Digest)
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("signed.", dns.TypeA)
+	answer.Answer = []dns.RR{forgedA}
+
+	err := v.Validate(answer)
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrInsecureDelegation),
+		"unauthenticated empty DS must be bogus, not an insecure delegation; got %v", err)
+}
+
+// TestBuildChainOfTrustRejectsEmptyDSWithoutDenial covers the second downgrade
+// path: the answer carries an attacker-signed RRSIG, so validation enters
+// buildChainOfTrust for the signer zone. The attacker then returns an empty DS
+// response for that zone. Without authenticated denial this must be bogus.
+func TestBuildChainOfTrustRejectsEmptyDSWithoutDenial(t *testing.T) {
+	now := time.Now()
+
+	rootKSK, rootKSKpriv := genKey(t, ".", 257)
+	rootZSK, _ := genKey(t, ".", 256)
+	rootDNSKEYSig := signRRset(t, rootKSK, rootKSKpriv, now, []dns.RR{rootZSK, rootKSK})
+
+	attackerKSK, attackerKSKpriv := genKey(t, "victim.", 257)
+	attackerZSK, attackerZSKpriv := genKey(t, "victim.", 256)
+	attackerDNSKEYSig := signRRset(t, attackerKSK, attackerKSKpriv, now, []dns.RR{attackerZSK, attackerKSK})
+
+	forgedA, _ := dns.NewRR("victim. 300 IN A 6.6.6.6")
+	forgedASig := signRRset(t, attackerZSK, attackerZSKpriv, now, []dns.RR{forgedA})
+
+	resolver := func(q *dns.Msg) (*dns.Msg, error) {
+		a := new(dns.Msg)
+		a.SetReply(q)
+		name := dns.CanonicalName(q.Question[0].Name)
+		switch q.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			switch name {
+			case ".":
+				a.Answer = []dns.RR{rootZSK, rootKSK, rootDNSKEYSig}
+			case "victim.":
+				a.Answer = []dns.RR{attackerZSK, attackerKSK, attackerDNSKEYSig}
+			}
+		case dns.TypeDS:
+			// Attacker returns empty NOERROR for victim. DS — no NSEC/NSEC3.
+		}
+		return a, nil
+	}
+
+	v := NewValidator(WithResolver(resolver), WithTime(func() time.Time { return now }))
+	rootAnchor := rootKSK.ToDS(dns.SHA256)
+	v.SetAnchor(".", rootAnchor.KeyTag, rootAnchor.Algorithm, rootAnchor.DigestType, rootAnchor.Digest)
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("victim.", dns.TypeA)
+	answer.Answer = []dns.RR{forgedA, forgedASig}
+
+	err := v.Validate(answer)
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrInsecureDelegation),
+		"unauthenticated empty DS in chain must be bogus, not insecure; got %v", err)
+}
+
+// TestValidateAcceptsProvenInsecureDelegation is the positive counterpart:
+// the parent zone serves a signed NSEC record proving no DS exists for the
+// child. This is a legitimate insecure delegation and must yield
+// ErrInsecureDelegation so the caller can pass the unsigned answer through.
+func TestValidateAcceptsProvenInsecureDelegation(t *testing.T) {
+	now := time.Now()
+
+	rootKSK, rootKSKpriv := genKey(t, ".", 257)
+	rootZSK, rootZSKpriv := genKey(t, ".", 256)
+	rootDNSKEYSig := signRRset(t, rootKSK, rootKSKpriv, now, []dns.RR{rootZSK, rootKSK})
+
+	// Root-signed NSEC at "unsigned." proving the delegation exists (NS in
+	// bitmap) but has no DS.
+	nsec := &dns.NSEC{
+		Hdr: dns.RR_Header{
+			Name:   "unsigned.",
+			Rrtype: dns.TypeNSEC,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		NextDomain: "\x00.unsigned.",
+		TypeBitMap: []uint16{dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC},
+	}
+	nsecSig := signRRset(t, rootZSK, rootZSKpriv, now, []dns.RR{nsec})
+
+	unsignedA, _ := dns.NewRR("unsigned. 300 IN A 1.2.3.4")
+
+	resolver := func(q *dns.Msg) (*dns.Msg, error) {
+		a := new(dns.Msg)
+		a.SetReply(q)
+		name := dns.CanonicalName(q.Question[0].Name)
+		switch q.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			if name == "." {
+				a.Answer = []dns.RR{rootZSK, rootKSK, rootDNSKEYSig}
+			}
+		case dns.TypeDS:
+			if name == "unsigned." {
+				a.Ns = []dns.RR{nsec, nsecSig}
+			}
+		}
+		return a, nil
+	}
+
+	v := NewValidator(WithResolver(resolver), WithTime(func() time.Time { return now }))
+	rootAnchor := rootKSK.ToDS(dns.SHA256)
+	v.SetAnchor(".", rootAnchor.KeyTag, rootAnchor.Algorithm, rootAnchor.DigestType, rootAnchor.Digest)
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("unsigned.", dns.TypeA)
+	answer.Answer = []dns.RR{unsignedA}
+
+	err := v.Validate(answer)
+	require.ErrorIs(t, err, ErrInsecureDelegation,
+		"NSEC-proven absence of DS must yield ErrInsecureDelegation; got %v", err)
+}
+
+// TestValidateRejectsForgedNSECDenial ensures an attacker cannot fabricate an
+// NSEC denial signed with their own key — the NSEC RRSIG must chain to the
+// trust anchor via the parent zone.
+func TestValidateRejectsForgedNSECDenial(t *testing.T) {
+	now := time.Now()
+
+	rootKSK, rootKSKpriv := genKey(t, ".", 257)
+	rootZSK, _ := genKey(t, ".", 256)
+	rootDNSKEYSig := signRRset(t, rootKSK, rootKSKpriv, now, []dns.RR{rootZSK, rootKSK})
+
+	// Attacker generates their own key claiming to be the root ZSK and signs
+	// an NSEC denying DS for "signed.".
+	fakeRootZSK, fakeRootZSKpriv := genKey(t, ".", 256)
+	nsec := &dns.NSEC{
+		Hdr:        dns.RR_Header{Name: "signed.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300},
+		NextDomain: "\x00.signed.",
+		TypeBitMap: []uint16{dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC},
+	}
+	forgedNSECSig := signRRset(t, fakeRootZSK, fakeRootZSKpriv, now, []dns.RR{nsec})
+
+	forgedA, _ := dns.NewRR("signed. 300 IN A 6.6.6.6")
+
+	resolver := func(q *dns.Msg) (*dns.Msg, error) {
+		a := new(dns.Msg)
+		a.SetReply(q)
+		name := dns.CanonicalName(q.Question[0].Name)
+		switch q.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			if name == "." {
+				a.Answer = []dns.RR{rootZSK, rootKSK, rootDNSKEYSig}
+			}
+		case dns.TypeDS:
+			if name == "signed." {
+				a.Ns = []dns.RR{nsec, forgedNSECSig}
+			}
+		}
+		return a, nil
+	}
+
+	v := NewValidator(WithResolver(resolver), WithTime(func() time.Time { return now }))
+	rootAnchor := rootKSK.ToDS(dns.SHA256)
+	v.SetAnchor(".", rootAnchor.KeyTag, rootAnchor.Algorithm, rootAnchor.DigestType, rootAnchor.Digest)
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("signed.", dns.TypeA)
+	answer.Answer = []dns.RR{forgedA}
+
+	err := v.Validate(answer)
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrInsecureDelegation),
+		"NSEC signed by an untrusted key must be rejected; got %v", err)
 }
 
 // genKey creates an ECDSAP256SHA256 DNSKEY for the given owner and flags

--- a/dnssec/validator_test.go
+++ b/dnssec/validator_test.go
@@ -65,11 +65,10 @@ func TestFilterKeysByDS(t *testing.T) {
 }
 
 func TestValidateNoRRSIG(t *testing.T) {
-	// A response with records but no RRSIG should return ErrNoSignature
-	// unless it's an insecure delegation
+	// A response with records but no RRSIG, where the follow-up DS lookup
+	// returns empty without authenticated denial, must be treated as bogus.
 	v := NewValidator(
 		WithResolver(func(q *dns.Msg) (*dns.Msg, error) {
-			// DS lookup returns empty → insecure delegation
 			a := new(dns.Msg)
 			a.SetReply(q)
 			return a, nil
@@ -83,7 +82,7 @@ func TestValidateNoRRSIG(t *testing.T) {
 
 	err := v.Validate(answer)
 	require.Error(t, err)
-	require.ErrorIs(t, err, ErrInsecureDelegation)
+	require.NotErrorIs(t, err, ErrInsecureDelegation)
 }
 
 func TestValidateEmptyAnswer(t *testing.T) {
@@ -208,18 +207,18 @@ func TestFindKeysByTag(t *testing.T) {
 	require.Len(t, found, 0)
 }
 
-func TestValidateInsecureDelegation(t *testing.T) {
+func TestValidateInsecureDelegationRequiresProof(t *testing.T) {
+	// An empty DS response with no NSEC/NSEC3 in authority is not proof of
+	// an insecure delegation. The validator must reject it as bogus so the
+	// caller does not pass forged data through.
 	v := NewValidator(
 		WithResolver(func(q *dns.Msg) (*dns.Msg, error) {
 			a := new(dns.Msg)
 			a.SetReply(q)
-			// Return empty for DS lookups → insecure delegation
-			// Return empty for DNSKEY lookups → will fail
 			return a, nil
 		}),
 	)
 
-	// Build a response with an unsigned A record
 	answer := new(dns.Msg)
 	answer.SetQuestion("insecure.example.", dns.TypeA)
 	rr, _ := dns.NewRR("insecure.example. 300 IN A 1.2.3.4")
@@ -227,5 +226,5 @@ func TestValidateInsecureDelegation(t *testing.T) {
 
 	err := v.Validate(answer)
 	require.Error(t, err)
-	require.ErrorIs(t, err, ErrInsecureDelegation)
+	require.NotErrorIs(t, err, ErrInsecureDelegation)
 }

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -136,8 +136,10 @@ func TestDNSSECValidatorPassthroughOnError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestDNSSECValidatorInsecureDelegationPassthrough(t *testing.T) {
-	// Upstream returns unsigned data for an insecure zone (no DS)
+func TestDNSSECValidatorRejectsUnauthenticatedEmptyDS(t *testing.T) {
+	// Upstream returns unsigned data and an empty DS response with no
+	// NSEC/NSEC3 proof. This is indistinguishable from an on-path attacker
+	// stripping RRSIGs and must SERVFAIL rather than pass through.
 	upstream := &TestResolver{
 		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 			a := new(dns.Msg)
@@ -146,7 +148,6 @@ func TestDNSSECValidatorInsecureDelegationPassthrough(t *testing.T) {
 				rr, _ := dns.NewRR("insecure.example. 300 IN A 1.2.3.4")
 				a.Answer = []dns.RR{rr}
 			}
-			// DS lookup returns empty → insecure delegation
 			return a, nil
 		},
 	}
@@ -158,9 +159,8 @@ func TestDNSSECValidatorInsecureDelegationPassthrough(t *testing.T) {
 	q.SetQuestion("insecure.example.", dns.TypeA)
 	answer, err := v.Resolve(q, ClientInfo{})
 	require.NoError(t, err)
-	// Insecure delegations should pass through
-	require.Equal(t, dns.RcodeSuccess, answer.Rcode)
-	require.Len(t, answer.Answer, 1)
+	require.Equal(t, dns.RcodeServerFailure, answer.Rcode)
+	require.Empty(t, answer.Answer)
 }
 
 func TestDNSSECValidatorString(t *testing.T) {


### PR DESCRIPTION
## Summary

`ErrInsecureDelegation` was being returned whenever a DS lookup came back
empty, without verifying that the absence of DS was actually proven by the
parent zone. Per RFC 4035 §5.2 and RFC 6840 §4.4/§5.2, a validator may only
conclude a delegation is unsigned after validating an NSEC/NSEC3 record —
signed by the parent and chained to a trust anchor — that shows NS present
and DS absent at the cut. An empty NOERROR/NODATA on its own is not
sufficient and must be treated as bogus.

Because the `dnssec` group passes `ErrInsecureDelegation` results through
unmodified, the previous behaviour meant that a response missing its RRSIG
would be delivered to the client whenever the follow-up DS query happened to
return no records, rather than being SERVFAILed.

## Changes

- New `dnssec/denial.go` with `verifyDSDenial`, which validates NSEC/NSEC3
  records in a DS response's authority section against the parent zone's
  keys and checks the type bitmap (NS set, DS/SOA clear) or NSEC3 opt-out
  coverage. Returns the new sentinel `ErrBogusDenial` when no valid proof
  is found.
- `lookupDS` now returns the full response message so callers can inspect
  the authority section, and no longer discards non-NOERROR responses
  before they can be examined.
- `checkInsecureDelegation` rewritten to walk top-down from the root toward
  the queried name. At each label it calls `proveNoDS`, which builds the
  parent's chain of trust and requires a verified denial before reporting
  the cut as insecure.
- `buildChainOfTrust` reordered so the parent's validated keys are obtained
  before the empty-DS branch is taken; that branch now calls
  `verifyDSDenial` instead of returning `ErrInsecureDelegation` directly.

## Tests

New cases in `validator_chain_test.go`:

- `TestValidateRejectsStrippedRRSIGWithEmptyDS` — RRSIG missing, DS lookup
  returns empty NOERROR with no authority records → bogus.
- `TestBuildChainOfTrustRejectsEmptyDSWithoutDenial` — same scenario reached
  via the chain-of-trust path → bogus.
- `TestValidateRejectsForgedNSECDenial` — NSEC present but signed by a key
  that doesn't chain to the anchor → bogus.
- `TestValidateAcceptsProvenInsecureDelegation` — parent serves a properly
  signed NSEC with NS-but-no-DS → `ErrInsecureDelegation` (pass-through
  still works for genuinely unsigned zones).

Three existing tests that asserted `ErrInsecureDelegation` from a bare empty
DS response have been updated to expect bogus/SERVFAIL, since that scenario
is exactly what this change tightens.

## Test plan

- [x] `go test ./...`
- [x] `go test -race ./dnssec/`
- [x] `go build ./...`