### PR TITLE
doh: bound upstream response body before parsing (#555)

### DIFF
--- a/dohclient.go
+++ b/dohclient.go
@@ -26,6 +26,30 @@ import (
 // defaultDoHIdleTimeout is the default idle connection timeout for DoH TCP transport.
 const defaultDoHIdleTimeout = 30 * time.Second
 
+// maxDoHResponseSize is the largest HTTP response body a DoH/ODoH client will
+// buffer before attempting to parse it. A DNS message can't exceed 65535 bytes
+// (the 16-bit length prefix used over TCP); the extra slack covers ODoH
+// AEAD/encoding overhead. Bounding the read prevents a malicious or compromised
+// upstream from forcing RouteDNS to buffer an arbitrarily large response body.
+const maxDoHResponseSize = 65535 + 512
+
+// errResponseTooLarge is returned when an upstream HTTP response body exceeds
+// maxDoHResponseSize.
+var errResponseTooLarge = errors.New("upstream response body exceeds maximum size")
+
+// readBoundedBody reads up to limit bytes from r. It returns errResponseTooLarge
+// if the body is larger than limit rather than buffering it in full.
+func readBoundedBody(r io.Reader, limit int64) ([]byte, error) {
+	b, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) > limit {
+		return nil, errResponseTooLarge
+	}
+	return b, nil
+}
+
 // DoHClientOptions contains options used by the DNS-over-HTTP resolver.
 type DoHClientOptions struct {
 	// Query method, either GET or POST. If empty, POST is used.
@@ -243,9 +267,13 @@ func (d *DoHClient) responseFromHTTP(resp *http.Response) (*dns.Msg, error) {
 		d.metrics.err.Add(fmt.Sprintf("http%d", resp.StatusCode), 1)
 		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
-	rb, err := io.ReadAll(resp.Body)
+	rb, err := readBoundedBody(resp.Body, maxDoHResponseSize)
 	if err != nil {
-		d.metrics.err.Add("read", 1)
+		if errors.Is(err, errResponseTooLarge) {
+			d.metrics.err.Add("toolarge", 1)
+		} else {
+			d.metrics.err.Add("read", 1)
+		}
 		return nil, err
 	}
 	a := new(dns.Msg)

--- a/dohclient_test.go
+++ b/dohclient_test.go
@@ -1,7 +1,10 @@
 package rdns
 
 import (
+	"expvar"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,4 +67,76 @@ func TestDoHClientIdleTimeoutNegative(t *testing.T) {
 	_, err := NewDoHClient("test-doh", "https://example.com/dns-query", DoHClientOptions{IdleTimeout: -1 * time.Second})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "idle-timeout must not be negative")
+}
+
+func TestReadBoundedBody(t *testing.T) {
+	t.Run("under limit", func(t *testing.T) {
+		b, err := readBoundedBody(strings.NewReader("hello"), 10)
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello"), b)
+	})
+	t.Run("at limit", func(t *testing.T) {
+		b, err := readBoundedBody(strings.NewReader(strings.Repeat("x", 10)), 10)
+		require.NoError(t, err)
+		require.Len(t, b, 10)
+	})
+	t.Run("over limit", func(t *testing.T) {
+		_, err := readBoundedBody(strings.NewReader(strings.Repeat("x", 11)), 10)
+		require.ErrorIs(t, err, errResponseTooLarge)
+	})
+}
+
+// TestDoHClientResponseSizeLimit verifies that the DoH client bounds the upstream
+// response body before parsing, so a malicious upstream returning an oversized
+// body is rejected cleanly rather than buffered in full. See issue #555.
+func TestDoHClientResponseSizeLimit(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("healthy.test.", dns.TypeA)
+
+	healthy := new(dns.Msg)
+	healthy.SetReply(q)
+	rr, err := dns.NewRR("healthy.test. 3600 IN A 6.6.6.6")
+	require.NoError(t, err)
+	healthy.Answer = []dns.RR{rr}
+	healthyWire, err := healthy.Pack()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		body    []byte
+		wantErr error // when set, Resolve must return an error matching it
+		wantOK  bool  // when true, Resolve must succeed with an answer
+	}{
+		{name: "healthy", body: healthyWire, wantOK: true},
+		{name: "oversized", body: make([]byte, maxDoHResponseSize+1024), wantErr: errResponseTooLarge},
+		{name: "not a dns message", body: []byte("definitely not a valid DNS wire message")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("content-type", "application/dns-message")
+				_, _ = w.Write(tc.body)
+			}))
+			defer srv.Close()
+
+			d, err := NewDoHClient("test-doh-limit", srv.URL+"/dns-query", DoHClientOptions{Method: "POST"})
+			require.NoError(t, err)
+
+			a, err := d.Resolve(q, ClientInfo{})
+			switch {
+			case tc.wantOK:
+				require.NoError(t, err)
+				require.NotEmpty(t, a.Answer)
+			case tc.wantErr != nil:
+				require.ErrorIs(t, err, tc.wantErr)
+				// The oversized rejection must be reflected in the metrics.
+				v := d.metrics.err.Get("toolarge")
+				require.NotNil(t, v)
+				require.Equal(t, int64(1), v.(*expvar.Int).Value())
+			default:
+				require.Error(t, err)
+			}
+		})
+	}
 }

--- a/odohclient.go
+++ b/odohclient.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -109,9 +108,13 @@ func (d *ODoHClient) decodeProxyResponse(resp *http.Response, queryContext odoh.
 	if resp.Header.Get("content-type") != ODOH_CONTENT_TYPE {
 		return nil, errors.New("received invalid odoh header from proxy")
 	}
-	rb, err := io.ReadAll(resp.Body)
+	rb, err := readBoundedBody(resp.Body, maxDoHResponseSize)
 	if err != nil {
-		d.proxy.metrics.err.Add("read", 1)
+		if errors.Is(err, errResponseTooLarge) {
+			d.proxy.metrics.err.Add("toolarge", 1)
+		} else {
+			d.proxy.metrics.err.Add("read", 1)
+		}
 		return nil, err
 	}
 	odohQueryResponse, err := odoh.UnmarshalDNSMessage(rb)
@@ -193,7 +196,7 @@ func (d *ODoHClient) refreshTargetKey() (*odoh.ObliviousDoHConfig, time.Time, er
 	if err != nil {
 		return nil, time.Time{}, err
 	}
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := readBoundedBody(resp.Body, maxDoHResponseSize)
 	if err != nil {
 		return nil, time.Time{}, err
 	}


### PR DESCRIPTION
## Summary

Fixes #555. The DoH and ODoH clients read the entire upstream HTTP response body with `io.ReadAll` before attempting to parse it as a DNS message. Because the response body is controlled by the upstream, a malicious or compromised upstream can return an oversized body that RouteDNS buffers in full before any validation.

This bounds the read to a DNS-appropriate maximum, rejecting larger bodies with a clear error instead of buffering them.

## Changes

- Add a shared `readBoundedBody` helper and `maxDoHResponseSize` constant (`65535 + 512`). A DNS message can't exceed 65535 bytes (the 16-bit length prefix used over TCP); the slack covers ODoH AEAD/encoding overhead, so the cap never rejects a legitimate response.
- Replace the unbounded `io.ReadAll` calls in:
  - `DoHClient.responseFromHTTP` — covers **both** the TCP and QUIC (DoH3) transports, which share this path.
  - `ODoHClient.decodeProxyResponse` and `ODoHClient.refreshTargetKey`.
- Oversized responses are counted under a new `toolarge` error metric.

## Notes

The issue also suggested checking `Content-Length` up front. I left that out deliberately: a malicious upstream can lie about or omit `Content-Length`, so the bounded read is the actual protection and makes the header check redundant for security. The bounded reader reads at most `limit+1` bytes and aborts, so it never accumulates more than ~64 KB regardless of what the upstream claims.

## Tests

- `TestReadBoundedBody` — under/at/over the limit.
- `TestDoHClientResponseSizeLimit` — table-driven against an `httptest` server covering a healthy DNS response, an oversized body (rejected with `errResponseTooLarge` + `toolarge` metric), and a non-DNS body.

All pass under `-race`.