### PR TITLE
dnssec: enforce label-aware RRSIG SignerName bailiwick check

### DIFF
--- a/dnssec/validator.go
+++ b/dnssec/validator.go
@@ -16,8 +16,9 @@ var (
 	ErrNoKey              = errors.New("dnssec: no matching DNSKEY")
 	ErrSignatureInvalid   = errors.New("dnssec: signature verification failed")
 	ErrDSMismatch         = errors.New("dnssec: DNSKEY doesn't match DS")
-	ErrNoTrustAnchor      = errors.New("dnssec: no trust anchor")
-	ErrInsecureDelegation = errors.New("dnssec: insecure delegation")
+	ErrNoTrustAnchor        = errors.New("dnssec: no trust anchor")
+	ErrInsecureDelegation   = errors.New("dnssec: insecure delegation")
+	ErrSignerOutOfBailiwick = errors.New("dnssec: RRSIG signer name out of bailiwick")
 )
 
 type Validator struct {
@@ -158,7 +159,18 @@ func (v *Validator) proveNoDS(zone string) (bool, error) {
 // validateRRset validates a set of RRs against the provided RRSIG by
 // building a chain of trust to the signer's DNSKEY.
 func (v *Validator) validateRRset(rrset []dns.RR, sig *dns.RRSIG) error {
-	zsk, _, err := v.buildChainOfTrust(sig.SignerName)
+	// RFC 4035 §5.3.1: the RRSIG Signer's Name MUST be the zone that
+	// contains the RRset, i.e. equal to or an ancestor of the owner name.
+	// miekg/dns Verify() only does a textual strings.HasSuffix check, so a
+	// signer "tim." would be accepted for owner "victim." — enforce a
+	// label-aware comparison here before fetching keys for the signer.
+	owner := dns.CanonicalName(rrset[0].Header().Name)
+	signer := dns.CanonicalName(sig.SignerName)
+	// dns.IsSubDomain(parent, child): true when child is at or below parent.
+	if !dns.IsSubDomain(signer, owner) {
+		return fmt.Errorf("%w: %s cannot sign %s", ErrSignerOutOfBailiwick, signer, owner)
+	}
+	zsk, _, err := v.buildChainOfTrust(signer)
 	if err != nil {
 		return err
 	}

--- a/dnssec/validator_chain_test.go
+++ b/dnssec/validator_chain_test.go
@@ -328,6 +328,125 @@ func TestValidateRejectsForgedNSECDenial(t *testing.T) {
 		"NSEC signed by an untrusted key must be rejected; got %v", err)
 }
 
+// TestValidateRejectsCrossZoneSignerName reproduces the RFC 4035 §5.3.1
+// bypass: an attacker who controls a legitimately signed zone returns a
+// forged A record for an unrelated owner name covered by an RRSIG whose
+// SignerName is the attacker's zone. The attacker zone → root chain is
+// valid and the cryptographic signature verifies, but the signer is not at
+// or above the owner name in the DNS hierarchy and MUST be rejected.
+//
+// miekg/dns RRSIG.Verify() has its own guard, but it is a textual
+// strings.HasSuffix check rather than a label-aware comparison, so an
+// attacker zone "tim." passes the library check for owner "victim." even
+// though "tim." is a sibling of "victim.", not an ancestor.
+func TestValidateRejectsCrossZoneSignerName(t *testing.T) {
+	now := time.Now()
+
+	rootKSK, rootKSKpriv := genKey(t, ".", 257)
+	rootZSK, rootZSKpriv := genKey(t, ".", 256)
+	rootDNSKEYSig := signRRset(t, rootKSK, rootKSKpriv, now, []dns.RR{rootZSK, rootKSK})
+
+	// "tim." is a real, properly delegated, DNSSEC-signed zone the attacker
+	// controls. It is NOT an ancestor of "victim." but is a textual suffix.
+	attackerKSK, attackerKSKpriv := genKey(t, "tim.", 257)
+	attackerZSK, attackerZSKpriv := genKey(t, "tim.", 256)
+	attackerDNSKEYSig := signRRset(t, attackerKSK, attackerKSKpriv, now, []dns.RR{attackerZSK, attackerKSK})
+	attackerDS := attackerKSK.ToDS(dns.SHA256)
+	require.NotNil(t, attackerDS)
+	attackerDSSig := signRRset(t, rootZSK, rootZSKpriv, now, []dns.RR{attackerDS})
+
+	// Forged answer for victim. signed by the attacker's ZSK. signRRset sets
+	// SignerName = key owner, so this RRSIG has owner=victim. and
+	// SignerName=tim. — out of bailiwick.
+	forgedA, _ := dns.NewRR("victim. 300 IN A 6.6.6.6")
+	forgedASig := signRRset(t, attackerZSK, attackerZSKpriv, now, []dns.RR{forgedA})
+	require.Equal(t, "tim.", forgedASig.SignerName)
+
+	resolver := func(q *dns.Msg) (*dns.Msg, error) {
+		a := new(dns.Msg)
+		a.SetReply(q)
+		name := dns.CanonicalName(q.Question[0].Name)
+		switch q.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			switch name {
+			case ".":
+				a.Answer = []dns.RR{rootZSK, rootKSK, rootDNSKEYSig}
+			case "tim.":
+				a.Answer = []dns.RR{attackerZSK, attackerKSK, attackerDNSKEYSig}
+			}
+		case dns.TypeDS:
+			if name == "tim." {
+				a.Answer = []dns.RR{attackerDS, attackerDSSig}
+			}
+		}
+		return a, nil
+	}
+
+	v := NewValidator(WithResolver(resolver), WithTime(func() time.Time { return now }))
+	rootAnchor := rootKSK.ToDS(dns.SHA256)
+	v.SetAnchor(".", rootAnchor.KeyTag, rootAnchor.Algorithm, rootAnchor.DigestType, rootAnchor.Digest)
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("victim.", dns.TypeA)
+	answer.Answer = []dns.RR{forgedA, forgedASig}
+
+	err := v.Validate(answer)
+	require.ErrorIs(t, err, ErrSignerOutOfBailiwick,
+		"RRSIG whose SignerName is not at or above the owner name must be rejected; got %v", err)
+}
+
+// TestValidateAcceptsAncestorSignerName is the positive counterpart: an RRset
+// at www.child. signed by the child. zone's ZSK (SignerName=child., a proper
+// ancestor of the owner) must validate.
+func TestValidateAcceptsAncestorSignerName(t *testing.T) {
+	now := time.Now()
+
+	rootKSK, rootKSKpriv := genKey(t, ".", 257)
+	rootZSK, rootZSKpriv := genKey(t, ".", 256)
+	rootDNSKEYSig := signRRset(t, rootKSK, rootKSKpriv, now, []dns.RR{rootZSK, rootKSK})
+
+	childKSK, childKSKpriv := genKey(t, "child.", 257)
+	childZSK, childZSKpriv := genKey(t, "child.", 256)
+	childDNSKEYSig := signRRset(t, childKSK, childKSKpriv, now, []dns.RR{childZSK, childKSK})
+	childDS := childKSK.ToDS(dns.SHA256)
+	require.NotNil(t, childDS)
+	childDSSig := signRRset(t, rootZSK, rootZSKpriv, now, []dns.RR{childDS})
+
+	wwwA, _ := dns.NewRR("www.child. 300 IN A 1.2.3.4")
+	wwwASig := signRRset(t, childZSK, childZSKpriv, now, []dns.RR{wwwA})
+	require.Equal(t, "child.", wwwASig.SignerName)
+
+	resolver := func(q *dns.Msg) (*dns.Msg, error) {
+		a := new(dns.Msg)
+		a.SetReply(q)
+		name := dns.CanonicalName(q.Question[0].Name)
+		switch q.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			switch name {
+			case ".":
+				a.Answer = []dns.RR{rootZSK, rootKSK, rootDNSKEYSig}
+			case "child.":
+				a.Answer = []dns.RR{childZSK, childKSK, childDNSKEYSig}
+			}
+		case dns.TypeDS:
+			if name == "child." {
+				a.Answer = []dns.RR{childDS, childDSSig}
+			}
+		}
+		return a, nil
+	}
+
+	v := NewValidator(WithResolver(resolver), WithTime(func() time.Time { return now }))
+	rootAnchor := rootKSK.ToDS(dns.SHA256)
+	v.SetAnchor(".", rootAnchor.KeyTag, rootAnchor.Algorithm, rootAnchor.DigestType, rootAnchor.Digest)
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("www.child.", dns.TypeA)
+	answer.Answer = []dns.RR{wwwA, wwwASig}
+
+	require.NoError(t, v.Validate(answer))
+}
+
 // genKey creates an ECDSAP256SHA256 DNSKEY for the given owner and flags
 // (256 = ZSK, 257 = KSK) and returns the public DNSKEY plus its private signer.
 func genKey(t *testing.T, owner string, flags uint16) (*dns.DNSKEY, crypto.Signer) {


### PR DESCRIPTION
## Summary

RFC 4035 §5.3.1 requires an RRSIG's Signer's Name to be the name of the zone containing the signed RRset — i.e. equal to, or a label-boundary ancestor of, the RRset owner name.

`validateRRset()` previously passed `sig.SignerName` straight to `buildChainOfTrust()` without checking this relationship, relying on `miekg/dns` `RRSIG.Verify()` to catch mismatches. That library check uses `strings.HasSuffix`, which is a textual comparison rather than a label-aware one, so a signer name that happens to be a string suffix of the owner (e.g. `tim.` vs `victim.`) is not rejected even though it is a sibling in the DNS tree, not an ancestor.

`validateRRset()` now canonicalizes both names and requires `dns.IsSubDomain(signer, owner)` before fetching keys for the signer. A new `ErrSignerOutOfBailiwick` sentinel is returned on mismatch.

## Test plan

- [x] `TestValidateRejectsCrossZoneSignerName` — owner `victim.` with SignerName `tim.` (string suffix, not a DNS ancestor) is rejected with `ErrSignerOutOfBailiwick`
- [x] `TestValidateAcceptsAncestorSignerName` — owner `www.child.` with SignerName `child.` (proper ancestor) continues to validate
- [x] `go test ./...` passes
- [x] `go vet ./dnssec/` clean