### PR TITLE
lua: persist in-place mutation of msg.questions fields

### DIFF
--- a/lua-message.go
+++ b/lua-message.go
@@ -31,8 +31,8 @@ func (s *LuaScript) RegisterMessageType() {
 			switch fieldName {
 			case "questions":
 				table := L.CreateTable(len(msg.Question), 0)
-				for _, q := range msg.Question {
-					lv := userDataWithMetatable(L, luaQuestionMetatableName, &q)
+				for i := range msg.Question {
+					lv := userDataWithMetatable(L, luaQuestionMetatableName, &msg.Question[i])
 					table.Append(lv)
 				}
 				L.Push(table)

--- a/lua_test.go
+++ b/lua_test.go
@@ -128,6 +128,30 @@ end`,
 	}
 }
 
+func TestLuaQuestionInPlaceMutation(t *testing.T) {
+	opt := LuaOptions{
+		Script: `
+function Resolve(msg, ci)
+	msg.questions[1].name = "blocked.invalid."
+	return Resolvers[1]:resolve(msg, ci)
+end`,
+	}
+
+	var ci ClientInfo
+	resolver := new(TestResolver)
+
+	r, err := NewLua("test-lua", opt, resolver)
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("attacker.example.com.", dns.TypeA)
+
+	answer, err := r.Resolve(q, ci)
+	require.NoError(t, err)
+	require.Equal(t, 1, resolver.HitCount())
+	require.Equal(t, "blocked.invalid.", answer.Question[0].Name)
+}
+
 func TestLuaQuestionOperations(t *testing.T) {
 	opt := LuaOptions{
 		Script: `


### PR DESCRIPTION
## Problem

The `msg.questions` getter in `lua-message.go` ranged over `msg.Question` with a value loop variable and wrapped `&q` (a pointer to the per-iteration copy) in userdata:

```go
for _, q := range msg.Question {
	lv := userDataWithMetatable(L, luaQuestionMetatableName, &q)
	table.Append(lv)
}
```

Lua code like `msg.questions[1].name = "x"` calls the Question `__newindex` setter on the throwaway copy, never `msg.Question[i]`. The assignment is silently dropped — no error, no warning, the script appears to succeed.

This is inconsistent with `msg.answer` / `ns` / `extra`, whose elements are `dns.RR` interface values holding shared pointers, so in-place mutation there *does* persist.

### Impact

Operator sanitization scripts that rewrite query names (e.g. neutralizing abusive queries before forwarding upstream) have no effect. The original, attacker-controlled name is forwarded unchanged and the control fails silently and open for every query.

## Fix

Take the address of the backing-array element (`&msg.Question[i]`) instead of the loop copy, so question field assignments persist to the underlying message — consistent with `answer`/`ns`/`extra`. The whole-slice replacement path (`msg.questions = { ... }`) is unaffected.

## Test

Added `TestLuaQuestionInPlaceMutation`, which rewrites `msg.questions[1].name` then resolves through the echoing `TestResolver` and asserts the mutation reached the upstream. Verified it fails before the fix (forwards `attacker.example.com.`) and passes after. Full `go test -run TestLua ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)