### PR TITLE
fastest-tcp: fix goroutine/socket leak in probe and cap probe count

### DIFF
--- a/fastest-tcp.go
+++ b/fastest-tcp.go
@@ -11,6 +11,11 @@ import (
 	"github.com/miekg/dns"
 )
 
+// fastestTCPMaxProbes caps how many A/AAAA records are probed concurrently.
+// This bounds the number of goroutines and sockets spawned per query so that
+// responses with very large RRsets cannot exhaust file descriptors or memory.
+const fastestTCPMaxProbes = 32
+
 // FastestTCP first resolves the query with the upstream resolver, then
 // performs TCP connection tests with the response IPs to determine which
 // IP responds the fastest. This IP is then returned in the response as first
@@ -70,11 +75,14 @@ func (r *FastestTCP) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		return a, nil
 	}
 
-	// Extract the IP responses
+	// Extract the IP responses, up to the probe cap
 	var ipRRs []dns.RR
 	for _, rr := range a.Answer {
 		if rr.Header().Rrtype == question.Qtype {
 			ipRRs = append(ipRRs, rr)
+			if len(ipRRs) >= fastestTCPMaxProbes {
+				break
+			}
 		}
 	}
 
@@ -101,7 +109,12 @@ func (r *FastestTCP) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 
 	// Merge the sorted list of RRs back into the original answer in the same
 	// positions. The original answer could have CNAMEs and other types in it.
+	// Stop once the sorted list is exhausted; any records beyond the probe cap
+	// remain in their original positions.
 	for i, rr := range a.Answer {
+		if len(sorted) == 0 {
+			break
+		}
 		if rr.Header().Rrtype == question.Qtype {
 			a.Answer[i] = sorted[0]
 			sorted = sorted[1:]
@@ -175,8 +188,12 @@ type tcpProbeResult struct {
 }
 
 // Probes all IPs and returns a channel with responses in the order they succeed or fail.
+// The channel is buffered to len(rrs) so that probe goroutines never block on send,
+// even when the caller stops reading early (e.g. probeFastest after the first result,
+// or probeAll on error/timeout). This guarantees every goroutine runs to completion
+// and closes its socket.
 func (r *FastestTCP) probe(ctx context.Context, log *slog.Logger, rrs []dns.RR) <-chan tcpProbeResult {
-	resultCh := make(chan tcpProbeResult)
+	resultCh := make(chan tcpProbeResult, len(rrs))
 	for _, rr := range rrs {
 		var d net.Dialer
 		go func(rr dns.RR) {

--- a/fastest-tcp_test.go
+++ b/fastest-tcp_test.go
@@ -1,0 +1,142 @@
+package rdns
+
+import (
+	"net"
+	"runtime"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// waitForGoroutines polls runtime.NumGoroutine until it drops to at most
+// the target or the deadline expires. require.Eventually cannot be used
+// here because it evaluates the condition in a separate goroutine, which
+// itself inflates the count.
+func waitForGoroutines(t *testing.T, target int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= target {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("probe goroutines did not terminate: have %d, want <= %d", runtime.NumGoroutine(), target)
+}
+
+// TestFastestTCPNoGoroutineLeak verifies that probe goroutines always
+// terminate and close their sockets even when the caller stops reading
+// after the first result (wait-all=false). Previously the unbuffered
+// result channel caused N-1 goroutines per query to block forever on
+// send, leaking goroutines and any successfully-dialed sockets.
+func TestFastestTCPNoGoroutineLeak(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	// Local TCP listener that accepts every probe so all goroutines
+	// reach the channel-send path with an open socket.
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	var accepted, closed int32
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			atomic.AddInt32(&accepted, 1)
+			go func() {
+				defer c.Close()
+				// Read returns once the peer closes the connection.
+				var buf [1]byte
+				c.Read(buf[:])
+				atomic.AddInt32(&closed, 1)
+			}()
+		}
+	}()
+
+	_, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+
+	// Upstream resolver returns several A records pointing at the listener.
+	const numRecords = 8
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			for i := 0; i < numRecords; i++ {
+				a.Answer = append(a.Answer, &dns.A{
+					Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+					A:   net.ParseIP("127.0.0.1"),
+				})
+			}
+			return a, nil
+		},
+	}
+
+	r := NewFastestTCP("test-fastest", upstream, FastestTCPOptions{Port: port})
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	a, err := r.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Len(t, a.Answer, numRecords)
+
+	// Every accepted probe connection must be closed by the probe side.
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&accepted) > 0 &&
+			atomic.LoadInt32(&closed) == atomic.LoadInt32(&accepted)
+	}, 2*time.Second, 10*time.Millisecond, "probe sockets were not closed")
+
+	// Stop the accept loop, then verify all goroutines spawned during the
+	// test have exited.
+	ln.Close()
+	waitForGoroutines(t, before, 2*time.Second)
+}
+
+// TestFastestTCPProbeCap verifies that responses with more A/AAAA records
+// than fastestTCPMaxProbes do not spawn an unbounded number of probe
+// goroutines and that the merge-back into the original answer does not
+// panic when the cap is hit.
+func TestFastestTCPProbeCap(t *testing.T) {
+	// Use a port that refuses connections so probes fail fast without
+	// needing a real listener; we only care that Resolve returns
+	// without panicking and without leaking goroutines.
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	_, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+	ln.Close() // closed listener -> dials get ECONNREFUSED
+
+	const numRecords = fastestTCPMaxProbes + 20
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			for i := 0; i < numRecords; i++ {
+				a.Answer = append(a.Answer, &dns.A{
+					Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+					A:   net.ParseIP("127.0.0.1"),
+				})
+			}
+			return a, nil
+		},
+	}
+
+	r := NewFastestTCP("test-fastest", upstream, FastestTCPOptions{Port: port, WaitAll: true})
+
+	before := runtime.NumGoroutine()
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	a, err := r.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Len(t, a.Answer, numRecords)
+
+	waitForGoroutines(t, before, 2*time.Second)
+}


### PR DESCRIPTION
## Summary
- Buffer the probe result channel to `len(rrs)` so probe goroutines never block on send when the caller stops reading early (`probeFastest` after the first result, or `probeAll` on error/timeout). Previously N-1 goroutines per query blocked forever, and any that had dialed successfully leaked their socket because `defer c.Close()` never ran.
- Cap the number of A/AAAA records probed at 32 (`fastestTCPMaxProbes`) so responses with very large RRsets cannot exhaust goroutines or file descriptors.
- Guard the merge-back loop so it stops once the sorted slice is exhausted instead of panicking on `sorted[0]` when the cap is hit; records beyond the cap stay in their original positions.

## Test plan
- [x] `TestFastestTCPNoGoroutineLeak` — 8 A records pointing at a local listener, default `wait-all=false`; asserts every accepted connection is closed by the probe side and goroutine count returns to baseline. Fails on master with "probe sockets were not closed".
- [x] `TestFastestTCPProbeCap` — `fastestTCPMaxProbes + 20` records in `wait-all=true` mode; asserts no panic and no leaked goroutines.
- [x] `go test -race -count=5 -run TestFastestTCP ./...`
- [x] `go test ./...`