### PR TITLE
Reject queries with empty Question section in all listeners

### DIFF
--- a/blocklist.go
+++ b/blocklist.go
@@ -1,7 +1,6 @@
 package rdns
 
 import (
-	"errors"
 	"expvar"
 	"log/slog"
 	"net"
@@ -89,9 +88,6 @@ func NewBlocklist(id string, resolver Resolver, opt BlocklistOptions) (*Blocklis
 // Resolve a DNS query by first checking the query against the provided matcher.
 // Queries that do not match are passed on to the next resolver.
 func (r *Blocklist) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-	if len(q.Question) < 1 {
-		return nil, errors.New("no question in query")
-	}
 	question := q.Question[0]
 	log := logger(r.id, q, ci)
 

--- a/cache.go
+++ b/cache.go
@@ -1,7 +1,6 @@
 package rdns
 
 import (
-	"errors"
 	"expvar"
 	"math"
 	"math/rand"
@@ -131,9 +130,6 @@ func NewCache(id string, resolver Resolver, opt CacheOptions) *Cache {
 // Resolve a DNS query by first checking an internal cache for existing
 // results
 func (r *Cache) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-	if len(q.Question) < 1 {
-		return nil, errors.New("no question in query")
-	}
 	// While multiple questions in one DNS message is part of the standard,
 	// it's not actually supported by servers. If we do get one of those,
 	// just pass it through and bypass caching.

--- a/dnslistener.go
+++ b/dnslistener.go
@@ -107,6 +107,11 @@ func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNe
 			"protocol", protocol,
 			"addr", addr,
 		)
+		if len(req.Question) == 0 {
+			metrics.err.Add("noquestion", 1)
+			log.Warn("dropping query with no Question section")
+			return
+		}
 		log.Debug("received query")
 		metrics.query.Add(1)
 

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -259,6 +259,12 @@ func (s *DoHListener) parseAndRespond(b []byte, w http.ResponseWriter, r *http.R
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if len(q.Question) == 0 {
+		s.metrics.err.Add("noquestion", 1)
+		Log.With("id", s.id, "protocol", "doh", "addr", s.addr).Warn("dropping query with no Question section")
+		http.Error(w, "no question in query", http.StatusBadRequest)
+		return
+	}
 	// Extract the remote host address from the HTTP headers.
 	clientIP := s.extractClientAddress(r)
 	if clientIP == nil {

--- a/ecs-modifier.go
+++ b/ecs-modifier.go
@@ -1,7 +1,6 @@
 package rdns
 
 import (
-	"errors"
 	"net"
 
 	"github.com/miekg/dns"
@@ -27,10 +26,6 @@ func NewECSModifier(id string, resolver Resolver, f ECSModifierFunc) (*ECSModifi
 
 // Resolve modifies the OPT EDNS0 record and passes it to the next resolver.
 func (r *ECSModifier) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-	if len(q.Question) < 1 {
-		return nil, errors.New("no question in query")
-	}
-
 	// Modify the query
 	if r.modifier != nil {
 		r.modifier(r.id, q, ci)

--- a/edns0-modifier.go
+++ b/edns0-modifier.go
@@ -1,8 +1,6 @@
 package rdns
 
 import (
-	"errors"
-
 	"github.com/miekg/dns"
 )
 
@@ -26,10 +24,6 @@ func NewEDNS0Modifier(id string, resolver Resolver, f EDNS0ModifierFunc) (*EDNS0
 
 // Resolve modifies the OPT EDNS0 record and passes it to the next resolver.
 func (r *EDNS0Modifier) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-	if len(q.Question) < 1 {
-		return nil, errors.New("no question in query")
-	}
-
 	// Modify the query
 	if r.modifier != nil {
 		r.modifier(q, ci)

--- a/odohlistener.go
+++ b/odohlistener.go
@@ -224,6 +224,11 @@ func (s *ODoHListener) ODoHqueryHandler(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "unpacking oblivious query failed", http.StatusBadRequest)
 		return
 	}
+	if len(q.Question) == 0 {
+		Log.With("id", s.id, "protocol", "odoh", "addr", s.addr).Warn("dropping query with no Question section")
+		http.Error(w, "no question in query", http.StatusBadRequest)
+		return
+	}
 
 	a, err := s.r.Resolve(q, ClientInfo{Listener: s.id, TLSServerName: r.TLS.ServerName})
 	if err != nil {

--- a/replace.go
+++ b/replace.go
@@ -1,7 +1,6 @@
 package rdns
 
 import (
-	"errors"
 	"regexp"
 
 	"github.com/miekg/dns"
@@ -55,9 +54,6 @@ func NewReplace(id string, resolver Resolver, list ...ReplaceOperation) (*Replac
 // sending the query upstream and replace the name in the response with
 // the original query string again.
 func (r *Replace) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-	if len(q.Question) < 1 {
-		return nil, errors.New("no question in query")
-	}
 	oldName := q.Question[0].Name
 	newName := r.exp.apply(oldName)
 	log := logger(r.id, q, ci)

--- a/router.go
+++ b/router.go
@@ -1,7 +1,6 @@
 package rdns
 
 import (
-	"errors"
 	"expvar"
 	"fmt"
 
@@ -47,9 +46,6 @@ func NewRouter(id string) *Router {
 
 // Resolve a request by routing it to the right resolved based on the routes setup in the router.
 func (r *Router) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-	if len(q.Question) < 1 {
-		return nil, errors.New("no question in query")
-	}
 	question := q.Question[0]
 	log := logger(r.id, q, ci)
 	for _, route := range r.routes {


### PR DESCRIPTION
## Summary

Follow-up to #526 / #524. A DNS message with `QDCOUNT=0` unpacks cleanly but every downstream `Resolve()` implementation indexes `q.Question[0]` and panics. #526 added a guard to the DoQ listener; this applies the same guard to the remaining entry points and drops the now-redundant per-resolver checks.

- **Listener guards added**
  - `dnslistener.go` `listenHandler()` — covers UDP, TCP, DoT, DTLS (shared handler)
  - `dohlistener.go` `parseAndRespond()` — returns HTTP 400, mirrors the unpack-error path
  - `odohlistener.go` `ODoHqueryHandler()` — returns HTTP 400
  - DoQ already covered by #526; admin listener serves metrics only; ODoH proxy forwards encrypted bytes without unpacking
- **Redundant `len(q.Question) < 1` guards removed** from `blocklist.go`, `cache.go`, `ecs-modifier.go`, `edns0-modifier.go`, `replace.go`, `router.go` (plus the now-unused `errors` imports)
- **Left intact**: `> 1` multi-question bypass in `cache.go`; response-side checks in `failback`/`failrotate`/`random`/`pipeline`; `qName`/`qType` helpers (called during listener log construction before the guard); template zero-value fallbacks in `static-template.go`/`edns0ede.go`

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`