### PR TITLE
dohlistener: don't misattribute oversized X-Forwarded-For to proxy IP

### DIFF
--- a/dohlistener.go
+++ b/dohlistener.go
@@ -234,15 +234,24 @@ func (s *DoHListener) extractClientAddress(r *http.Request) net.IP {
 	// see the first (potentially attacker-supplied) line.
 	xForwardedFor := strings.Join(r.Header.Values("X-Forwarded-For"), ", ")
 
-	// Simple case: No proxy (or empty/long X-Forwarded-For).
-	if s.opt.HTTPProxyNet == nil || xForwardedFor == "" || len(xForwardedFor) >= 1024 {
+	// Simple case: No proxy or empty X-Forwarded-For.
+	if s.opt.HTTPProxyNet == nil || xForwardedFor == "" {
 		return clientIP
 	}
 
-	// If our client is a reverse proxy then use the last entry in X-Forwarded-For.
-	chain := strings.Split(xForwardedFor, ", ")
+	// If our client is a reverse proxy then use the last entry in
+	// X-Forwarded-For, i.e. the value the trusted proxy itself appended.
+	// Locate it by the final comma rather than splitting the whole header:
+	// an attacker behind a permissive proxy can pad the (client-controlled)
+	// prefix arbitrarily, so splitting it would allocate over attacker input
+	// and an overall length cap would discard the trusted last entry,
+	// misattributing the request to the proxy's own address.
+	last := xForwardedFor
+	if i := strings.LastIndex(xForwardedFor, ","); i >= 0 {
+		last = xForwardedFor[i+1:]
+	}
 	if clientIP != nil && s.opt.HTTPProxyNet.Contains(clientIP) {
-		if ip := net.ParseIP(strings.TrimSpace(chain[len(chain)-1])); ip != nil {
+		if ip := net.ParseIP(strings.TrimSpace(last)); ip != nil {
 			// Ignore XFF when the client is local to the proxy.
 			if !ip.IsLoopback() {
 				return ip

--- a/dohlistener_test.go
+++ b/dohlistener_test.go
@@ -3,6 +3,7 @@ package rdns
 import (
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -224,6 +225,17 @@ func TestClientBehindProxy(t *testing.T) {
 	r.Header.Add("X-Forwarded-For", "10.0.1.5")
 	client = s.extractClientAddress(r)
 	require.Equal(t, "10.0.1.5", client.String())
+
+	// The attacker pads the (client-controlled) X-Forwarded-For prefix past
+	// 1KB to try to make the request be attributed to the trusted proxy IP.
+	// Our proxy still appends the real client IP as the last entry, which
+	// must be used regardless of overall header length.
+	r, _ = http.NewRequest("GET", "https://www.example.com", nil)
+	r.RemoteAddr = "10.0.0.2:1234"
+	padding := strings.Repeat("A", 1100)
+	r.Header.Add("X-Forwarded-For", "203.0.113.50, "+padding+", 203.0.113.50")
+	client = s.extractClientAddress(r)
+	require.Equal(t, "203.0.113.50", client.String())
 }
 
 func TestIPv6Proxy(t *testing.T) {


### PR DESCRIPTION
## Problem

`extractClientAddress()` in `dohlistener.go` silently fell back to the TCP peer address (the trusted reverse proxy's IP) whenever `len(xForwardedFor) >= 1024`, with no error or log:

```go
if s.opt.HTTPProxyNet == nil || xForwardedFor == "" || len(xForwardedFor) >= 1024 {
    return clientIP
}
```

`ci.SourceIP` feeds `isAllowed()`, client-blocklist, rate-limiter, and source-based routing. A client behind a permissive reverse proxy can pad the (client-controlled) X-Forwarded-For prefix beyond 1024 bytes (typical proxy header limits are 8KB+). The trusted proxy still appends the real client IP as the last XFF entry, but the length guard discarded the whole chain before that entry was read, so the request was attributed to the proxy's own (typically trusted/unblocked) address — evading IP-keyed blocklists, rate limits, and source-IP routing.

## Fix

Only the last XFF entry (the one the trusted proxy itself appends) is ever needed for the trusted-proxy path. Locate it via the final comma instead of splitting the whole header and capping its length. A padded prefix can then neither force a large allocation (the original purpose of the cap) nor discard the trusted last entry.

This is non-breaking: every existing case in `TestClientBehindProxy` / `TestIPv6Proxy` (single entry, multi-entry chain, loopback, invalid value, multi-header-line) yields the identical result, since the last entry is unchanged for non-padded inputs.

A regression test mirroring the reported scenario (1.1KB-padded XFF prefix behind a trusted proxy) was added.