### PR TITLE
odoh: prevent SSRF via redirect-following in proxy mode

### DIFF
--- a/odohlistener.go
+++ b/odohlistener.go
@@ -61,11 +61,15 @@ func NewODoHListener(id, addr string, opt ODoHListenerOptions, resolver Resolver
 
 	configSet := odoh.CreateObliviousDoHConfigs([]odoh.ObliviousDoHConfig{keyPair.Config})
 	l := &ODoHListener{
-		id:          id,
-		addr:        addr,
-		r:           resolver,
-		opt:         opt,
-		proxyClient: &http.Client{},
+		id:   id,
+		addr: addr,
+		r:    resolver,
+		opt:  opt,
+		proxyClient: &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
 		odohKeyPair: keyPair,
 		config:      configSet.Marshal(),
 	}
@@ -150,6 +154,10 @@ func (s *ODoHListener) ODoHproxyHandler(w http.ResponseWriter, r *http.Request) 
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
 		http.Error(w, http.StatusText(response.StatusCode), response.StatusCode)
+		return
+	}
+	if response.Header.Get("Content-Type") != ODOH_CONTENT_TYPE {
+		http.Error(w, "unexpected response content type from target", http.StatusBadGateway)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Set `CheckRedirect` on the ODoH proxy `http.Client` to return `http.ErrUseLastResponse`, so redirects from the target are never followed. A 3xx now fails the existing status-code check instead of being dereferenced to an arbitrary internal host.
- Reject upstream responses whose `Content-Type` is not `application/oblivious-dns-message` before relaying the body, so non-ODoH content (e.g. metadata JSON) is never echoed to the client even on a direct 200.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Manual: POST to proxy with `targethost` pointing at a server that returns `302 Location: http://169.254.169.254/...` → expect `302 Found` error, no metadata in body
- [ ] Manual: POST to proxy with `targethost` returning `200` + `Content-Type: text/html` → expect `502 Bad Gateway`
- [ ] Manual: legitimate ODoH target still works end-to-end