### PR TITLE
cache: include CD bit and ECS prefix length in cache key

### DIFF
--- a/cache-redis.go
+++ b/cache-redis.go
@@ -270,6 +270,12 @@ func (b *redisBackend) keyFromQuery(q *dns.Msg) string {
 	key.WriteByte(':')
 	key.WriteString(dns.Type(q.Question[0].Qtype).String())
 	key.WriteByte(':')
+	// CD=1 responses are unvalidated (RFC 4035 §4.7 / RFC 6840 §5.9) and
+	// must be keyed separately from CD=0 ones.
+	if q.CheckingDisabled {
+		key.WriteString("cd")
+	}
+	key.WriteByte(':')
 
 	edns0 := q.IsEdns0()
 	if edns0 != nil {
@@ -279,6 +285,8 @@ func (b *redisBackend) keyFromQuery(q *dns.Msg) string {
 		for _, opt := range edns0.Option {
 			if subnet, ok := opt.(*dns.EDNS0_SUBNET); ok {
 				key.WriteString(subnet.Address.String())
+				key.WriteByte('/')
+				key.WriteString(fmt.Sprintf("%d", subnet.SourceNetmask))
 			}
 		}
 	}

--- a/cache-redis_test.go
+++ b/cache-redis_test.go
@@ -2,12 +2,45 @@ package rdns
 
 import (
 	"fmt"
+	"net"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 )
+
+// The Redis cache key must distinguish CD=0 from CD=1 (RFC 4035 §4.7 /
+// RFC 6840 §5.9) and ECS responses with a different source-prefix length.
+func TestRedisKeyFromQuery(t *testing.T) {
+	b := &redisBackend{}
+
+	queryCD := func(cd bool) *dns.Msg {
+		q := new(dns.Msg)
+		q.SetQuestion("example.com.", dns.TypeA)
+		q.CheckingDisabled = cd
+		return q
+	}
+	if b.keyFromQuery(queryCD(false)) == b.keyFromQuery(queryCD(true)) {
+		t.Fatal("CD=0 and CD=1 queries produced the same Redis cache key")
+	}
+
+	queryECS := func(mask uint8) *dns.Msg {
+		q := new(dns.Msg)
+		q.SetQuestion("example.com.", dns.TypeA)
+		q.SetEdns0(4096, false)
+		ecs := new(dns.EDNS0_SUBNET)
+		ecs.Code = dns.EDNS0SUBNET
+		ecs.Family = 1
+		ecs.SourceNetmask = mask
+		ecs.Address = net.IP{192, 0, 2, 0}
+		q.IsEdns0().Option = append(q.IsEdns0().Option, ecs)
+		return q
+	}
+	if b.keyFromQuery(queryECS(24)) == b.keyFromQuery(queryECS(16)) {
+		t.Fatal("ECS queries with different source-prefix lengths produced the same Redis cache key")
+	}
+}
 
 func TestEncodeDecode(t *testing.T) {
 	// Create a test DNS message

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -25,6 +25,8 @@ type lruKey struct {
 	Question dns.Question
 	Net      string
 	Do       bool
+	CD       bool  // RFC 4035 §4.7 / RFC 6840 §5.9: CD=1 responses are unvalidated and must not be served to CD=0 clients
+	ECSMask  uint8 // ECS source prefix length; responses with differing scope must not collide
 }
 
 type cacheAnswer struct {
@@ -215,7 +217,7 @@ func lruKeyFromQuery(q *dns.Msg) lruKey {
 	question := q.Question[0]
 	// disregard case of the question name when storing
 	question.Name = strings.ToLower(question.Name)
-	key := lruKey{Question: question}
+	key := lruKey{Question: question, CD: q.CheckingDisabled}
 
 	edns0 := q.IsEdns0()
 	if edns0 != nil {
@@ -224,6 +226,7 @@ func lruKeyFromQuery(q *dns.Msg) lruKey {
 		for _, opt := range edns0.Option {
 			if subnet, ok := opt.(*dns.EDNS0_SUBNET); ok {
 				key.Net = subnet.Address.String()
+				key.ECSMask = subnet.SourceNetmask
 			}
 		}
 	}

--- a/lru-cache_test.go
+++ b/lru-cache_test.go
@@ -66,3 +66,74 @@ func TestLRUAddGet(t *testing.T) {
 	})
 	require.Equal(t, 2, c.size())
 }
+
+// A CD=1 response is unvalidated (RFC 4035 §4.7 / RFC 6840 §5.9) and must not
+// be served to a CD=0 client. The cache key must therefore distinguish them.
+func TestLRUKeyCD(t *testing.T) {
+	answerFor := func(name string) *cacheAnswer {
+		msg := new(dns.Msg)
+		msg.SetQuestion(name, dns.TypeA)
+		msg.Answer = []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+				A:   net.IP{127, 0, 0, 1},
+			},
+		}
+		return &cacheAnswer{Msg: msg}
+	}
+
+	queryCD := func(name string, cd bool) *dns.Msg {
+		q := new(dns.Msg)
+		q.SetQuestion(name, dns.TypeA)
+		q.CheckingDisabled = cd
+		return q
+	}
+
+	c := newLRUCache(10)
+
+	// Store an (unvalidated) answer for a CD=1 query.
+	cdAnswer := answerFor("cd.example.com.")
+	c.add(queryCD("cd.example.com.", true), cdAnswer)
+
+	// A CD=0 lookup for the same name must NOT hit the CD=1 entry.
+	require.Nil(t, c.get(queryCD("cd.example.com.", false)),
+		"CD=0 query must not be served the cached CD=1 response")
+
+	// The original CD=1 query still hits its own entry.
+	require.Equal(t, cdAnswer, c.get(queryCD("cd.example.com.", true)))
+
+	// Storing a CD=0 answer is kept separate from the CD=1 one.
+	plainAnswer := answerFor("cd.example.com.")
+	c.add(queryCD("cd.example.com.", false), plainAnswer)
+	require.Equal(t, plainAnswer, c.get(queryCD("cd.example.com.", false)))
+	require.Equal(t, cdAnswer, c.get(queryCD("cd.example.com.", true)))
+	require.Equal(t, 2, c.size())
+}
+
+// ECS responses with a different source-prefix length have a different scope
+// and must not collide on the cache key.
+func TestLRUKeyECSMask(t *testing.T) {
+	queryECS := func(mask uint8) *dns.Msg {
+		q := new(dns.Msg)
+		q.SetQuestion("ecs.example.com.", dns.TypeA)
+		q.SetEdns0(4096, false)
+		ecs := new(dns.EDNS0_SUBNET)
+		ecs.Code = dns.EDNS0SUBNET
+		ecs.Family = 1
+		ecs.SourceNetmask = mask
+		ecs.SourceScope = 0
+		ecs.Address = net.IP{192, 0, 2, 0}
+		q.IsEdns0().Option = append(q.IsEdns0().Option, ecs)
+		return q
+	}
+
+	c := newLRUCache(10)
+
+	answer24 := &cacheAnswer{Msg: new(dns.Msg)}
+	c.add(queryECS(24), answer24)
+
+	// Same address, different prefix length must be a distinct entry.
+	require.Nil(t, c.get(queryECS(16)),
+		"ECS query with a different source-prefix length must not collide")
+	require.NotNil(t, c.get(queryECS(24)))
+}


### PR DESCRIPTION
## Problem

`lruKeyFromQuery()` (`lru-cache.go`) and the equivalent `keyFromQuery()` (`cache-redis.go`) build the cache key from the lowercased question, qtype, qclass, the DO bit and the ECS *address* string. They omit `q.CheckingDisabled` and the ECS *source-prefix length*. The `dedupKey` struct in `request-dedup.go` already keys on both (`cd bool`, `ecs_mask uint8`), so the codebase already recognizes these as query-distinguishing.

RFC 4035 §4.7 / RFC 6840 §5.9 require resolvers to keep separate cache states for CD=0 and CD=1, because an upstream returns potentially-bogus (unvalidated) data for CD=1 queries. With CD omitted from the key, a CD=1 response is stored under the same key a CD=0 lookup hits.

**Impact:** in the common `cache → upstream-DoH` setup, an allowed client sending a CD=1 query causes RouteDNS to cache the upstream's unvalidated answer; a subsequent legitimate CD=0 query for the same name is then served that unvalidated, potentially-spoofed answer instead of the SERVFAIL the upstream would have returned. ECS responses with different scope-prefix lengths also collide, widening the affected scope of a cached entry.

## Fix

- Add `CD bool` and `ECSMask uint8` to the in-memory `lruKey` struct and populate them in `lruKeyFromQuery()` from `q.CheckingDisabled` and `subnet.SourceNetmask`. Prefetch hit-counting and round-robin shuffle state, which derive their keys from `lruKeyFromQuery()`, inherit the fix automatically.
- Add a CD segment and the ECS source netmask to the Redis `keyFromQuery()`.

## Compatibility

- In-memory: the new fields default to zero (`CD=false`, `ECSMask=0`) when deserializing old cache-dump files, matching prior semantics — no breakage.
- Redis: the key-format change orphans existing entries (one-time cold cache after upgrade). This is the safe outcome — old entries never distinguished CD and should not be reused.
- `dedupKey` already correct — unchanged.

## Tests

- `TestLRUKeyCD`: a CD=0 lookup must not be served a cached CD=1 response (and vice versa); CD=0 and CD=1 entries for the same name coexist.
- `TestLRUKeyECSMask`: same ECS address with a different source-prefix length is a distinct entry.
- `TestRedisKeyFromQuery`: the Redis key differs for CD=0 vs CD=1 and for differing ECS source-prefix lengths.