### PR TITLE
example-config: add configs for uncovered features

### DIFF
--- a/cmd/routedns/example-config/dnssec-validator-iana.toml
+++ b/cmd/routedns/example-config/dnssec-validator-iana.toml
@@ -1,0 +1,25 @@
+# DNSSEC validator using a trust anchor fetched from a URL.
+#
+# Instead of the built-in IANA root anchor (see dnssec-validator.toml) or
+# explicitly configured anchors (see dnssec-validator-trust-anchors.toml),
+# the trust anchor is loaded at startup from the official IANA root-anchors
+# XML. This keeps the anchor current without hard-coding key digests.
+
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[groups.dnssec-validated]
+type = "dnssec-validator"
+resolvers = ["cloudflare-dot"]
+dnssec-trust-anchor-url = "https://data.iana.org/root-anchors/root-anchors.xml"
+
+[listeners.local-udp]
+address = "127.0.0.1:53"
+protocol = "udp"
+resolver = "dnssec-validated"
+
+[listeners.local-tcp]
+address = "127.0.0.1:53"
+protocol = "tcp"
+resolver = "dnssec-validated"

--- a/cmd/routedns/example-config/lua-any-emulator.toml
+++ b/cmd/routedns/example-config/lua-any-emulator.toml
@@ -1,0 +1,40 @@
+# Emulates ANY queries by querying common record types individually and
+# merging the results. Routes ANY queries to the Lua emulator, everything
+# else goes directly upstream.
+
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[groups.any-emulator]
+type = "lua"
+resolvers = ["cloudflare-dot"]
+lua-script = """
+function Resolve(msg, ci)
+    local reply = Message.new():set_reply(msg)
+    local results = {}
+    for _, t in ipairs({TypeA, TypeAAAA, TypeMX, TypeTXT, TypeCNAME, TypeNS, TypeSOA, TypeSRV}) do
+        local q = Message.new()
+        q.questions = { Question.new(msg.questions[1].name, t) }
+        q.recursion_desired = msg.recursion_desired
+        local a, err = Resolvers[1]:resolve(q, ci)
+        if err == nil and a ~= nil then
+            for _, rr in ipairs(a.answer) do
+                results[#results + 1] = rr
+            end
+        end
+    end
+    reply.answer = results
+    return reply, nil
+end
+"""
+
+[listeners.local-udp]
+address = "127.0.0.1:53"
+protocol = "udp"
+resolver = "any-emulator"
+
+[listeners.local-tcp]
+address = "127.0.0.1:53"
+protocol = "tcp"
+resolver = "any-emulator"

--- a/cmd/routedns/example-config/response-blocklist-asn.toml
+++ b/cmd/routedns/example-config/response-blocklist-asn.toml
@@ -1,0 +1,16 @@
+[resolvers.cloudflare-dot]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[groups.cloudflare-blocklist]
+type                = "response-blocklist-ip"
+resolvers           = ["cloudflare-dot"]
+blocklist-format    = "asn"
+blocklist           = [
+  "15169", # Google
+]
+
+[listeners.local-udp]
+address = ":53"
+protocol = "udp"
+resolver = "cloudflare-blocklist"

--- a/cmd/routedns/example-config/socks5-udp-resolvelocal.toml
+++ b/cmd/routedns/example-config/socks5-udp-resolvelocal.toml
@@ -1,0 +1,16 @@
+# DNS though SOCKS. The server address is given as a hostname and instead
+# of resolving it on the SOCKS proxy, we want to resolve it locally (which
+# could be done with a bootstrap-resolver).
+
+[resolvers.cloudflare-udp]
+address = "one.one.one.one:53"
+protocol = "udp"
+socks5-address = "127.0.0.1:1080"
+socks5-username = "test"
+socks5-password = "test"
+socks5-resolve-local = true
+
+[listeners.local-udp]
+address = "127.0.0.1:53"
+protocol = "udp"
+resolver = "cloudflare-udp"

--- a/cmd/routedns/example-config/static-regex.toml
+++ b/cmd/routedns/example-config/static-regex.toml
@@ -1,0 +1,41 @@
+# Static responder that builds a response based on the query name
+
+[listeners.local-udp]
+address = "127.0.0.1:53"
+protocol = "udp"
+resolver = "static"
+
+[groups.static]
+type   = "static-responder"
+question = '^(\d+)-(\d+)-(\d+)-(\d+)\.rebind\.$'
+answer = ["IN A $1.2.3.4"]
+ns = [
+    "domain.com. 18000 IN NS ns$2.domain.com.",
+    "domain.com. 18000 IN NS ns2.domain.com.",
+]
+extra = [
+    "ns1.domain.com. 1800 IN A $3.$4.0.1",
+    "ns1.domain.com. 1800 IN AAAA ::1",
+    "ns2.domain.com. 1800 IN A 127.0.0.1",
+    "ns2.domain.com. 1800 IN AAAA ::1",
+]
+
+# [groups.static]
+# type      = "static-responder"
+# question  = '^(.+)\.$'
+# answer    = [ "IN A 0.0.0.0" ]
+# edns0-ede = { code = 15, text = "IP $1 is in the blocklist" }
+
+# [groups.static]
+# type   = "static-responder"
+# answer = ["IN A 1.2.3.4"]
+# ns = [
+#     "domain.com. 18000 IN NS ns1.domain.com.",
+#     "domain.com. 18000 IN NS ns2.domain.com.",
+# ]
+# extra = [
+#     "ns1.domain.com. 1800 IN A 127.0.0.1",
+#     "ns1.domain.com. 1800 IN AAAA ::1",
+#     "ns2.domain.com. 1800 IN A 127.0.0.1",
+#     "ns2.domain.com. 1800 IN AAAA ::1",
+# ]


### PR DESCRIPTION
Adds five example configs, each demonstrating a feature that no existing example in `cmd/routedns/example-config/` covers:

| File | Feature |
|---|---|
| `static-regex.toml` | `static-responder` with regex question matching and capture groups (`$1`, `$2`) |
| `socks5-udp-resolvelocal.toml` | `socks5-resolve-local` option |
| `response-blocklist-asn.toml` | `response-blocklist-ip` with `blocklist-format = "asn"` |
| `lua-any-emulator.toml` | Emulating `ANY` queries by fanning out to individual types via the Lua scripting hook |
| `dnssec-validator-iana.toml` | `dnssec-validator` with a URL-fetched trust anchor (`dnssec-trust-anchor-url`), complementing the existing built-in and explicit-anchor examples |

All referenced config keys were verified against the source (`config.go`, `asn-db.go`). Each file has a header comment consistent with the surrounding examples.