### PR TITLE
replace: don't leak rewritten internal name to client on upstream error

### DIFF
--- a/replace.go
+++ b/replace.go
@@ -64,7 +64,10 @@ func (r *Replace) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		return r.resolver.Resolve(q, ci)
 	}
 
-	// Modify the query string
+	// Modify the query on a copy so the caller's message (which a listener
+	// may reuse to build a SERVFAIL/error response) is never mutated and
+	// the rewritten internal name cannot leak back to the client.
+	q = q.Copy()
 	q.Question[0].Name = newName
 
 	// Send the query upstream

--- a/replace_test.go
+++ b/replace_test.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"errors"
 	"net"
 	"testing"
 
@@ -54,4 +55,39 @@ func TestReplace(t *testing.T) {
 	require.Equal(t, "my.test.com.", a.Answer[0].Header().Name)
 	require.Equal(t, "my.test.com.", a.Question[0].Name)
 	require.Equal(t, "your.test.com.", actualQueryName)
+}
+
+// On an upstream error, Replace must not leave the caller's query mutated
+// with the rewritten (internal) name. A listener reuses that same message to
+// build the SERVFAIL response, so a leaked name would be disclosed to the
+// unauthenticated client.
+func TestReplaceErrorDoesNotLeakName(t *testing.T) {
+	var ci ClientInfo
+	var actualQueryName string
+	r := &TestResolver{
+		ResolveFunc: func(req *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			actualQueryName = req.Question[0].Name
+			return nil, errors.New("upstream failure")
+		},
+	}
+
+	exp := []ReplaceOperation{
+		{From: `^my\.(.*)`, To: `your.${1}`},
+	}
+
+	b, err := NewReplace("test-replace", r, exp...)
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("my.test.com.", dns.TypeA)
+
+	a, err := b.Resolve(q, ci)
+	require.Error(t, err)
+	require.Nil(t, a)
+
+	// The rewrite still happened upstream...
+	require.Equal(t, "your.test.com.", actualQueryName)
+	// ...but the caller's message must be untouched so the SERVFAIL built
+	// from it doesn't disclose the internal name.
+	require.Equal(t, "my.test.com.", q.Question[0].Name)
 }


### PR DESCRIPTION
## Problem

`Replace.Resolve()` rewrites `q.Question[0].Name` in place at `replace.go:68`, then forwards the mutated query upstream. `Replace` never copies `q`, so this is the same `*dns.Msg` the listener holds as `req`. On an upstream error it returns early (`replace.go:73-74`) without restoring the original name — the restoration at line 78 only runs on the success path, and even then targets the response, not the request.

The listener then builds the error response from that same mutated message: `dnslistener.go:121-125` does `a = servfail(req)`, and `servfail → responseWithCode → dns.SetRcode/SetReply` copies `req.Question` (now holding the rewritten internal name) into the SERVFAIL sent to the client. Same path in `dohlistener.go`, `doqlistener.go`, `odohlistener.go`.

### Impact

When an operator uses Replace to map a public name to an internal/upstream-specific hostname, any transient upstream error (timeout, packet loss) causes the SERVFAIL returned to the unauthenticated client to carry the rewritten name in its Question section — disclosing internal infrastructure naming, upstream provider hostnames, or rewrite rules. Strict downstream resolvers may also discard the mismatched SERVFAIL and retry, amplifying the leak.

## Fix

Modify a copy of the query (`q = q.Copy()`) before rewriting the name, so the caller's message is never mutated by this modifier. This matches the existing `q.Copy()` discipline already used by the protocol clients (`dnsclient.go`, `dotclient.go`, …) and other query-modifying components (`dnssec.go`, `dns64.go`). It fixes the error-path leak and also removes the latent success-path mutation of the caller's message. The response-to-original-name mapping is unchanged.

## Test

Adds `TestReplaceErrorDoesNotLeakName`: on an upstream error it asserts the caller's query name is still the original (`my.test.com.`) while the upstream resolver did see the rewritten name (`your.test.com.`). The test fails on the previous code (caller's name leaks as `your.test.com.`) and passes with the fix. Full package suite passes.