### PR TITLE
router: prevent ECS spoofing in ecs-source routing

### DIFF
--- a/cmd/routedns/example-config/use-case-7.toml
+++ b/cmd/routedns/example-config/use-case-7.toml
@@ -1,32 +1,58 @@
 # RouteDNS config demonstrating routing based on EDNS Client Subnet (ECS).
 # This allows for per-client policies even when RouteDNS is behind another
 # resolver that forwards the original client IP in an ECS record.
+#
+# SECURITY: ECS is carried in the query and is client-controlled. Used on its
+# own, `ecs-source` can be spoofed by any client able to reach RouteDNS
+# directly, bypassing security-relevant policies (here, the adblock filter).
+# This example uses the safe pattern:
+#
+#   1. RouteDNS only listens on the internal interface facing the trusted
+#      forwarder (10.0.0.1), not on networks reachable by untrusted clients.
+#   2. Each ecs-source route is additionally constrained with `source` so the
+#      ECS value is only honored when the query actually arrives from the
+#      trusted forwarder. Both conditions must match (logical AND).
+#   3. ECS is stripped before forwarding upstream to avoid leaking the
+#      original client's address.
 
-# Listener for the local network, receiving queries from the frontend resolver.
+# Listener for the internal network, receiving queries from the trusted
+# frontend resolver/proxy at 10.0.0.1 only.
 [listeners.local-udp]
-address = ":53"
+address = "10.0.0.2:53"
 protocol = "udp"
 resolver = "ecs-router"
 
-# A router that inspects the ECS data in incoming queries.
+# A router that inspects the ECS data in incoming queries. The `source`
+# constraint pins each ECS route to the trusted forwarder's IP so a client
+# that reaches RouteDNS directly cannot steer routing with a forged ECS.
 [routers.ecs-router]
 routes = [
-    # Route 1: Queries with an ECS source of 192.168.1.10/32 are sent to the adblocker.
-    { ecs-source = "192.168.1.10/32", resolver = "adblock-resolver" },
+    # Route 1: Queries from the trusted forwarder with an ECS source of
+    # 192.168.1.10/32 are sent to the adblocker.
+    { source = "10.0.0.1/32", ecs-source = "192.168.1.10/32", resolver = "adblock-resolver" },
 
-    # Route 2: Queries with an ECS source of 192.168.1.20/32 are sent to the unfiltered resolver.
-    { ecs-source = "192.168.1.20/32", resolver = "unfiltered-resolver" },
+    # Route 2: Queries from the trusted forwarder with an ECS source of
+    # 192.168.1.20/32 are sent to the unfiltered resolver.
+    { source = "10.0.0.1/32", ecs-source = "192.168.1.20/32", resolver = "remove-ecs" },
 
-    # Route 3 (Default): All other queries (including those without ECS) go to the unfiltered resolver.
-    { resolver = "unfiltered-resolver" },
+    # Route 3 (Default): Everything else (no/other ECS, other source IPs,
+    # direct clients) goes to the unfiltered resolver with ECS removed.
+    { resolver = "remove-ecs" },
 ]
 
-# A simple blocklist resolver for the "strict" policy.
-# It blocks queries for "doubleclick.net" and forwards others.
+# A simple blocklist resolver for the "strict" policy. It blocks queries for
+# "doubleclick.net" and forwards others (with ECS removed first).
 [groups.adblock-resolver]
 type = "blocklist-v2"
-resolvers = ["unfiltered-resolver"]
+resolvers = ["remove-ecs"]
 blocklist = ["doubleclick.net"]
+
+# Strip the client's ECS option before forwarding upstream so the original
+# client address is not leaked to the unfiltered resolver.
+[groups.remove-ecs]
+type = "ecs-modifier"
+resolvers = ["unfiltered-resolver"]
+ecs-op = "delete"
 
 # An unfiltered, secure upstream resolver (Cloudflare DoT).
 [resolvers.unfiltered-resolver]

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1374,6 +1374,14 @@ The `ecs-source` field allows routing based on the IP address provided in the ED
 
 **Important:** To prevent leaking ECS data to upstream resolvers, use an `ecs-modifier` with `ecs-op = "delete"` before forwarding queries. ECS data contains information about the original client's IP address, which may compromise privacy if shared with upstream resolvers. Removing ECS data ensures that upstream resolvers only see the proxy's IP address.
 
+**Security note — ECS is client-controlled:** Unlike `source`, which is derived from the transport connection and cannot be forged, `ecs-source` matches on the ECS option carried in the query itself. Any client that can reach RouteDNS directly can put an arbitrary address in that option and steer routing — bypassing security-relevant policies such as parental controls or per-network filtering. `ecs-source` is only safe for policy decisions when the ECS value is written by a component you trust:
+
+- RouteDNS must **not** be directly reachable by untrusted clients. Place it behind the trusted forwarder/proxy that adds the ECS option and firewall off direct access.
+- Constrain the route with `source` so the ECS value is only honored when the query actually arrives from the trusted proxy, for example `{ source = "10.0.0.1/32", ecs-source = "192.168.1.10/32", resolver = "..." }`. Both conditions must match (logical AND), so a query from any other source IP will not match the ECS route regardless of its ECS contents.
+- Prefer a forwarder that **replaces** the client's ECS option rather than appending to it. RouteDNS evaluates the *last* ECS option in the query, so a proxy that appends its own option after a client-supplied one will take precedence; a proxy that appends but leaves the client's option untouched is still safe, but one that does not normalize at all is not.
+
+Note also that the router runs *before* groups in the pipeline, so an `ecs-modifier` group cannot normalize ECS ahead of the routing decision unless it is placed between the listener and the router (`listener → ecs-modifier → router`).
+
 #### Route Evaluation Order
 
 Routes are evaluated sequentially, and the first matching route is used. **Order matters** when defining routes:

--- a/route.go
+++ b/route.go
@@ -118,12 +118,17 @@ func (r *route) match(q *dns.Msg, ci ClientInfo) bool {
 		var ecsIP net.IP
 		opt := q.IsEdns0()
 		if opt != nil {
-			// According to RFC 7871, there should be only one EDNS0_SUBNET option per query.
-			// This code checks only the first found EDNS0_SUBNET option.
+			// According to RFC 7871 there should be only one EDNS0_SUBNET
+			// option per query. If a client injects its own ECS option ahead
+			// of one added by a trusted forwarder/proxy, both are present.
+			// Use the last option found so that an option appended by a proxy
+			// takes precedence over a client-supplied (potentially spoofed)
+			// value. Note that ecs-source still trusts client-controlled data
+			// when RouteDNS is reachable directly; see the security note in
+			// doc/configuration.md.
 			for _, s := range opt.Option {
 				if e, ok := s.(*dns.EDNS0_SUBNET); ok {
 					ecsIP = e.Address
-					break
 				}
 			}
 		}

--- a/router_test.go
+++ b/router_test.go
@@ -159,4 +159,27 @@ func TestRouterECSSource(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, r1.HitCount())
 	require.Equal(t, 2, r2.HitCount())
+
+	// A client-supplied (spoofed) ECS ahead of one appended by a trusted
+	// proxy: the last option must win, so this matches route1 (r1) based on
+	// the proxy's value, not the spoofed leading one.
+	o2 := new(dns.OPT)
+	o2.Hdr.Name = "."
+	o2.Hdr.Rrtype = dns.TypeOPT
+	spoofed := new(dns.EDNS0_SUBNET)
+	spoofed.Code = dns.EDNS0SUBNET
+	spoofed.Family = 1
+	spoofed.SourceNetmask = 32
+	spoofed.Address = net.ParseIP("192.168.1.1") // does not match 10.0.0.0/24
+	proxy := new(dns.EDNS0_SUBNET)
+	proxy.Code = dns.EDNS0SUBNET
+	proxy.Family = 1
+	proxy.SourceNetmask = 32
+	proxy.Address = net.ParseIP("10.0.0.1") // matches 10.0.0.0/24
+	o2.Option = append(o2.Option, spoofed, proxy)
+	q.Extra = append(q.Extra, o2)
+	_, err = router.Resolve(q, ClientInfo{SourceIP: net.ParseIP("192.168.1.100")})
+	require.NoError(t, err)
+	require.Equal(t, 2, r1.HitCount())
+	require.Equal(t, 2, r2.HitCount())
 }


### PR DESCRIPTION
## Problem

The `ecs-source` route matcher (`route.go`) reads the EDNS0 Client Subnet address directly from the client's query, in contrast to `source`, which uses the transport-authenticated connection IP (`ci.SourceIP`). ECS is wholly client-controlled, so a client able to reach RouteDNS directly can forge it to escape security-relevant routing — e.g. parental controls or per-network ad/content filtering — and fall through to an unfiltered resolver.

Additionally, the matcher took the **first** `EDNS0_SUBNET` option and stopped. A client that prepends its own ECS option ahead of one added by a trusted forwarder that *appends* its value would have its spoofed option win even in the documented trusted-proxy deployment.

`ecs-source` is by design a trusted-proxy feature, so the value cannot simply be distrusted without breaking it. This change makes the safe deployment robust and clearly documented.

## Changes

- **`route.go`**: evaluate the *last* `EDNS0_SUBNET` option instead of the first, consistent with RFC 7871 (one option expected), so an option appended by a trusted forwarder takes precedence over a client-supplied one. The residual limitation (still client-controlled when RouteDNS is directly reachable) is noted in the code comment.
- **`doc/configuration.md`**: new security note in *ECS Source Routing* explaining that `ecs-source` is client-controlled, the three conditions for safe use (no direct exposure; pin the trusted proxy with a `source` constraint, logical-AND; prefer a forwarder that replaces rather than appends ECS), and the router-runs-before-groups ordering caveat.
- **`use-case-7.toml`**: rewritten to the safe pattern — internal-only listener, each `ecs-source` route pinned with `source = "10.0.0.1/32"`, ECS stripped before forwarding upstream — with comments explaining the trust model so the example no longer teaches the vulnerable pattern.
- **`router_test.go`**: `TestRouterECSSource` extended with a spoofed-then-proxy ECS case asserting the last option wins.

## Verification

`go build ./...` passes; `go test -run TestRouterECSSource ./...` passes.