### PR TITLE
Fix data race in TestResolver hit counter

### DIFF
--- a/failback_test.go
+++ b/failback_test.go
@@ -120,7 +120,7 @@ func TestFailBackServfailOKOption(t *testing.T) {
 	a, err := g1.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, dns.RcodeServerFailure, a.Rcode)
-	require.Equal(t, 0, goodResolver.hitCount)
+	require.Equal(t, 0, goodResolver.HitCount())
 
 	// With ServfailError == true
 	g2 := NewFailBack("test-fb", FailBackOptions{ResetAfter: time.Second, ServfailError: true}, failResolver, goodResolver)
@@ -128,7 +128,7 @@ func TestFailBackServfailOKOption(t *testing.T) {
 	a, err = g2.Resolve(q, ci)
 	require.NoError(t, err)
 	require.NotEqual(t, dns.RcodeServerFailure, a.Rcode)
-	require.Equal(t, 1, goodResolver.hitCount)
+	require.Equal(t, 1, goodResolver.HitCount())
 }
 
 func TestFailBackIsSuccessResponse(t *testing.T) {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"sync/atomic"
 
 	"github.com/miekg/dns"
 )
@@ -18,12 +19,16 @@ func init() {
 // defined externally.
 type TestResolver struct {
 	ResolveFunc func(*dns.Msg, ClientInfo) (*dns.Msg, error)
-	hitCount    int
-	shouldFail  bool
+	// hitCount is atomic because Fastest (and similar groups) abandon
+	// slower resolvers' goroutines, which keep calling Resolve after
+	// the group has returned, concurrently with the test reading
+	// HitCount().
+	hitCount   atomic.Int64
+	shouldFail bool
 }
 
 func (r *TestResolver) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-	r.hitCount++
+	r.hitCount.Add(1)
 	if r.shouldFail {
 		return nil, errors.New("failed")
 	}
@@ -38,7 +43,7 @@ func (r *TestResolver) String() string {
 }
 
 func (r *TestResolver) HitCount() int {
-	return r.hitCount
+	return int(r.hitCount.Load())
 }
 
 func (r *TestResolver) SetFail(f bool) {


### PR DESCRIPTION
## Problem

`go test -race ./` fails at `TestFastest` with a data race on `TestResolver.hitCount`.

`Fastest.Resolve` queries all resolvers concurrently and returns the first successful response, **abandoning** the slower resolvers' goroutines by design. Those abandoned goroutines keep executing `TestResolver.Resolve` (`r.hitCount++`) while the test reads `r1.HitCount()`. Because the abandoned goroutine's response is never received from `Fastest`'s channel, there is no happens-before edge between that write and the test's read — a genuine data race. The `time.Sleep(time.Millisecond)` in the test establishes no ordering, so the race detector correctly flags it.

`TestFastestFail` / `TestFastestFailAll` don't trip this because there `Fastest` waits for every goroutine, which creates the synchronization edge via the response channel.

## Fix

- `TestResolver.hitCount` is now an `atomic.Int64` (`Add(1)` on write, `Load()` in `HitCount()`). `TestResolver` is explicitly designed to be hit concurrently and to count hits, which requires synchronized access.
- Two direct `goodResolver.hitCount` field reads in `failback_test.go` switched to the `HitCount()` accessor — copying an atomic into `require.Equal` is a `go vet` copylocks violation.

`shouldFail` is intentionally left as a plain `bool`: `SetFail` is only used by the `FailRotate`/`FailBack` tests, which try resolvers sequentially with no abandoned goroutines.

## Verification

- `go vet ./` clean.
- `go test -race -short ./` now passes the full root package (previously aborted at `TestFastest`).