### PR TITLE
dohlistener: trust all X-Forwarded-For header lines, not just the first

### DIFF
--- a/dohlistener.go
+++ b/dohlistener.go
@@ -226,7 +226,13 @@ func (s *DoHListener) extractClientAddress(r *http.Request) net.IP {
 
 	// TODO: Prefer RFC 7239 Forwarded once https://github.com/golang/go/issues/30963
 	//       is resolved and provides a safe parser.
-	xForwardedFor := r.Header.Get("X-Forwarded-For")
+	//
+	// A request may carry more than one X-Forwarded-For header line; some
+	// reverse proxies append a new line instead of extending the existing
+	// one. Per RFC 7230 these are equivalent to a single comma-separated
+	// value in receive order, so flatten them all. Header.Get would only
+	// see the first (potentially attacker-supplied) line.
+	xForwardedFor := strings.Join(r.Header.Values("X-Forwarded-For"), ", ")
 
 	// Simple case: No proxy (or empty/long X-Forwarded-For).
 	if s.opt.HTTPProxyNet == nil || xForwardedFor == "" || len(xForwardedFor) >= 1024 {
@@ -236,7 +242,7 @@ func (s *DoHListener) extractClientAddress(r *http.Request) net.IP {
 	// If our client is a reverse proxy then use the last entry in X-Forwarded-For.
 	chain := strings.Split(xForwardedFor, ", ")
 	if clientIP != nil && s.opt.HTTPProxyNet.Contains(clientIP) {
-		if ip := net.ParseIP(chain[len(chain)-1]); ip != nil {
+		if ip := net.ParseIP(strings.TrimSpace(chain[len(chain)-1])); ip != nil {
 			// Ignore XFF when the client is local to the proxy.
 			if !ip.IsLoopback() {
 				return ip

--- a/dohlistener_test.go
+++ b/dohlistener_test.go
@@ -214,6 +214,16 @@ func TestClientBehindProxy(t *testing.T) {
 	r.Header.Add("X-Forwarded-For", "192.168.1.2, 10.0.0.2")
 	client = s.extractClientAddress(r)
 	require.Equal(t, "10.0.1.6", client.String())
+
+	// The attacker sends a spoofed X-Forwarded-For and our proxy appends
+	// its own as a separate header line (as HAProxy and others do). The
+	// spoofed first line must be ignored in favor of the proxy-supplied one.
+	r, _ = http.NewRequest("GET", "https://www.example.com", nil)
+	r.RemoteAddr = "10.0.0.2:1234"
+	r.Header.Add("X-Forwarded-For", "1.2.3.4")
+	r.Header.Add("X-Forwarded-For", "10.0.1.5")
+	client = s.extractClientAddress(r)
+	require.Equal(t, "10.0.1.5", client.String())
 }
 
 func TestIPv6Proxy(t *testing.T) {


### PR DESCRIPTION
## Problem

`extractClientAddress()` read the forwarded client IP via `r.Header.Get("X-Forwarded-For")`. Per Go's `net/http`, `Header.Get` returns **only the first** header line when a request carries multiple `X-Forwarded-For:` lines.

Reverse proxies that append a *new* `X-Forwarded-For` header line rather than extending the existing comma-separated value — HAProxy's `option forwardfor` does exactly this — leave an attacker-supplied first line intact:

```
X-Forwarded-For: 10.0.0.5          <- attacker-supplied, passed through
X-Forwarded-For: <real client IP>  <- appended by the trusted proxy
```

`Header.Get` returns only `10.0.0.5`, and the existing rightmost-entry logic then picks that single spoofed value. The attacker-controlled IP becomes `ci.SourceIP`, bypassing `allowed-net`, client-blocklist, and IP-based router/ECS checks downstream. The trust gate on the source IP being inside `HTTPProxyNet` does not help, since the spoofed value rides through a legitimately-trusted proxy.

## Fix

Flatten **all** `X-Forwarded-For` header lines into a single chain via `strings.Join(r.Header.Values("X-Forwarded-For"), ", ")` before applying the existing rightmost-entry selection. Per RFC 7230 §3.2.2 multiple same-name header lines are equivalent to one comma-separated value in receive order, and Go preserves wire order in `Header.Values`, so a proxy's appended line is rightmost and is the value used — not the spoofed leading line.

The existing single-trusted-proxy model, the length cap, and the loopback handling are unchanged. The documented "ignore XFF when our proxy is itself behind an untrusted proxy" behavior is preserved. Also trims whitespace on the selected entry as minor hardening.

All existing tests use a single `Header.Add` per request, so flattening reproduces the identical string and behavior. A regression test covering the spoofed-line + proxy-appended-line case is added; it fails on the previous code and passes with the fix.