### PR TITLE
Fix regexp blocklist bypass via query name case variation

### DIFF
--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -37,6 +37,14 @@ func TestBlocklistRegexp(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, r.HitCount())
 	require.Equal(t, dns.RcodeNameError, a.Rcode)
+
+	// A mixed-case variation of a blocked name must still be blocked (DNS
+	// names are case-insensitive); it must not be forwarded upstream.
+	q.SetQuestion("X.EvIl.TeSt.", dns.TypeA)
+	a, err = b.Resolve(q, ci)
+	require.NoError(t, err)
+	require.Equal(t, 1, r.HitCount())
+	require.Equal(t, dns.RcodeNameError, a.Rcode)
 }
 
 func TestBlocklistAllow(t *testing.T) {
@@ -81,4 +89,18 @@ func TestBlocklistAllow(t *testing.T) {
 	_, err = b.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, 2, r.HitCount())
+
+	// A mixed-case blocked name must still be blocked (not forwarded).
+	q.SetQuestion("X.EvIl.TeSt.", dns.TypeA)
+	a, err = b.Resolve(q, ci)
+	require.NoError(t, err)
+	require.Equal(t, 2, r.HitCount())
+	require.Equal(t, dns.RcodeNameError, a.Rcode)
+
+	// A mixed-case variation of an allowlisted name must still be allowed
+	// through, consistent with case-insensitive DNS semantics.
+	q.SetQuestion("GoOd.EvIl.TeSt.", dns.TypeA)
+	_, err = b.Resolve(q, ci)
+	require.NoError(t, err)
+	require.Equal(t, 3, r.HitCount())
 }

--- a/blocklistdb-regexp.go
+++ b/blocklistdb-regexp.go
@@ -46,7 +46,7 @@ func (m *RegexpDB) Reload() (BlocklistDB, error) {
 func (m *RegexpDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
 	q := msg.Question[0]
 	for _, rule := range m.rules {
-		if rule.MatchString(q.Name) {
+		if rule.MatchString(strings.ToLower(q.Name)) {
 			return nil, nil, &BlocklistMatch{List: m.name, Rule: rule.String()}, true
 		}
 	}


### PR DESCRIPTION
## Problem

`RegexpDB.Match()` matched the raw wire-format DNS question name against the compiled rules without canonicalizing case. DNS names are case-insensitive per RFC 1035, and the on-the-wire case is non-deterministic when DNS 0x20 / case randomization is in play. As a result, a lowercase rule like `(^|\.)evil\.com\.$` (typical of public threat feeds and the shipped example configs) does **not** match a query for `EvIl.CoM.`. The query is forwarded upstream, resolved normally, and the client receives the blocked domain's IP — a full blocklist bypass triggerable by simply varying letter case.

Regexp is the default blocklist format, so the shipped example rules (`blocklist-regexp.toml`, `family-browsing.toml`) are affected. RegexpDB was the inconsistent outlier: `DomainDB`, `HostsDB`, and the LRU cache key all already `strings.ToLower` the question name.

## Fix

Lowercase the query name before matching, mirroring the sibling backends:

```go
if rule.MatchString(strings.ToLower(q.Name)) {
```

Only the input string is lowercased — the rule pattern is deliberately left untouched, since lowercasing a pattern would corrupt regex metacharacters such as `\D`, `\S`, `\W`. This also applies to the allowlist path, which uses the same `NewRegexpDB` code.

## Tests

Added regression cases to `blocklist_test.go`:

- `TestBlocklistRegexp`: a mixed-case variant of a blocked name (`X.EvIl.TeSt.`) must be blocked (NXDOMAIN) and not forwarded upstream.
- `TestBlocklistAllow`: mixed-case blocked names stay blocked; a mixed-case allowlisted name still passes through.

These assertions exercise the exact bypass path and fail without the fix.