### PR TITLE
Fix domain blocklist exact-match rule destroyed by overlapping subdomain rule

### DIFF
--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -29,6 +29,15 @@ type DomainDB struct {
 
 type node map[string]node
 
+// exactKey marks a node as an exact-match terminal that must also act
+// as an interior node for more-specific rules. A nil/empty node still
+// means an exact terminal on its own; exactKey is only added when the
+// same node additionally carries children or other sentinels so the
+// marker isn't masked. The value can never collide with a real label
+// (rules are split on ".", so labels never contain ".") nor with the
+// "" (apex+sub) or "*" (sub-only) sentinels.
+const exactKey = "."
+
 var _ BlocklistDB = &DomainDB{}
 
 // NewDomainDB returns a new instance of a matcher for a list of domain rules.
@@ -99,9 +108,42 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 					subNode = make(node)
 				}
 				n[part] = subNode
-			} else if i != 0 && isSharedShape(subNode) {
+				n = subNode
+				continue
+			}
+
+			// The path segment already exists.
+			if i == 0 {
+				// This rule is an exact match terminating here. A
+				// nil/empty leaf already means an exact terminal, and a
+				// "" sentinel already matches the apex, so in both
+				// cases there's nothing to add. Otherwise the node also
+				// acts as an interior node for more-specific rules, so
+				// record an explicit exact marker that survives
+				// alongside the children. Clone shared shapes before
+				// mutating so siblings sharing the instance aren't
+				// corrupted.
+				if len(subNode) == 0 {
+					break
+				}
+				if _, apex := subNode[""]; apex {
+					break
+				}
+				if isSharedShape(subNode) {
+					subNode = maps.Clone(subNode)
+					n[part] = subNode
+				}
+				subNode[exactKey] = nil
+				break
+			}
+
+			// Descending through an existing segment. Clone/expand
+			// shared shapes so sibling paths that share the instance
+			// aren't corrupted, preserving an exact terminal that a
+			// shorter rule stored here as a nil leaf.
+			if isSharedShape(subNode) {
 				if subNode == nil {
-					subNode = make(node)
+					subNode = node{exactKey: nil}
 				} else {
 					subNode = maps.Clone(subNode)
 				}
@@ -171,13 +213,14 @@ func (m *DomainDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, boo
 		}
 		n = subNode
 	}
+	_, exact := n[exactKey]
 	return nil,
 		nil,
 		&BlocklistMatch{
 			List: m.name,
 			Rule: matchedDomainParts("", matched),
 		},
-		len(n) == 0 // exact match
+		len(n) == 0 || exact // exact match
 }
 
 func (m *DomainDB) String() string {

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -61,6 +61,109 @@ func TestDomainDB(t *testing.T) {
 	}
 }
 
+// TestDomainDBOverlap covers exact rules that overlap with more-specific
+// rules. The trie's exact-match marker must survive regardless of the
+// order in which the overlapping rules are inserted.
+func TestDomainDBOverlap(t *testing.T) {
+	cases := []struct {
+		name  string
+		rules []string
+		tests []struct {
+			q     string
+			match bool
+		}
+	}{
+		{
+			name:  "exact apex then exact subdomain",
+			rules: []string{"domain.com", "sub.domain.com"},
+			tests: []struct {
+				q     string
+				match bool
+			}{
+				{"domain.com.", true},
+				{"sub.domain.com.", true},
+				{"other.domain.com.", false},
+			},
+		},
+		{
+			name:  "exact subdomain then exact apex",
+			rules: []string{"sub.domain.com", "domain.com"},
+			tests: []struct {
+				q     string
+				match bool
+			}{
+				{"domain.com.", true},
+				{"sub.domain.com.", true},
+				{"other.domain.com.", false},
+			},
+		},
+		{
+			name:  "exact apex then deep exact subdomain",
+			rules: []string{"domain.com", "sub.domain.com", "deep.sub.domain.com"},
+			tests: []struct {
+				q     string
+				match bool
+			}{
+				{"domain.com.", true},
+				{"sub.domain.com.", true},
+				{"deep.sub.domain.com.", true},
+				{"x.sub.domain.com.", false},
+			},
+		},
+		{
+			name:  "apex+sub rule then exact apex (shared dot sentinel untouched)",
+			rules: []string{".domain.com", "domain.com", ".other.com"},
+			tests: []struct {
+				q     string
+				match bool
+			}{
+				{"domain.com.", true},
+				{"sub.domain.com.", true},
+				{"other.com.", true},
+				{"sub.other.com.", true},
+			},
+		},
+		{
+			name:  "wildcard rule then exact apex (shared star sentinel untouched)",
+			rules: []string{"*.domain.com", "*.other.com", "domain.com"},
+			tests: []struct {
+				q     string
+				match bool
+			}{
+				{"domain.com.", true},
+				{"sub.domain.com.", true},
+				{"other.com.", false},
+				{"sub.other.com.", true},
+			},
+		},
+		{
+			name:  "exact tld then exact apex under it",
+			rules: []string{"com", "domain.com"},
+			tests: []struct {
+				q     string
+				match bool
+			}{
+				{"com.", true},
+				{"domain.com.", true},
+				{"other.com.", false},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m, err := NewDomainDB("testlist", NewStaticLoader(c.rules))
+			require.NoError(t, err)
+			for _, test := range c.tests {
+				msg := new(dns.Msg)
+				msg.SetQuestion(test.q, dns.TypeA)
+				_, _, _, ok := m.Match(msg)
+				require.Equal(t, test.match, ok, "rules=%v query=%s", c.rules, test.q)
+			}
+		})
+	}
+}
+
 func TestDomainSubdomainDB(t *testing.T) {
 	loader := NewStaticLoader([]string{
 		"domain1.com",     // bare entry: apex + subdomains


### PR DESCRIPTION
## Problem

An exact-only domain rule (e.g. `domain.com`) was encoded in the blocklist trie as an empty/`nil` node and detected in `Match` via `len(n) == 0`. That structural marker collides with the same node also having to act as an interior node for a more-specific rule (e.g. `sub.domain.com`):

- **Parent first** (`domain.com`, then `sub.domain.com`): descending through the `nil` leaf hit `isSharedShape(nil)` and replaced it with `make(node)`, discarding the implicit exact marker.
- **Child first** (`sub.domain.com`, then `domain.com`): the terminal label already existed, so neither insert branch recorded the exact marker.

Either order made `Match("domain.com")` return `false`, silently un-blocking an apex domain an operator believed was blocked (common when blocklists from multiple sources are merged and contain both `evil.com` and `tracker.evil.com`).

## Fix

Add an explicit `exactKey` sentinel, consistent with the existing `""` (apex+sub) and `"*"` (sub-only) key sentinels:

- `nil`/empty still means an exact terminal for the common zero-allocation leaf case, so the memory optimization is unchanged.
- `exactKey` is added only when the same node must additionally act as an interior node, so the marker survives alongside the children.
- Shared `dotNode`/`starNode` sentinels are cloned before mutation so sibling paths sharing the instance are not corrupted.
- `Match` treats a trailing `exactKey` as an exact match.

## Tests

New `TestDomainDBOverlap` covers both insertion orders of `domain.com`+`sub.domain.com`, deep subdomains, apex+sub and wildcard overlaps (verifying the shared sentinels stay intact), and an exact-TLD overlap. Existing domain and node-sharing/memory tests still pass; the domain/blocklist suite is race-clean.