### PR TITLE
pipeline: reject upstream responses with an empty question section

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -210,15 +210,19 @@ func newRequest(q *dns.Msg) *request {
 func (r *request) waitFor() (*dns.Msg, error) {
 	<-r.done
 
-	if r.err == nil {
-		// As per https://tools.ietf.org/html/rfc7858#section-3.3, we need to double check this
-		// really is the correct response.
-		if len(r.a.Question) > 0 && len(r.q.Question) > 0 {
-			q := r.q.Question[0]
-			a := r.a.Question[0]
-			if a.Name != q.Name || a.Qclass != q.Qclass || a.Qtype != q.Qtype {
-				return nil, fmt.Errorf("expected answer for %s, got %s", q.String(), a.String())
-			}
+	if r.err == nil && len(r.q.Question) > 0 {
+		// As per https://tools.ietf.org/html/rfc7858#section-3.3 and RFC 5452
+		// section 9.1, the response to a query that carried a Question must echo
+		// it back. A response with an empty Question section (QDCOUNT=0) must be
+		// rejected rather than accepted - skipping the check would leave only the
+		// 16-bit transaction ID and source port as anti-spoofing protection.
+		q := r.q.Question[0]
+		if len(r.a.Question) == 0 {
+			return nil, fmt.Errorf("expected answer for %s, got response with empty question section", q.String())
+		}
+		a := r.a.Question[0]
+		if a.Name != q.Name || a.Qclass != q.Qclass || a.Qtype != q.Qtype {
+			return nil, fmt.Errorf("expected answer for %s, got %s", q.String(), a.String())
 		}
 	}
 

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -77,3 +77,70 @@ func TestPipelineInFlightCleanup(t *testing.T) {
 	p.inFlight.mu.Unlock()
 	require.Equal(t, 0, n, "in-flight map should be empty after all callers timed out")
 }
+
+// A response that echoes back a matching Question must be accepted.
+func TestPipelineQuestionMatch(t *testing.T) {
+	server, client := net.Pipe()
+	go func() { // upstream that echoes the question and adds an answer
+		conn := &dns.Conn{Conn: server}
+		query, err := conn.ReadMsg()
+		if err != nil {
+			return
+		}
+		resp := new(dns.Msg)
+		resp.SetReply(query)
+		resp.Answer = []dns.RR{&dns.A{
+			Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   net.IPv4(192, 0, 2, 1),
+		}}
+		_ = conn.WriteMsg(resp)
+	}()
+	t.Cleanup(func() { server.Close() })
+
+	df := func(address string) (*dns.Conn, error) {
+		return &dns.Conn{Conn: client}, nil
+	}
+	p := NewPipeline("test", "localhost:53", testDialer(df), time.Second)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	a, err := p.Resolve(q)
+	require.NoError(t, err)
+	require.Len(t, a.Answer, 1)
+}
+
+// A spoofed response with QDCOUNT=0 must be rejected even when the transaction
+// ID matches, instead of silently bypassing the RFC 5452 9.1 / RFC 7858 3.3
+// anti-spoofing question check.
+func TestPipelineRejectEmptyQuestion(t *testing.T) {
+	server, client := net.Pipe()
+	go func() { // upstream that replies with a matching ID but no Question
+		conn := &dns.Conn{Conn: server}
+		query, err := conn.ReadMsg()
+		if err != nil {
+			return
+		}
+		resp := new(dns.Msg)
+		resp.Id = query.Id // matching transaction ID, as a spoofer would brute-force
+		resp.Response = true
+		// Deliberately no Question section (QDCOUNT=0).
+		resp.Answer = []dns.RR{&dns.A{
+			Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   net.IPv4(192, 0, 2, 1),
+		}}
+		_ = conn.WriteMsg(resp)
+	}()
+	t.Cleanup(func() { server.Close() })
+
+	df := func(address string) (*dns.Conn, error) {
+		return &dns.Conn{Conn: client}, nil
+	}
+	p := NewPipeline("test", "localhost:53", testDialer(df), time.Second)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	_, err := p.Resolve(q)
+	require.Error(t, err, "response with empty question section must be rejected")
+}


### PR DESCRIPTION
## Problem

`waitFor()` in `pipeline.go` only ran the response/query Question comparison when **both** sections were non-empty:

```go
if len(r.a.Question) > 0 && len(r.q.Question) > 0 {
```

A response with `QDCOUNT=0` therefore silently bypassed the RFC 5452 §9.1 / RFC 7858 §3.3 anti-spoofing check entirely, leaving only the random 16-bit transaction ID and the ephemeral source port as matching criteria.

`Pipeline` is the shared transport for the plain UDP/TCP (`dnsclient.go`), DoT (`dotclient.go`), and DTLS (`dtlsclient.go`) clients, and it reuses a single connection — i.e. a single source port — for many queries until idle. For a plain UDP upstream, an off-path attacker can spoof a response to that stable source port with `QR=1, QDCOUNT=0, ANCOUNT=1`, brute-forcing only the 16-bit ID. On a hit the question check is skipped, RouteDNS accepts the forged answer, and the in-memory cache stores it (then `cache-memory.go` overwrites `answer.Question = q.Question` on serve, masking the missing question). The result is untargeted cache pollution / DoS for whatever name the in-flight legitimate query was for.

This is also asymmetric: the listeners (`doqlistener.go`, `dohlistener.go`, `odohlistener.go`, `dnslistener.go`) already reject inbound queries with `QDCOUNT=0`; only the upstream-response side was missing the equivalent guard.

## Fix

Validate whenever the query carried a Question. A response that echoes no Question is now rejected instead of accepted:

- `len(r.q.Question) > 0` preserves today's lenient behavior for the (non-spoofing) question-less query case.
- The `r.err == nil` guard is kept so a nil `r.a` is never dereferenced.
- Well-behaved DNS servers always echo the question, so there is no behavior change for legitimate traffic. The poison is now stopped in `waitFor()` before it can reach the cache, so no cache/client changes are needed.

## Tests

Added to `pipeline_test.go`:

- `TestPipelineRejectEmptyQuestion` — a spoofed reply with a matching transaction ID but `QDCOUNT=0` is rejected.
- `TestPipelineQuestionMatch` — a correctly echoed Question still resolves successfully (no regression).

Both pass under `go test -race`, along with the existing pipeline and cache tests.