### PR TITLE
doh: bound POST request body in the DoH listener (#556)

### DIFF
--- a/dohlistener.go
+++ b/dohlistener.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/base64"
+	"errors"
 	"expvar"
 	"fmt"
 	"io"
@@ -21,6 +22,12 @@ import (
 
 // Read/Write timeout in the DoH server
 const dohServerTimeout = 10 * time.Second
+
+// maxDoHRequestSize is the largest POST request body the DoH server will buffer.
+// A DNS message can't exceed 65535 bytes (the 16-bit length used over TCP), so
+// this never rejects a legitimate query while preventing a client from driving
+// the server into memory exhaustion with an oversized or slow-streamed body.
+const maxDoHRequestSize = 65535
 
 // DoHListener is a DNS listener/server for DNS-over-HTTPS.
 type DoHListener struct {
@@ -210,8 +217,18 @@ func (s *DoHListener) getHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *DoHListener) postHandler(w http.ResponseWriter, r *http.Request) {
-	b, err := io.ReadAll(r.Body)
+	// Bound the request body so a client can't force the server to buffer an
+	// arbitrarily large (or slowly streamed) POST body into memory before any
+	// DNS-level validation. This protects both the TCP and QUIC transports,
+	// which share this handler.
+	b, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxDoHRequestSize))
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			s.metrics.err.Add("toolarge", 1)
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/dohlistener_test.go
+++ b/dohlistener_test.go
@@ -1,8 +1,11 @@
 package rdns
 
 import (
+	"bytes"
+	"expvar"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -277,4 +280,44 @@ func TestIPv6Proxy(t *testing.T) {
 	r.Header.Add("X-Forwarded-For", "10.0.1.5")
 	client = s.extractClientAddress(r)
 	require.Equal(t, net.IPv4(10, 0, 1, 5), client)
+}
+
+// TestDoHListenerPostBodySizeLimit verifies the DoH POST handler bounds the
+// request body, so a client can't drive the server into memory exhaustion with
+// an oversized body. Healthy queries are still accepted. See issue #556.
+func TestDoHListenerPostBodySizeLimit(t *testing.T) {
+	upstream := new(TestResolver)
+	s, err := NewDoHListener("test-doh-bodylimit", "127.0.0.1:0", DoHListenerOptions{NoTLS: true}, upstream)
+	require.NoError(t, err)
+
+	// A valid, small DNS query must be accepted and forwarded to the resolver.
+	t.Run("healthy", func(t *testing.T) {
+		q := new(dns.Msg)
+		q.SetQuestion("example.com.", dns.TypeA)
+		packed, err := q.Pack()
+		require.NoError(t, err)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/dns-query", bytes.NewReader(packed))
+		req.RemoteAddr = "10.0.0.1:1234"
+		s.postHandler(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, 1, upstream.HitCount())
+	})
+
+	// An oversized body must be rejected with 413 and never reach the resolver.
+	t.Run("oversized", func(t *testing.T) {
+		before := upstream.HitCount()
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/dns-query", bytes.NewReader(make([]byte, maxDoHRequestSize+1024)))
+		req.RemoteAddr = "10.0.0.1:1234"
+		s.postHandler(rec, req)
+
+		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+		require.Equal(t, before, upstream.HitCount()) // resolver must not be hit
+		v := s.metrics.err.Get("toolarge")
+		require.NotNil(t, v)
+		require.Equal(t, int64(1), v.(*expvar.Int).Value())
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #556. The DoH listener's POST handler reads the entire request body with `io.ReadAll` and no size limit before any DNS-level validation (`dohlistener.go:213`). Because the body is supplied by an unauthenticated client, a remote client can drive the server into memory exhaustion by streaming an oversized body — the reporter confirmed an OOM-kill (`ExitCode 137`) of the process.

This bounds the request body to the maximum size a DNS message can have.

## Changes

- Wrap `r.Body` with `http.MaxBytesReader` bounded to `maxDoHRequestSize` (`65535`, the maximum DNS message size given the 16-bit length prefix used over TCP). A legitimate query can never exceed this, so nothing valid is rejected.
- Oversized bodies are rejected with `413 Request Entity Too Large` and counted under a new `toolarge` error metric, before the resolver is reached.
- `postHandler` is shared by the TCP and QUIC (DoH3) transports, so this covers both.

## Scope / notes

This addresses the **listener** (downstream client → RouteDNS) side. It is independent of the upstream-client fix in #557 (RouteDNS → upstream, issue #555); the two share no code.

The issue also suggested an HTTP/3 request-body **deadline** for the slow-drip case (suggested-fix item 3). I left that out: `http3.Server` has no direct `ReadTimeout` equivalent to the TCP path, and the reporter could not reproduce an outage from the slow-body test. Bounding the body size is what addresses the confirmed memory-exhaustion DoS. A request-body deadline can be a separate follow-up if desired.

## Tests

`TestDoHListenerPostBodySizeLimit`:
- **healthy** — a valid small DNS query is accepted (`200`) and forwarded to the resolver.
- **oversized** — a body over the cap is rejected with `413`, the resolver is never hit, and the `toolarge` metric increments.

Passes under `-race`; `go vet ./...` clean.