### PR TITLE
Fix linter deprecation and vet warnings

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -267,7 +267,7 @@ func loadConfig(name ...string) (config, error) {
 		}
 		b.WriteString("\n")
 	}
-	_, err := toml.DecodeReader(b, &c)
+	_, err := toml.NewDecoder(b).Decode(&c)
 	return c, err
 }
 

--- a/query-log.go
+++ b/query-log.go
@@ -54,7 +54,9 @@ func NewQueryLogResolver(id string, resolver Resolver, opt QueryLogResolverOptio
 		return nil, fmt.Errorf("invalid output format %q", opt.OutputFormat)
 	}
 	return &QueryLogResolver{
+		id:       id,
 		resolver: resolver,
+		opt:      opt,
 		logger:   logger,
 	}, nil
 }

--- a/router_test.go
+++ b/router_test.go
@@ -56,7 +56,7 @@ func TestRouterClass(t *testing.T) {
 
 	// ClassAny should go to r1
 	q.Question = make([]dns.Question, 1)
-	q.Question[0] = dns.Question{"miek.nl.", dns.TypeMX, dns.ClassANY}
+	q.Question[0] = dns.Question{Name: "miek.nl.", Qtype: dns.TypeMX, Qclass: dns.ClassANY}
 	_, err = router.Resolve(q, ci)
 	require.NoError(t, err)
 	require.Equal(t, 1, r1.HitCount())


### PR DESCRIPTION
Cleans up the linter/vet warnings that can be safely addressed without changing public API or behavior.

## Changes

| File | Warning | Fix |
|---|---|---|
| \`cmd/routedns/config.go\` | \`toml.DecodeReader\` is deprecated (staticcheck SA1019) | Switched to \`toml.NewDecoder(b).Decode(&c)\` |
| \`query-log.go\` | field \`opt\` unused (staticcheck U1000) | Wired \`id\` and \`opt\` into the \`QueryLogResolver\` constructor. This also fixes a latent bug: \`String()\` returned an empty ID because \`id\` was never assigned. |
| \`router_test.go\` | \`dns.Question\` struct literal uses unkeyed fields (\`go vet\`) | Used keyed fields (\`Name:\`, \`Qtype:\`, \`Qclass:\`) |

After these changes, \`go build ./...\` and \`go vet ./...\` are clean and \`staticcheck\` reports no remaining \`SA1019\`/\`U1000\` outside of \`pion/dtls\`.

## Left as-is

The remaining \`pion/dtls\` deprecations (\`dtls.Config\`, \`dtls.Client\`, \`dtls.Listen\`) are intentionally not addressed:

- \`dtls.Config\` is part of routedns's **public API** (\`DTLSClientOptions.DTLSConfig\`, \`DTLSListenerOptions.DTLSConfig\`, return type of \`DTLSServerConfig\`/\`DTLSClientConfig\`).
- The deprecation note says removal is in pion/dtls **v4**; the project pins **v3.1.2**, where the API still works correctly.
- Migrating to the \`*WithOptions\` API would be a breaking change for library consumers and warrants its own change, ideally alongside a future pion/dtls v4 upgrade.