### PR TITLE
tls: require explicit ca when mutual-tls is enabled

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -140,8 +140,8 @@ Secure listeners, such as DNS-over-TLS, DNS-over-HTTPS, DNS-over-DTLS, DNS-over-
 
 - `server-crt` - Server certificate file. Required.
 - `server-key` - Server key file. Required.
-- `ca` - CA to validate client certificates. Optional. Uses the operating system's CA store by default.
-- `mutual-tls` - Requires clients to send valid (as per `ca` option) certificates before establishing a connection. Optional.
+- `ca` - CA to validate client certificates. Optional, but required when `mutual-tls` is enabled.
+- `mutual-tls` - Requires clients to send valid (as per `ca` option) certificates before establishing a connection. Optional. When enabled, `ca` must be set; the listener will refuse to start otherwise (to avoid silently trusting the operating system's CA store for client authentication).
 
 The DNS-over-HTTPS listener also accepts the client IP address from trusted reverse proxies in a particular subnet. X-Forwarded-For headers are only used if they are provided from this subnet.
 

--- a/dtls.go
+++ b/dtls.go
@@ -3,6 +3,7 @@ package rdns
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"os"
 
@@ -12,6 +13,9 @@ import (
 // DTLSServerConfig is a convenience function that builds a dtls.Config instance for DTLS servers
 // based on common options and certificate+key files.
 func DTLSServerConfig(caFile, crtFile, keyFile string, mutualTLS bool) (*dtls.Config, error) {
+	if mutualTLS && caFile == "" {
+		return nil, errors.New("mutual-tls requires a ca to be configured to verify client certificates")
+	}
 	dtlsConfig := &dtls.Config{}
 	if mutualTLS {
 		dtlsConfig.ClientAuth = dtls.RequireAndVerifyClientCert

--- a/tls.go
+++ b/tls.go
@@ -3,6 +3,7 @@ package rdns
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"os"
 )
@@ -10,6 +11,9 @@ import (
 // TLSServerConfig is a convenience function that builds a tls.Config instance for TLS servers
 // based on common options and certificate+key files.
 func TLSServerConfig(caFile, crtFile, keyFile string, mutualTLS bool) (*tls.Config, error) {
+	if mutualTLS && caFile == "" {
+		return nil, errors.New("mutual-tls requires a ca to be configured to verify client certificates")
+	}
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,33 @@
+package rdns
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTLSServerConfigMutualTLSRequiresCA(t *testing.T) {
+	// Without a CA, mutual-tls must fail rather than silently fall back to
+	// the system root pool for client certificate verification.
+	_, err := TLSServerConfig("", "testdata/server.crt", "testdata/server.key", true)
+	require.Error(t, err)
+
+	// With a CA it should succeed.
+	_, err = TLSServerConfig("testdata/ca.crt", "testdata/server.crt", "testdata/server.key", true)
+	require.NoError(t, err)
+
+	// Without mutual-tls, no CA is required.
+	_, err = TLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+	require.NoError(t, err)
+}
+
+func TestDTLSServerConfigMutualTLSRequiresCA(t *testing.T) {
+	_, err := DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", true)
+	require.Error(t, err)
+
+	_, err = DTLSServerConfig("testdata/ca.crt", "testdata/server.crt", "testdata/server.key", true)
+	require.NoError(t, err)
+
+	_, err = DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Problem

When `mutual-tls = true` is set on a TLS/DTLS listener but no `ca` is configured, `ClientAuth` was set to `RequireAndVerifyClientCert` while `ClientCAs` (resp. the DTLS equivalent) remained `nil`. Go's TLS stack falls back to the **system root pool** to verify client certificates when `ClientCAs` is nil.

The result: any client certificate chaining to a publicly trusted CA (e.g. Let's Encrypt) satisfies mutual-TLS authentication. An operator who enables `mutual-tls` intending to restrict a listener to clients holding certs from a private CA gets no such restriction, and there was no validation preventing the misconfiguration.

## Fix

Fail fast at config load. `TLSServerConfig` and `DTLSServerConfig` now return an error when `mutual-tls` is enabled but no `ca` is provided, so the listener refuses to start rather than silently trusting the system trust store. All six listener types (`admin`, `dot`, `dtls`, `doh`, `doq`, `odoh`) route through these two functions and already propagate the error, so startup aborts cleanly.

No behavior change when a `ca` is configured correctly.

## Changes

- `tls.go` / `dtls.go`: return an error when `mutual-tls` is enabled without a `ca`.
- `doc/configuration.md`: document that `ca` is required when `mutual-tls` is enabled.
- `tls_test.go`: unit tests covering both functions (no network required).

`go build ./...` and `go test ./...` pass.