### PR TITLE
odohlistener: guard against nil response from resolver

### DIFF
--- a/odohlistener.go
+++ b/odohlistener.go
@@ -237,6 +237,12 @@ func (s *ODoHListener) ODoHqueryHandler(w http.ResponseWriter, r *http.Request) 
 		a.SetRcode(q, dns.RcodeServerFailure)
 	}
 
+	// A nil response from the resolvers means "drop", return blank response
+	if a == nil {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
 	p, err := a.Pack()
 	if err != nil {
 		Log.Error("failed to encode response", "error", err)


### PR DESCRIPTION
## Problem

`ODoHqueryHandler` (`odohlistener.go:233-240`) calls `s.r.Resolve()`, checks only `err != nil`, then dereferences the response via `a.Pack()`. A drop-style resolver — a `drop` rule or a tripped rate limiter — returns `(nil, nil)`. Since `err` is nil the recovery block is skipped, and `a.Pack()` dereferences a nil `*dns.Msg`.

Because this handler runs inside `net/http`'s `ServeHTTP` goroutine, the panic is recovered per-request (no process crash), but the connection is reset and a goroutine stack trace is logged on **every** dropped query. Repeated dropped queries cause log spam and CPU overhead from stack unwinding.

The wrapped DoH handler (`dohlistener.go:317-322`) already guards this case; the ODoH path did not.

## Fix

Add a nil check between the error block and `a.Pack()`, mirroring the existing DoH guard: return a blank `403` on a nil ("drop") response instead of dereferencing it.

The metrics increment present in the DoH guard (`s.metrics.drop.Add(1)`) is intentionally omitted — `ODoHListener` has no metrics field, and adding metrics infrastructure to ODoH is out of scope for this fix.