### PR TITLE
client-blocklist: handle nil client IP without panicking

### DIFF
--- a/cidr-db.go
+++ b/cidr-db.go
@@ -59,6 +59,11 @@ func (m *CidrDB) Reload() (IPBlocklistDB, error) {
 }
 
 func (m *CidrDB) Match(ip net.IP) (*BlocklistMatch, bool) {
+	// A nil/empty IP can't be in any network; guard here so the trie
+	// lookup never indexes into a zero-length slice and panics.
+	if len(ip) == 0 {
+		return nil, false
+	}
 	if addr := ip.To4(); addr == nil {
 		rule, ok := m.ip6.hasIP(ip)
 		return &BlocklistMatch{List: m.name, Rule: rule}, ok

--- a/cidr-db_test.go
+++ b/cidr-db_test.go
@@ -25,6 +25,8 @@ func TestCidrDB(t *testing.T) {
 		{ip: net.ParseIP("192.168.1.1"), match: false},
 		{ip: net.ParseIP("2a03:2880:f101:83:1:1:1:1"), match: true},
 		{ip: net.ParseIP("::1"), match: false},
+		{ip: nil, match: false},
+		{ip: net.IP{}, match: false},
 	}
 
 	for _, test := range tests {

--- a/client-blocklist.go
+++ b/client-blocklist.go
@@ -70,6 +70,14 @@ func (r *ClientBlocklist) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		}
 	}
 
+	// Internal or anonymous lookups (DNSSEC validation, prefetch, ODoH)
+	// carry no client IP. A client blocklist can't act on a missing IP, so
+	// let the query through rather than risk matching (or panicking) on nil.
+	if ip == nil {
+		r.metrics.allowed.Add(1)
+		return r.resolver.Resolve(q, ci)
+	}
+
 	if match, ok := r.BlocklistDB.Match(ip); ok {
 		log := Log.With(
 			slog.String("id", r.id),

--- a/client-blocklist_test.go
+++ b/client-blocklist_test.go
@@ -1,0 +1,65 @@
+package rdns
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// A query without a client IP (internal DNSSEC/prefetch lookups, anonymous
+// ODoH) must not crash a CIDR client-blocklist that contains an IPv6 prefix.
+// See: nil SourceIP previously panicked in the IPv6 trie.
+func TestClientBlocklistNilSourceIP(t *testing.T) {
+	loader := NewStaticLoader([]string{
+		"127.0.0.0/24",
+		"2a03:2880:f101:83::0/64",
+	})
+	db, err := NewCidrDB("testlist", loader)
+	require.NoError(t, err)
+
+	r := &TestResolver{}
+	b, err := NewClientBlocklist("test-cb", r, ClientBlocklistOptions{BlocklistDB: db})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	// ClientInfo{} has a nil SourceIP. This must pass through to the
+	// inner resolver instead of panicking.
+	a, err := b.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, a)
+	require.Equal(t, 1, r.HitCount())
+}
+
+// A query carrying a blocked client IP is still refused (normal behavior
+// unchanged by the nil guard).
+func TestClientBlocklistMatch(t *testing.T) {
+	loader := NewStaticLoader([]string{
+		"192.168.0.0/16",
+		"2a03:2880:f101:83::0/64",
+	})
+	db, err := NewCidrDB("testlist", loader)
+	require.NoError(t, err)
+
+	r := &TestResolver{}
+	b, err := NewClientBlocklist("test-cb", r, ClientBlocklistOptions{BlocklistDB: db})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	// Blocked client -> REFUSED, inner resolver not called.
+	a, err := b.Resolve(q, ClientInfo{SourceIP: net.ParseIP("192.168.1.1")})
+	require.NoError(t, err)
+	require.Equal(t, dns.RcodeRefused, a.Rcode)
+	require.Equal(t, 0, r.HitCount())
+
+	// Allowed client -> passed through.
+	a, err = b.Resolve(q, ClientInfo{SourceIP: net.ParseIP("10.0.0.1")})
+	require.NoError(t, err)
+	require.NotNil(t, a)
+	require.Equal(t, 1, r.HitCount())
+}


### PR DESCRIPTION
## Problem

A query that carries no client IP can crash the process when it reaches a CIDR-based client-blocklist.

`ClientBlocklist.Resolve()` does `ip := ci.SourceIP` and passes it straight to `BlocklistDB.Match(ip)`. Several call sites legitimately construct `ClientInfo` without a `SourceIP`:

- `odohlistener.go` — `ClientInfo{Listener, TLSServerName}` for anonymous ODoH queries
- `dnssec.go` — `ClientInfo{}` for internal DNSKEY/DS lookups
- `prefetch.go` — `ClientInfo{Listener: "prefetch"}`

When the blocklist is a `CidrDB` containing at least one IPv6 prefix, `nil.To4()` returns nil so `Match` falls through to the IPv6 trie; `bit()` then indexes a zero-length slice (`ip[0]`) and panics, terminating routedns. (GeoIPDB/ASNDB pass the nil to `maxminddb.Lookup`, which errors gracefully, so only the CIDR DB hits the panic — also reachable via `MultiIPDB`.)

## Fix

Two layers:

1. **`ClientBlocklist.Resolve`** — a missing client IP is treated as a pass-through (counted as `allowed`). A *client* blocklist can't meaningfully act on a request with no client IP, so internal/anonymous lookups should flow through rather than be blocked or crash. The call sites are intentionally left unchanged — a nil `SourceIP` for internal lookups is legitimate, and fabricating a placeholder IP could itself match a blocklist.
2. **`CidrDB.Match`** — guards a nil/empty IP and returns no-match, so the `IPBlocklistDB` contract never panics on nil regardless of caller (also hardens `ResponseBlocklistIP` and `MultiIPDB`).

## Tests

- `cidr-db_test.go`: added `nil` and empty-`net.IP` cases (expect no match).
- New `client-blocklist_test.go`: a nil `SourceIP` against an IPv6-containing CIDR list passes through without panicking; block (`REFUSED`) and allow behavior for real client IPs is unchanged.

`go vet ./...` clean; full `rdns` package suite passes with `-race`.