### PR TITLE
Add xsocket support for network namespaces without CAP_SYS_ADMIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Listeners receive queries over any supported protocol. Routers, groups and modif
 - Bootstrap addresses to avoid initial service name lookups
 
 **Deployment**
-- Linux network namespace support — listen in one netns, resolve in another
+- Linux network namespace support — listen in one netns, resolve in another, via `setns` or [xsocket](https://github.com/koro666/xsocket) (no `CAP_SYS_ADMIN` required)
 - Firewall mark (fwmark) and interface binding (SO_BINDTODEVICE) for policy routing and VRF
 - Admin listener with expvar metrics (Prometheus-compatible)
 - Query/response logging, syslog integration

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -36,6 +36,7 @@ type listener struct {
 	OdohMode      string   `toml:"odoh-mode"` // ODoH mode - accepts "proxy", "target" or "dual", default is target mode
 	AllowDoH      bool     `toml:"allow-doh"` // Allow ODoH listeners to also handle DoH queries to /dns-query
 	NetNS         string   `toml:"netns"`     // Linux network namespace name or absolute path
+	XSocket       string   `toml:"xsocket"`   // xsocket-server Unix socket path; alternative to netns that avoids CAP_SYS_ADMIN
 	FWMark        uint32   `toml:"fwmark"`    // Linux firewall mark (SO_MARK) for the listening socket
 	BindInterface string   `toml:"bind-if"`   // Linux network interface to bind the socket to (SO_BINDTODEVICE)
 	Frontend      dohFrontend
@@ -62,6 +63,7 @@ type resolver struct {
 	EDNS0UDPSize  uint16 `toml:"edns0-udp-size"` // UDP resolver option
 	QueryTimeout  int    `toml:"query-timeout"`  // Query timeout in seconds
 	NetNS         string `toml:"netns"`          // Linux network namespace name or absolute path
+	XSocket       string `toml:"xsocket"`        // xsocket-server Unix socket path; alternative to netns that avoids CAP_SYS_ADMIN
 	FWMark        uint32 `toml:"fwmark"`         // Linux firewall mark (SO_MARK) for outbound connections
 	BindInterface string `toml:"bind-if"`        // Linux network interface to bind outbound connections to (SO_BINDTODEVICE)
 

--- a/cmd/routedns/example-config/xsocket.toml
+++ b/cmd/routedns/example-config/xsocket.toml
@@ -1,0 +1,41 @@
+# Example demonstrating xsocket support. xsocket is an alternative to the
+# "netns" option that lets RouteDNS create listening and outbound sockets inside
+# a Linux network namespace WITHOUT requiring CAP_SYS_ADMIN. A small privileged
+# "xsocket-server" (https://github.com/koro666/xsocket) runs inside the target
+# namespace, listening on a Unix socket; it hands RouteDNS sockets created in
+# that namespace via SCM_RIGHTS, and RouteDNS binds/connects them itself.
+#
+# Setup:
+#   sudo ip netns add ns1
+#   sudo ip netns add ns2
+#   # Run an xsocket-server in each namespace, listening on a Unix socket.
+#   # (Abstract sockets, prefixed with '@', avoid filesystem permissions.)
+#   sudo ip netns exec ns1 xsocket-server /var/tmp/xsocket/ns1 &
+#   sudo ip netns exec ns2 xsocket-server /var/tmp/xsocket/ns2 &
+#
+# Notes:
+#   - "xsocket" and "netns" are mutually exclusive on a component.
+#   - Upstream hostnames are resolved in RouteDNS's own namespace, so prefer
+#     giving resolver addresses as IPs.
+#   - "fwmark"/"bind-if" still require CAP_NET_ADMIN/CAP_NET_RAW in the RouteDNS
+#     process even with xsocket.
+#   - Not supported for DTLS or SOCKS5-proxied resolvers.
+#   - Linux only.
+
+[resolvers.res]
+address = "9.9.9.9:53"
+protocol = "udp"
+query-timeout = 10
+xsocket = "/var/tmp/xsocket/ns1"
+
+[listeners.local-udp]
+address = "[::]:1053"
+protocol = "udp"
+resolver = "res"
+xsocket = "/var/tmp/xsocket/ns2"
+
+[listeners.local-tcp]
+address = "[::]:1053"
+protocol = "tcp"
+resolver = "res"
+xsocket = "/var/tmp/xsocket/ns2"

--- a/cmd/routedns/example-config/xsocket.toml
+++ b/cmd/routedns/example-config/xsocket.toml
@@ -1,20 +1,26 @@
 # Example demonstrating xsocket support. xsocket is an alternative to the
 # "netns" option that lets RouteDNS create listening and outbound sockets inside
-# a Linux network namespace WITHOUT requiring CAP_SYS_ADMIN. A small privileged
+# a Linux network namespace WITHOUT requiring CAP_SYS_ADMIN. A small
 # "xsocket-server" (https://github.com/koro666/xsocket) runs inside the target
 # namespace, listening on a Unix socket; it hands RouteDNS sockets created in
 # that namespace via SCM_RIGHTS, and RouteDNS binds/connects them itself.
+# RouteDNS needs no elevated privileges; the xsocket-server can also run as an
+# unprivileged user once it's placed in the namespace (it only needs privilege
+# to apply socket options like fwmark itself).
 #
 # Setup:
 #   sudo ip netns add ns1
 #   sudo ip netns add ns2
 #   # Run an xsocket-server in each namespace, listening on a Unix socket.
-#   # (Abstract sockets, prefixed with '@', avoid filesystem permissions.)
 #   sudo ip netns exec ns1 xsocket-server /var/tmp/xsocket/ns1 &
 #   sudo ip netns exec ns2 xsocket-server /var/tmp/xsocket/ns2 &
 #
 # Notes:
 #   - "xsocket" and "netns" are mutually exclusive on a component.
+#   - Security: access to the xsocket-server's Unix socket grants sockets in its
+#     namespace, so restrict it with filesystem permissions/ownership/ACLs.
+#     Abstract sockets ('@name') can't be permission-controlled (any process in
+#     the namespace can reach them) - prefer a pathname socket when that matters.
 #   - Upstream hostnames are resolved in RouteDNS's own namespace, so prefer
 #     giving resolver addresses as IPs.
 #   - "fwmark"/"bind-if" still require CAP_NET_ADMIN/CAP_NET_RAW in the RouteDNS

--- a/cmd/routedns/example-config/xsocket.toml
+++ b/cmd/routedns/example-config/xsocket.toml
@@ -19,7 +19,8 @@
 #     giving resolver addresses as IPs.
 #   - "fwmark"/"bind-if" still require CAP_NET_ADMIN/CAP_NET_RAW in the RouteDNS
 #     process even with xsocket.
-#   - Not supported for DTLS or SOCKS5-proxied resolvers.
+#   - For SOCKS5-proxied resolvers, xsocket controls the connection to the
+#     proxy (the proxy is reached from inside the target namespace).
 #   - Linux only.
 
 [resolvers.res]

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -225,9 +225,9 @@ func start(opt options, args []string) error {
 			return errors.New("ip-version must be 4 or 6")
 		}
 
-		var netns *rdns.NetNS
-		if l.NetNS != "" {
-			netns = &rdns.NetNS{Name: l.NetNS}
+		netns, err := buildNetNS(l.NetNS, l.XSocket)
+		if err != nil {
+			return fmt.Errorf("listener '%s': %w", id, err)
 		}
 
 		opt := rdns.ListenOptions{
@@ -1245,6 +1245,19 @@ func stopNetNSListener(id string, ln rdns.Listener, startErr <-chan error) {
 			}
 		}
 	}
+}
+
+// buildNetNS constructs the namespace target for a listener or resolver from the
+// netns and xsocket options. The two are mutually exclusive; nil is returned
+// when neither is configured.
+func buildNetNS(name, xsocket string) (*rdns.NetNS, error) {
+	if name != "" && xsocket != "" {
+		return nil, errors.New("'netns' and 'xsocket' are mutually exclusive")
+	}
+	if name == "" && xsocket == "" {
+		return nil, nil
+	}
+	return &rdns.NetNS{Name: name, XSocket: xsocket}, nil
 }
 
 func printVersion() {

--- a/cmd/routedns/netns_test.go
+++ b/cmd/routedns/netns_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+func TestBuildNetNS(t *testing.T) {
+	t.Run("neither", func(t *testing.T) {
+		ns, err := buildNetNS("", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ns != nil {
+			t.Fatalf("expected nil, got %+v", ns)
+		}
+	})
+
+	t.Run("netns only", func(t *testing.T) {
+		ns, err := buildNetNS("container", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ns == nil || ns.Name != "container" || ns.XSocket != "" {
+			t.Fatalf("unexpected result: %+v", ns)
+		}
+	})
+
+	t.Run("xsocket only", func(t *testing.T) {
+		ns, err := buildNetNS("", "/run/xsocket/ns1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ns == nil || ns.XSocket != "/run/xsocket/ns1" || ns.Name != "" {
+			t.Fatalf("unexpected result: %+v", ns)
+		}
+	})
+
+	t.Run("both is an error", func(t *testing.T) {
+		if _, err := buildNetNS("container", "/run/xsocket/ns1"); err == nil {
+			t.Fatal("expected an error when both netns and xsocket are set")
+		}
+	})
+}

--- a/cmd/routedns/resolver.go
+++ b/cmd/routedns/resolver.go
@@ -12,9 +12,9 @@ import (
 func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolver) error {
 	var err error
 
-	var netns *rdns.NetNS
-	if r.NetNS != "" {
-		netns = &rdns.NetNS{Name: r.NetNS}
+	netns, err := buildNetNS(r.NetNS, r.XSocket)
+	if err != nil {
+		return fmt.Errorf("resolver '%s': %w", id, err)
 	}
 
 	sockOpts := rdns.SocketOptions{

--- a/cmd/routedns/resolver.go
+++ b/cmd/routedns/resolver.go
@@ -60,7 +60,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			LocalAddrV6:   net.ParseIP(r.LocalAddrV6),
 			TLSConfig:     tlsConfig,
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
-			Dialer:        socks5DialerFromConfig(r),
+			Dialer:        socks5DialerFromConfig(r, netns, sockOpts),
 			NetNS:         netns,
 			SocketOptions: sockOpts,
 		}
@@ -107,7 +107,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			LocalAddrV6:   net.ParseIP(r.LocalAddrV6),
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
 			IdleTimeout:   time.Duration(r.DoH.IdleTimeout) * time.Second,
-			Dialer:        socks5DialerFromConfig(r),
+			Dialer:        socks5DialerFromConfig(r, netns, sockOpts),
 			Use0RTT:       r.Use0RTT,
 			NetNS:         netns,
 			SocketOptions: sockOpts,
@@ -147,7 +147,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			LocalAddrV6:   net.ParseIP(r.LocalAddrV6),
 			UDPSize:       r.EDNS0UDPSize,
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
-			Dialer:        socks5DialerFromConfig(r),
+			Dialer:        socks5DialerFromConfig(r, netns, sockOpts),
 			NetNS:         netns,
 			SocketOptions: sockOpts,
 		}
@@ -161,22 +161,25 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 	return nil
 }
 
-// Returns a dialer if a socks5 proxy is configured, nil otherwise
-func socks5DialerFromConfig(cfg resolver) rdns.Dialer {
+// Returns a dialer if a socks5 proxy is configured, nil otherwise. The netns
+// and socket options are used for the connection to the proxy itself.
+func socks5DialerFromConfig(cfg resolver, netns *rdns.NetNS, sockOpts rdns.SocketOptions) rdns.Dialer {
 	if cfg.Socks5Address == "" {
 		return nil
 	}
 	r := rdns.NewSocks5Dialer(
 		cfg.Socks5Address,
 		rdns.Socks5DialerOptions{
-			Username:     cfg.Socks5Username,
-			Password:     cfg.Socks5Password,
-			TCPTimeout:   0,
-			UDPTimeout:   5 * time.Second,
-			ResolveLocal: cfg.Socks5ResolveLocal,
-			LocalAddr:    net.ParseIP(cfg.LocalAddr),
-			LocalAddrV4:  net.ParseIP(cfg.LocalAddrV4),
-			LocalAddrV6:  net.ParseIP(cfg.LocalAddrV6),
+			Username:      cfg.Socks5Username,
+			Password:      cfg.Socks5Password,
+			TCPTimeout:    0,
+			UDPTimeout:    5 * time.Second,
+			ResolveLocal:  cfg.Socks5ResolveLocal,
+			LocalAddr:     net.ParseIP(cfg.LocalAddr),
+			LocalAddrV4:   net.ParseIP(cfg.LocalAddrV4),
+			LocalAddrV6:   net.ParseIP(cfg.LocalAddrV6),
+			NetNS:         netns,
+			SocketOptions: sockOpts,
 		})
 	return r
 }

--- a/dnsclient.go
+++ b/dnsclient.go
@@ -2,7 +2,6 @@ package rdns
 
 import (
 	"crypto/tls"
-	"errors"
 	"net"
 	"strings"
 	"time"
@@ -148,9 +147,13 @@ func (d GenericDNSClient) Dial(address string) (*dns.Conn, error) {
 		switch {
 		case d.NetNS.usesXSocket():
 			if d.Dialer != nil {
-				return nil, errors.New("xsocket is not supported with a custom dialer (e.g. SOCKS proxy)")
+				// A custom dialer (e.g. SOCKS5) reaches the proxy through the
+				// xsocket-server itself, applying socket options to that
+				// socket, so just use it directly.
+				conn.Conn, err = d.Dialer.Dial(network, address)
+			} else {
+				conn.Conn, err = dialXSocket(d.NetNS.XSocket, network, address, d.SocketOptions, localAddr, d.Timeout)
 			}
-			conn.Conn, err = dialXSocket(d.NetNS.XSocket, network, address, d.SocketOptions, localAddr, d.Timeout)
 		default:
 			if netDialer, ok := dialer.(*net.Dialer); ok {
 				conn.Conn, err = DialInNetNS(d.NetNS, network, address, netDialer)
@@ -174,8 +177,9 @@ func (d GenericDNSClient) Dial(address string) (*dns.Conn, error) {
 	// Custom dialers (e.g. SOCKS5) don't expose a Control callback,
 	// so we apply post-connect. SO_MARK still affects future packets
 	// on the socket; SO_BINDTODEVICE has no routing effect after
-	// connect but is applied for consistency.
-	if d.Dialer != nil {
+	// connect but is applied for consistency. The xsocket path is
+	// excluded: the dialer already applied options to the proxy socket.
+	if d.Dialer != nil && !d.NetNS.usesXSocket() {
 		if err := d.SocketOptions.applyToConn(conn.Conn); err != nil {
 			conn.Conn.Close()
 			return nil, err

--- a/dnsclient.go
+++ b/dnsclient.go
@@ -172,19 +172,10 @@ func (d GenericDNSClient) Dial(address string) (*dns.Conn, error) {
 		return nil, err
 	}
 
-	// Apply socket options to connections made by custom dialers.
-	// For net.Dialer, options were already applied via Control.
-	// Custom dialers (e.g. SOCKS5) don't expose a Control callback,
-	// so we apply post-connect. SO_MARK still affects future packets
-	// on the socket; SO_BINDTODEVICE has no routing effect after
-	// connect but is applied for consistency. The xsocket path is
-	// excluded: the dialer already applied options to the proxy socket.
-	if d.Dialer != nil && !d.NetNS.usesXSocket() {
-		if err := d.SocketOptions.applyToConn(conn.Conn); err != nil {
-			conn.Conn.Close()
-			return nil, err
-		}
-	}
+	// For net.Dialer, socket options were applied via Control. Custom dialers
+	// (e.g. SOCKS5) apply them when creating their own sockets; the returned
+	// conn doesn't expose the underlying descriptor, so they can't be applied
+	// here post-connect (nor would SO_BINDTODEVICE affect routing by then).
 
 	// Trick dns.Conn.ReadMsg() into thinking this is a packet connection (udp) so it
 	// correctly handles any length-prefixes

--- a/dnsclient.go
+++ b/dnsclient.go
@@ -2,6 +2,7 @@ package rdns
 
 import (
 	"crypto/tls"
+	"errors"
 	"net"
 	"strings"
 	"time"
@@ -118,12 +119,13 @@ func (d GenericDNSClient) Dial(address string) (*dns.Conn, error) {
 	network = strings.TrimSuffix(network, "-tls")
 
 	dialer := d.Dialer
+	var localAddr net.IP
 	if dialer == nil {
 		// Resolve hostname to IP so selectLocalAddr can determine the address
 		// family. Use the resolved address for the dial to avoid double resolution.
 		address = resolveEndpointAddr(address)
 		nd := &net.Dialer{Timeout: d.Timeout, Control: d.SocketOptions.dialerControl()}
-		localAddr := selectLocalAddr(address, d.LocalAddr, d.LocalAddrV4, d.LocalAddrV6)
+		localAddr = selectLocalAddr(address, d.LocalAddr, d.LocalAddrV4, d.LocalAddrV6)
 		if localAddr != nil {
 			switch network {
 			case "tcp":
@@ -142,15 +144,23 @@ func (d GenericDNSClient) Dial(address string) (*dns.Conn, error) {
 		err error
 	)
 	// Open a raw connection, optionally in a network namespace
-	if d.NetNS != nil && d.NetNS.Name != "" {
-		if netDialer, ok := dialer.(*net.Dialer); ok {
-			conn.Conn, err = DialInNetNS(d.NetNS, network, address, netDialer)
-		} else {
-			err = RunInNetNS(d.NetNS, func() error {
-				var e error
-				conn.Conn, e = dialer.Dial(network, address)
-				return e
-			})
+	if d.NetNS.isSet() {
+		switch {
+		case d.NetNS.usesXSocket():
+			if d.Dialer != nil {
+				return nil, errors.New("xsocket is not supported with a custom dialer (e.g. SOCKS proxy)")
+			}
+			conn.Conn, err = dialXSocket(d.NetNS.XSocket, network, address, d.SocketOptions, localAddr, d.Timeout)
+		default:
+			if netDialer, ok := dialer.(*net.Dialer); ok {
+				conn.Conn, err = DialInNetNS(d.NetNS, network, address, netDialer)
+			} else {
+				err = RunInNetNS(d.NetNS, func() error {
+					var e error
+					conn.Conn, e = dialer.Dial(network, address)
+					return e
+				})
+			}
 		}
 	} else {
 		conn.Conn, err = dialer.Dial(network, address)

--- a/dnslistener.go
+++ b/dnslistener.go
@@ -46,7 +46,7 @@ func NewDNSListener(id, addr, net string, opt ListenOptions, resolver Resolver) 
 // Start the DNS listener.
 func (s DNSListener) Start() error {
 	Log.Info("starting listener", "id", s.id, "protocol", s.Net, "addr", s.Addr)
-	if (s.opt.NetNS != nil && s.opt.NetNS.Name != "") || s.opt.SocketOptions.active() {
+	if s.opt.NetNS.isSet() || s.opt.SocketOptions.active() {
 		return s.startWithSocketSetup()
 	}
 	return s.ListenAndServe()

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -134,7 +134,7 @@ Common options for all listeners:
 - `resolver` - Name/identifier of the next element in the pipeline. Can be a router, group, modifier or resolver.
 - `allowed-net` - Array of network addresses that are allowed to send queries to this listener, in CIDR notation, such as `["192.167.1.0/24", "::1/128"]`. If not set, no filter is applied, all clients can send queries.
 - `netns` - Linux network namespace for the listening socket. Can be a name (looked up in `/var/run/netns/`) or an absolute path (e.g. `/proc/PID/ns/net`). Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
-- `xsocket` - Path to an `xsocket-server` Unix socket. The listening socket is created in that server's network namespace without requiring `CAP_SYS_ADMIN`. Mutually exclusive with `netns`. Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
+- `xsocket` - Path to an `xsocket-server` Unix socket. The listening socket is created in that server's network namespace without requiring `CAP_SYS_ADMIN`. Mutually exclusive with `netns`. Not supported for `dtls` listeners (use `netns` instead). Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
 - `fwmark` - Linux firewall mark (`SO_MARK`) to set on the listening socket. Used for netfilter matching and policy routing. Optional, Linux only, integer. See [Firewall Mark and Interface Binding](#firewall-mark-and-interface-binding).
 - `bind-if` - Bind the listening socket to a specific network interface (`SO_BINDTODEVICE`). Useful for VRFs or restricting a listener to one interface. Optional, Linux only. See [Firewall Mark and Interface Binding](#firewall-mark-and-interface-binding).
 
@@ -2301,7 +2301,7 @@ Notes and limitations:
 - Security boundary: anyone who can connect to the `xsocket-server`'s Unix socket can obtain sockets in its namespace. Access is controlled entirely by filesystem ownership, permissions and ACLs on the socket (and its parent directory) - set these up restrictively. Abstract sockets (`@name`) have no filesystem entry and so cannot be permission-controlled; they are reachable by any process in the server's network namespace. Prefer a pathname socket with restrictive permissions when access control matters.
 - Upstream resolver addresses are resolved in RouteDNS's own namespace; prefer giving them as IP addresses.
 - `fwmark` and `bind-if` still require `CAP_NET_ADMIN` / `CAP_NET_RAW` in the RouteDNS process even when used with `xsocket`.
-- Supported for `udp`, `tcp`, `dot`, `doh` (including DoH/3), `doq`, `dtls`, `admin` and `odoh`, on both listeners and resolvers.
+- Supported for `udp`, `tcp`, `dot`, `doh` (including DoH/3), `doq`, `admin` and `odoh`, on both listeners and resolvers. For `dtls` it is supported on resolvers only: the DTLS library opens the listening socket internally, leaving no descriptor to inject, so a DTLS listener with `xsocket` fails to start (use `netns` instead). The same limitation applies to `fwmark`/`bind-if` on DTLS listeners.
 - For SOCKS5-proxied resolvers, `xsocket` controls the connection to the proxy: RouteDNS asks the `xsocket-server` for the socket used to reach the proxy, so the proxy is contacted from inside the target namespace. The proxy's own outbound connections to the upstream resolver are made by the proxy and unaffected. Alternatively, run the SOCKS5 proxy inside the target namespace and reach it from RouteDNS's own namespace without `xsocket`.
 - Linux only.
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -2298,7 +2298,8 @@ Notes and limitations:
 - `xsocket` and `netns` are mutually exclusive on the same component.
 - Upstream resolver addresses are resolved in RouteDNS's own namespace; prefer giving them as IP addresses.
 - `fwmark` and `bind-if` still require `CAP_NET_ADMIN` / `CAP_NET_RAW` in the RouteDNS process even when used with `xsocket`.
-- Supported for `udp`, `tcp`, `dot`, `doh` (including DoH/3) and `doq`. Not supported for DTLS or SOCKS5-proxied resolvers (these create their own sockets internally) - configuring `xsocket` for them returns an error.
+- Supported for `udp`, `tcp`, `dot`, `doh` (including DoH/3), `doq`, `admin` and `odoh`, on both listeners and resolvers. Not supported for DTLS or SOCKS5-proxied resolvers (these create their own sockets internally) - configuring `xsocket` for them returns an error.
+- SOCKS5-proxied resolvers can't use `xsocket` because the SOCKS5 library opens its own connection to the proxy, leaving no descriptor for the `xsocket-server` to hand over. To combine the two, run the SOCKS5 proxy inside the target namespace instead: RouteDNS reaching the proxy from its own namespace is fine, since the proxy's outbound connections are already made in the right namespace.
 - Linux only.
 
 Example config files: [xsocket.toml](../cmd/routedns/example-config/xsocket.toml)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1972,7 +1972,7 @@ Resolvers are defined in the configuration like so `[resolvers.NAME]` and have t
 - `edns0-udp-size` - If set, modifies the EDNS0 UDP size option in all queries sent upstream. Only meaningful when using UDP or DTLS resolvers. Upstream resolvers may not respect this value and apply their own limits.
 - `query-timeout` - Sets the query timeout to allow. In seconds.
 - `netns` - Linux network namespace for outbound connections. Can be a name (looked up in `/var/run/netns/`) or an absolute path (e.g. `/proc/PID/ns/net`). Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
-- `xsocket` - Path to an `xsocket-server` Unix socket. Outbound connections are made through a socket created in that server's network namespace without requiring `CAP_SYS_ADMIN`. Mutually exclusive with `netns`. Not supported for SOCKS5-proxied resolvers. Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
+- `xsocket` - Path to an `xsocket-server` Unix socket. Outbound connections are made through a socket created in that server's network namespace without requiring `CAP_SYS_ADMIN`. Mutually exclusive with `netns`. For SOCKS5-proxied resolvers it is the connection to the proxy that is made in the target namespace. Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
 
 Secure resolvers such as DoT, DoH, or DoQ offer additional options to configure the TLS connections.
 
@@ -2298,8 +2298,8 @@ Notes and limitations:
 - `xsocket` and `netns` are mutually exclusive on the same component.
 - Upstream resolver addresses are resolved in RouteDNS's own namespace; prefer giving them as IP addresses.
 - `fwmark` and `bind-if` still require `CAP_NET_ADMIN` / `CAP_NET_RAW` in the RouteDNS process even when used with `xsocket`.
-- Supported for `udp`, `tcp`, `dot`, `doh` (including DoH/3), `doq`, `dtls`, `admin` and `odoh`, on both listeners and resolvers. Not supported for SOCKS5-proxied resolvers (the SOCKS5 library creates its own sockets internally) - configuring `xsocket` for them returns an error.
-- SOCKS5-proxied resolvers can't use `xsocket` because the SOCKS5 library opens its own connection to the proxy, leaving no descriptor for the `xsocket-server` to hand over. To combine the two, run the SOCKS5 proxy inside the target namespace instead: RouteDNS reaching the proxy from its own namespace is fine, since the proxy's outbound connections are already made in the right namespace.
+- Supported for `udp`, `tcp`, `dot`, `doh` (including DoH/3), `doq`, `dtls`, `admin` and `odoh`, on both listeners and resolvers.
+- For SOCKS5-proxied resolvers, `xsocket` controls the connection to the proxy: RouteDNS asks the `xsocket-server` for the socket used to reach the proxy, so the proxy is contacted from inside the target namespace. The proxy's own outbound connections to the upstream resolver are made by the proxy and unaffected. Alternatively, run the SOCKS5 proxy inside the target namespace and reach it from RouteDNS's own namespace without `xsocket`.
 - Linux only.
 
 Example config files: [xsocket.toml](../cmd/routedns/example-config/xsocket.toml)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -2314,7 +2314,7 @@ On Linux, listeners and resolvers support two socket-level options for advanced 
 - `fwmark` - Sets the `SO_MARK` socket option. The firewall mark is attached to all packets sent from the socket, allowing Linux netfilter (`iptables`/`nftables`) and policy routing (`ip rule`) to match and route them. The value is an integer and supports TOML hex notation (e.g. `0xb`).
 - `bind-if` - Sets the `SO_BINDTODEVICE` socket option. Binds the socket to a specific network interface so that traffic can only flow through that interface. This is useful with [VRFs](https://docs.kernel.org/networking/vrf.html) or as a safeguard against route leaks. On kernels >= 5.7, `SO_BINDTODEVICE` does not require root privileges.
 
-Both options can be used independently or together on any listener or resolver. On non-Linux platforms, configuring either option returns an error. DTLS listeners do not support these options (a warning is logged).
+Both options can be used independently or together on any listener or resolver. On non-Linux platforms, configuring either option returns an error. DTLS listeners do not support these options (a warning is logged). On a resolver with `socks5-address`, the options are applied to the sockets reaching the SOCKS5 proxy.
 
 **Resolver with fwmark and interface binding:**
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1972,7 +1972,7 @@ Resolvers are defined in the configuration like so `[resolvers.NAME]` and have t
 - `edns0-udp-size` - If set, modifies the EDNS0 UDP size option in all queries sent upstream. Only meaningful when using UDP or DTLS resolvers. Upstream resolvers may not respect this value and apply their own limits.
 - `query-timeout` - Sets the query timeout to allow. In seconds.
 - `netns` - Linux network namespace for outbound connections. Can be a name (looked up in `/var/run/netns/`) or an absolute path (e.g. `/proc/PID/ns/net`). Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
-- `xsocket` - Path to an `xsocket-server` Unix socket. Outbound connections are made through a socket created in that server's network namespace without requiring `CAP_SYS_ADMIN`. Mutually exclusive with `netns`. Not supported for DTLS or SOCKS5-proxied resolvers. Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
+- `xsocket` - Path to an `xsocket-server` Unix socket. Outbound connections are made through a socket created in that server's network namespace without requiring `CAP_SYS_ADMIN`. Mutually exclusive with `netns`. Not supported for SOCKS5-proxied resolvers. Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
 
 Secure resolvers such as DoT, DoH, or DoQ offer additional options to configure the TLS connections.
 
@@ -2298,7 +2298,7 @@ Notes and limitations:
 - `xsocket` and `netns` are mutually exclusive on the same component.
 - Upstream resolver addresses are resolved in RouteDNS's own namespace; prefer giving them as IP addresses.
 - `fwmark` and `bind-if` still require `CAP_NET_ADMIN` / `CAP_NET_RAW` in the RouteDNS process even when used with `xsocket`.
-- Supported for `udp`, `tcp`, `dot`, `doh` (including DoH/3), `doq`, `admin` and `odoh`, on both listeners and resolvers. Not supported for DTLS or SOCKS5-proxied resolvers (these create their own sockets internally) - configuring `xsocket` for them returns an error.
+- Supported for `udp`, `tcp`, `dot`, `doh` (including DoH/3), `doq`, `dtls`, `admin` and `odoh`, on both listeners and resolvers. Not supported for SOCKS5-proxied resolvers (the SOCKS5 library creates its own sockets internally) - configuring `xsocket` for them returns an error.
 - SOCKS5-proxied resolvers can't use `xsocket` because the SOCKS5 library opens its own connection to the proxy, leaving no descriptor for the `xsocket-server` to hand over. To combine the two, run the SOCKS5 proxy inside the target namespace instead: RouteDNS reaching the proxy from its own namespace is fine, since the proxy's outbound connections are already made in the right namespace.
 - Linux only.
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -2276,7 +2276,9 @@ Example config files: [netns.toml](../cmd/routedns/example-config/netns.toml)
 
 #### Without elevated privileges: xsocket
 
-The `netns` option uses `setns(2)`, which requires the RouteDNS process to hold `CAP_SYS_ADMIN`. The `xsocket` option is an alternative that avoids this. It relies on [xsocket](https://github.com/koro666/xsocket): a small privileged `xsocket-server` runs inside the target namespace and listens on a Unix socket. RouteDNS connects to that socket, asks the server to create a socket in its namespace, and receives the file descriptor back over the Unix socket (`SCM_RIGHTS`). RouteDNS then binds or connects that descriptor itself - so only the tiny `xsocket-server` needs privileges, not RouteDNS.
+The `netns` option uses `setns(2)`, which requires the RouteDNS process to hold `CAP_SYS_ADMIN`. The `xsocket` option is an alternative that avoids this. It relies on [xsocket](https://github.com/koro666/xsocket): a small `xsocket-server` runs inside the target namespace and listens on a Unix socket. RouteDNS connects to that socket, asks the server to create a socket in its namespace, and receives the file descriptor back over the Unix socket (`SCM_RIGHTS`). RouteDNS then binds or connects that descriptor itself - so RouteDNS itself needs no elevated privileges at all, while still listening in and connecting to any number of namespaces.
+
+Placing `xsocket-server` inside the target namespace usually requires privilege to set up (e.g. `ip netns exec`, which needs root), but the server process itself can drop to an unprivileged user once there: creating sockets and passing file descriptors needs no capabilities. It only needs to retain privileges - e.g. `CAP_NET_ADMIN`/`CAP_NET_RAW`, possibly via an `LD_PRELOAD` shim - if it must apply privileged socket options such as firewall marks (`fwmark`) itself.
 
 The `xsocket` value is the path to the server's Unix socket. A leading `@` denotes an abstract socket (no filesystem entry), e.g. `xsocket = "@xsocket-ns1"`.
 
@@ -2296,6 +2298,7 @@ xsocket = "/var/tmp/xsocket/ns2"
 Notes and limitations:
 
 - `xsocket` and `netns` are mutually exclusive on the same component.
+- Security boundary: anyone who can connect to the `xsocket-server`'s Unix socket can obtain sockets in its namespace. Access is controlled entirely by filesystem ownership, permissions and ACLs on the socket (and its parent directory) - set these up restrictively. Abstract sockets (`@name`) have no filesystem entry and so cannot be permission-controlled; they are reachable by any process in the server's network namespace. Prefer a pathname socket with restrictive permissions when access control matters.
 - Upstream resolver addresses are resolved in RouteDNS's own namespace; prefer giving them as IP addresses.
 - `fwmark` and `bind-if` still require `CAP_NET_ADMIN` / `CAP_NET_RAW` in the RouteDNS process even when used with `xsocket`.
 - Supported for `udp`, `tcp`, `dot`, `doh` (including DoH/3), `doq`, `dtls`, `admin` and `odoh`, on both listeners and resolvers.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -134,6 +134,7 @@ Common options for all listeners:
 - `resolver` - Name/identifier of the next element in the pipeline. Can be a router, group, modifier or resolver.
 - `allowed-net` - Array of network addresses that are allowed to send queries to this listener, in CIDR notation, such as `["192.167.1.0/24", "::1/128"]`. If not set, no filter is applied, all clients can send queries.
 - `netns` - Linux network namespace for the listening socket. Can be a name (looked up in `/var/run/netns/`) or an absolute path (e.g. `/proc/PID/ns/net`). Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
+- `xsocket` - Path to an `xsocket-server` Unix socket. The listening socket is created in that server's network namespace without requiring `CAP_SYS_ADMIN`. Mutually exclusive with `netns`. Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
 - `fwmark` - Linux firewall mark (`SO_MARK`) to set on the listening socket. Used for netfilter matching and policy routing. Optional, Linux only, integer. See [Firewall Mark and Interface Binding](#firewall-mark-and-interface-binding).
 - `bind-if` - Bind the listening socket to a specific network interface (`SO_BINDTODEVICE`). Useful for VRFs or restricting a listener to one interface. Optional, Linux only. See [Firewall Mark and Interface Binding](#firewall-mark-and-interface-binding).
 
@@ -1971,6 +1972,7 @@ Resolvers are defined in the configuration like so `[resolvers.NAME]` and have t
 - `edns0-udp-size` - If set, modifies the EDNS0 UDP size option in all queries sent upstream. Only meaningful when using UDP or DTLS resolvers. Upstream resolvers may not respect this value and apply their own limits.
 - `query-timeout` - Sets the query timeout to allow. In seconds.
 - `netns` - Linux network namespace for outbound connections. Can be a name (looked up in `/var/run/netns/`) or an absolute path (e.g. `/proc/PID/ns/net`). Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
+- `xsocket` - Path to an `xsocket-server` Unix socket. Outbound connections are made through a socket created in that server's network namespace without requiring `CAP_SYS_ADMIN`. Mutually exclusive with `netns`. Not supported for DTLS or SOCKS5-proxied resolvers. Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
 
 Secure resolvers such as DoT, DoH, or DoQ offer additional options to configure the TLS connections.
 
@@ -2271,6 +2273,35 @@ netns = "container"
 ```
 
 Example config files: [netns.toml](../cmd/routedns/example-config/netns.toml)
+
+#### Without elevated privileges: xsocket
+
+The `netns` option uses `setns(2)`, which requires the RouteDNS process to hold `CAP_SYS_ADMIN`. The `xsocket` option is an alternative that avoids this. It relies on [xsocket](https://github.com/koro666/xsocket): a small privileged `xsocket-server` runs inside the target namespace and listens on a Unix socket. RouteDNS connects to that socket, asks the server to create a socket in its namespace, and receives the file descriptor back over the Unix socket (`SCM_RIGHTS`). RouteDNS then binds or connects that descriptor itself - so only the tiny `xsocket-server` needs privileges, not RouteDNS.
+
+The `xsocket` value is the path to the server's Unix socket. A leading `@` denotes an abstract socket (no filesystem entry), e.g. `xsocket = "@xsocket-ns1"`.
+
+```toml
+[resolvers.res]
+address = "9.9.9.9:53"
+protocol = "udp"
+xsocket = "/var/tmp/xsocket/ns1"
+
+[listeners.local-udp]
+address = "[::]:1053"
+protocol = "udp"
+resolver = "res"
+xsocket = "/var/tmp/xsocket/ns2"
+```
+
+Notes and limitations:
+
+- `xsocket` and `netns` are mutually exclusive on the same component.
+- Upstream resolver addresses are resolved in RouteDNS's own namespace; prefer giving them as IP addresses.
+- `fwmark` and `bind-if` still require `CAP_NET_ADMIN` / `CAP_NET_RAW` in the RouteDNS process even when used with `xsocket`.
+- Supported for `udp`, `tcp`, `dot`, `doh` (including DoH/3) and `doq`. Not supported for DTLS or SOCKS5-proxied resolvers (these create their own sockets internally) - configuring `xsocket` for them returns an error.
+- Linux only.
+
+Example config files: [xsocket.toml](../cmd/routedns/example-config/xsocket.toml)
 
 ### Firewall Mark and Interface Binding
 

--- a/dohclient.go
+++ b/dohclient.go
@@ -307,7 +307,7 @@ func dohTcpTransport(opt DoHClientOptions) (http.RoundTripper, error) {
 	}
 
 	// Use a custom dialer if a bootstrap address, local address, proxy, netns, or socket options were provided
-	if opt.BootstrapAddr != "" || opt.LocalAddr != nil || opt.LocalAddrV4 != nil || opt.LocalAddrV6 != nil || opt.Dialer != nil || (opt.NetNS != nil && opt.NetNS.Name != "") || opt.SocketOptions.active() {
+	if opt.BootstrapAddr != "" || opt.LocalAddr != nil || opt.LocalAddrV4 != nil || opt.LocalAddrV6 != nil || opt.Dialer != nil || opt.NetNS.isSet() || opt.SocketOptions.active() {
 		tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 			if opt.BootstrapAddr != "" {
 				_, port, err := net.SplitHostPort(addr)
@@ -317,6 +317,9 @@ func dohTcpTransport(opt DoHClientOptions) (http.RoundTripper, error) {
 				addr = net.JoinHostPort(opt.BootstrapAddr, port)
 			}
 			if opt.Dialer != nil {
+				if opt.NetNS.usesXSocket() {
+					return nil, errors.New("xsocket is not supported with a SOCKS proxy")
+				}
 				var conn net.Conn
 				err := RunInNetNS(opt.NetNS, func() error {
 					var e error
@@ -334,6 +337,9 @@ func dohTcpTransport(opt DoHClientOptions) (http.RoundTripper, error) {
 			}
 			addr = resolveEndpointAddr(addr)
 			localAddr := selectLocalAddr(addr, opt.LocalAddr, opt.LocalAddrV4, opt.LocalAddrV6)
+			if opt.NetNS.usesXSocket() {
+				return dialXSocket(opt.NetNS.XSocket, network, addr, opt.SocketOptions, localAddr, 0)
+			}
 			d := net.Dialer{LocalAddr: &net.TCPAddr{IP: localAddr}, Control: opt.SocketOptions.dialerControl()}
 			var conn net.Conn
 			err := RunInNetNS(opt.NetNS, func() error {

--- a/dohclient.go
+++ b/dohclient.go
@@ -317,12 +317,14 @@ func dohTcpTransport(opt DoHClientOptions) (http.RoundTripper, error) {
 				addr = net.JoinHostPort(opt.BootstrapAddr, port)
 			}
 			if opt.Dialer != nil {
+				// The dialer (e.g. SOCKS5) creates the sockets reaching the
+				// proxy itself and applies socket options to them, whether via
+				// xsocket or not.
 				var conn net.Conn
 				var err error
 				if opt.NetNS.usesXSocket() {
-					// The dialer (e.g. SOCKS5) reaches the proxy through the
-					// xsocket-server itself, applying socket options to that
-					// socket, so use it directly without entering a namespace.
+					// The proxy is reached through the xsocket-server, so use
+					// the dialer directly without entering a namespace.
 					conn, err = opt.Dialer.Dial(network, addr)
 				} else {
 					err = RunInNetNS(opt.NetNS, func() error {
@@ -331,16 +333,7 @@ func dohTcpTransport(opt DoHClientOptions) (http.RoundTripper, error) {
 						return e
 					})
 				}
-				if err != nil {
-					return nil, err
-				}
-				if !opt.NetNS.usesXSocket() {
-					if err := opt.SocketOptions.applyToConn(conn); err != nil {
-						conn.Close()
-						return nil, err
-					}
-				}
-				return conn, nil
+				return conn, err
 			}
 			addr = resolveEndpointAddr(addr)
 			localAddr := selectLocalAddr(addr, opt.LocalAddr, opt.LocalAddrV4, opt.LocalAddrV6)

--- a/dohclient.go
+++ b/dohclient.go
@@ -317,21 +317,28 @@ func dohTcpTransport(opt DoHClientOptions) (http.RoundTripper, error) {
 				addr = net.JoinHostPort(opt.BootstrapAddr, port)
 			}
 			if opt.Dialer != nil {
-				if opt.NetNS.usesXSocket() {
-					return nil, errors.New("xsocket is not supported with a SOCKS proxy")
-				}
 				var conn net.Conn
-				err := RunInNetNS(opt.NetNS, func() error {
-					var e error
-					conn, e = opt.Dialer.Dial(network, addr)
-					return e
-				})
+				var err error
+				if opt.NetNS.usesXSocket() {
+					// The dialer (e.g. SOCKS5) reaches the proxy through the
+					// xsocket-server itself, applying socket options to that
+					// socket, so use it directly without entering a namespace.
+					conn, err = opt.Dialer.Dial(network, addr)
+				} else {
+					err = RunInNetNS(opt.NetNS, func() error {
+						var e error
+						conn, e = opt.Dialer.Dial(network, addr)
+						return e
+					})
+				}
 				if err != nil {
 					return nil, err
 				}
-				if err := opt.SocketOptions.applyToConn(conn); err != nil {
-					conn.Close()
-					return nil, err
+				if !opt.NetNS.usesXSocket() {
+					if err := opt.SocketOptions.applyToConn(conn); err != nil {
+						conn.Close()
+						return nil, err
+					}
 				}
 				return conn, nil
 			}

--- a/dotlistener.go
+++ b/dotlistener.go
@@ -51,7 +51,7 @@ func (s DoTListener) Start() error {
 		"id", s.id,
 		"protocol", "dot",
 		"addr", s.Addr)
-	if (s.opt.NetNS != nil && s.opt.NetNS.Name != "") || s.opt.SocketOptions.active() {
+	if s.opt.NetNS.isSet() || s.opt.SocketOptions.active() {
 		ln, err := ListenInNetNS(context.Background(), s.opt.NetNS, "tcp", s.Addr, s.opt.SocketOptions)
 		if err != nil {
 			return err

--- a/dtlsclient.go
+++ b/dtlsclient.go
@@ -139,6 +139,9 @@ type dtlsDialer struct {
 }
 
 func (d dtlsDialer) Dial(address string) (*dns.Conn, error) {
+	if d.netns.usesXSocket() {
+		return nil, fmt.Errorf("xsocket is not supported for DTLS clients")
+	}
 	var pConn net.PacketConn
 	err := RunInNetNS(d.netns, func() error {
 		laddr := ":0"

--- a/dtlsclient.go
+++ b/dtlsclient.go
@@ -139,23 +139,21 @@ type dtlsDialer struct {
 }
 
 func (d dtlsDialer) Dial(address string) (*dns.Conn, error) {
-	if d.netns.usesXSocket() {
-		return nil, fmt.Errorf("xsocket is not supported for DTLS clients")
+	// pion/dtls operates on a caller-supplied net.PacketConn, so socket options
+	// and the network namespace (including xsocket) are handled when we create
+	// the underlying UDP socket.
+	laddr := ":0"
+	if d.laddr != nil {
+		laddr = d.laddr.String()
 	}
-	var pConn net.PacketConn
-	err := RunInNetNS(d.netns, func() error {
-		laddr := ":0"
-		if d.laddr != nil {
-			laddr = d.laddr.String()
-		}
-		lc := net.ListenConfig{Control: d.socketOptions.dialerControl()}
-		var e error
-		pConn, e = lc.ListenPacket(context.Background(), "udp", laddr)
-		return e
-	})
+	pConn, err := ListenPacketInNetNS(context.Background(), d.netns, "udp", laddr, d.socketOptions)
 	if err != nil {
 		return nil, err
 	}
 	c, err := dtls.Client(pConn, d.raddr, d.dtlsConfig)
-	return &dns.Conn{Conn: &dtlsConn{Conn: c}}, err
+	if err != nil {
+		pConn.Close()
+		return nil, err
+	}
+	return &dns.Conn{Conn: &dtlsConn{Conn: c}}, nil
 }

--- a/dtlslistener.go
+++ b/dtlslistener.go
@@ -2,6 +2,7 @@ package rdns
 
 import (
 	"bytes"
+	"errors"
 	"net"
 	"strconv"
 
@@ -44,6 +45,9 @@ func NewDTLSListener(id, addr string, opt DTLSListenerOptions, resolver Resolver
 func (s *DTLSListener) Start() error {
 	Log.Info("starting listener", slog.Group("details", slog.String("id", s.id), slog.String("protocol", "dtls"), slog.String("addr", s.Addr)))
 
+	if s.opt.NetNS.usesXSocket() {
+		return errors.New("xsocket is not supported for DTLS listeners")
+	}
 	if s.opt.SocketOptions.active() {
 		Log.Warn("socket options (fwmark, bind-interface) are not supported for DTLS listeners", "id", s.id)
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/redis/go-redis/v9 v9.17.2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	github.com/txthinking/socks5 v0.0.0-20251011041537-5c31f201a10e
+	github.com/txthinking/socks5 v0.0.0-20260601051520-339b044ab0eb
 	github.com/yuin/gopher-lua v1.1.2-0.20241109074121-ccacf662c9d2
 	golang.org/x/net v0.48.0
 	golang.org/x/sys v0.39.0

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/txthinking/runnergroup v0.0.0-20210608031112-152c7c4432bf/go.mod h1:CLUSJbazqETbaR+i0YAhXBICV9TrKH93pziccMhmhpM=
 github.com/txthinking/runnergroup v0.0.0-20250224021307-5864ffeb65ae h1:ArVM1jICfm7g4E4dBet+KHUFMLuxmj1Nxdp/tr3ByCU=
 github.com/txthinking/runnergroup v0.0.0-20250224021307-5864ffeb65ae/go.mod h1:cldYm15/XHcGt7ndItnEWHwFZo7dinU+2QoyjfErhsI=
-github.com/txthinking/socks5 v0.0.0-20251011041537-5c31f201a10e h1:xA7GVlbz6teIF4FdvuqwbX6C4tiqNk2PH7FRPIDerao=
-github.com/txthinking/socks5 v0.0.0-20251011041537-5c31f201a10e/go.mod h1:ntmMHL/xPq1WLeKiw8p/eRATaae6PiVRNipHFJxI8PM=
+github.com/txthinking/socks5 v0.0.0-20260601051520-339b044ab0eb h1:cFSmrCbLJPb87QrwDhUTnguVLezlIqDiJuY8xKcFZnw=
+github.com/txthinking/socks5 v0.0.0-20260601051520-339b044ab0eb/go.mod h1:ntmMHL/xPq1WLeKiw8p/eRATaae6PiVRNipHFJxI8PM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/gopher-lua v1.1.2-0.20241109074121-ccacf662c9d2 h1:PF/PSu+RcSOzNpCqGo6KEO+4qw+LEiX/oqVxGm8rup8=
 github.com/yuin/gopher-lua v1.1.2-0.20241109074121-ccacf662c9d2/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -13,9 +13,26 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// NetNS represents a Linux network namespace.
+// NetNS represents a target Linux network namespace and how to reach it.
+//
+// Name selects the namespace via setns(2) (requires CAP_SYS_ADMIN). XSocket
+// instead points at the Unix socket of an xsocket-server running inside the
+// target namespace, which hands back sockets created in that namespace via
+// SCM_RIGHTS - avoiding the need for elevated privileges. The two are mutually
+// exclusive.
 type NetNS struct {
-	Name string
+	Name    string
+	XSocket string
+}
+
+// isSet reports whether a namespace target is configured (either mechanism).
+func (ns *NetNS) isSet() bool {
+	return ns != nil && (ns.Name != "" || ns.XSocket != "")
+}
+
+// usesXSocket reports whether sockets should be obtained from an xsocket-server.
+func (ns *NetNS) usesXSocket() bool {
+	return ns != nil && ns.XSocket != ""
 }
 
 // nsPath returns the filesystem path for this namespace.
@@ -32,6 +49,9 @@ func (ns *NetNS) nsPath() string {
 // has an empty Name, fn is executed in the current namespace (no-op).
 // The calling goroutine is locked to its OS thread for the duration.
 func RunInNetNS(ns *NetNS, fn func() error) error {
+	if ns.usesXSocket() {
+		return fmt.Errorf("xsocket is not supported for this operation; use setns-based netns instead")
+	}
 	if ns == nil || ns.Name == "" {
 		return fn()
 	}
@@ -68,6 +88,9 @@ func RunInNetNS(ns *NetNS, fn func() error) error {
 // Socket options (SO_MARK, SO_BINDTODEVICE) are applied before bind() via
 // net.ListenConfig.Control so that interface binding works correctly.
 func ListenInNetNS(ctx context.Context, ns *NetNS, network, address string, opts SocketOptions) (net.Listener, error) {
+	if ns.usesXSocket() {
+		return listenXSocket(ns.XSocket, network, address, opts)
+	}
 	var ln net.Listener
 	err := RunInNetNS(ns, func() error {
 		lc := net.ListenConfig{Control: opts.dialerControl()}
@@ -82,6 +105,9 @@ func ListenInNetNS(ctx context.Context, ns *NetNS, network, address string, opts
 // Socket options (SO_MARK, SO_BINDTODEVICE) are applied before bind() via
 // net.ListenConfig.Control so that interface binding works correctly.
 func ListenPacketInNetNS(ctx context.Context, ns *NetNS, network, address string, opts SocketOptions) (net.PacketConn, error) {
+	if ns.usesXSocket() {
+		return listenPacketXSocket(ns.XSocket, network, address, opts)
+	}
 	var pc net.PacketConn
 	err := RunInNetNS(ns, func() error {
 		lc := net.ListenConfig{Control: opts.dialerControl()}
@@ -96,6 +122,9 @@ func ListenPacketInNetNS(ctx context.Context, ns *NetNS, network, address string
 // Socket options (SO_MARK, SO_BINDTODEVICE) are applied before bind() via
 // net.ListenConfig.Control so that interface binding works correctly.
 func ListenUDPInNetNS(ctx context.Context, ns *NetNS, network string, laddr *net.UDPAddr, opts SocketOptions) (*net.UDPConn, error) {
+	if ns.usesXSocket() {
+		return listenUDPXSocket(ns.XSocket, network, laddr, opts)
+	}
 	var conn *net.UDPConn
 	err := RunInNetNS(ns, func() error {
 		lc := net.ListenConfig{Control: opts.dialerControl()}
@@ -116,6 +145,9 @@ func ListenUDPInNetNS(ctx context.Context, ns *NetNS, network string, laddr *net
 
 // DialInNetNS dials a connection in the given network namespace.
 func DialInNetNS(ns *NetNS, network, address string, dialer *net.Dialer) (net.Conn, error) {
+	if ns.usesXSocket() {
+		return nil, fmt.Errorf("xsocket dial must be handled by the caller, not DialInNetNS")
+	}
 	var conn net.Conn
 	err := RunInNetNS(ns, func() error {
 		var e error

--- a/netns_other.go
+++ b/netns_other.go
@@ -8,24 +8,35 @@ import (
 	"net"
 )
 
-// NetNS represents a Linux network namespace.
-// On non-Linux platforms, configuring a namespace returns an error.
+// NetNS represents a target Linux network namespace and how to reach it.
+// On non-Linux platforms, configuring a namespace (or xsocket) returns an error.
 type NetNS struct {
-	Name string
+	Name    string
+	XSocket string
+}
+
+// isSet reports whether a namespace target is configured (either mechanism).
+func (ns *NetNS) isSet() bool {
+	return ns != nil && (ns.Name != "" || ns.XSocket != "")
+}
+
+// usesXSocket reports whether sockets should be obtained from an xsocket-server.
+func (ns *NetNS) usesXSocket() bool {
+	return ns != nil && ns.XSocket != ""
 }
 
 // RunInNetNS executes fn in the given network namespace. On non-Linux
 // platforms this returns an error if a namespace is configured.
 func RunInNetNS(ns *NetNS, fn func() error) error {
-	if ns == nil || ns.Name == "" {
-		return fn()
+	if ns.isSet() {
+		return fmt.Errorf("network namespaces are only supported on Linux")
 	}
-	return fmt.Errorf("network namespaces are only supported on Linux")
+	return fn()
 }
 
 // ListenInNetNS creates a net.Listener in the given network namespace.
 func ListenInNetNS(ctx context.Context, ns *NetNS, network, address string, opts SocketOptions) (net.Listener, error) {
-	if ns != nil && ns.Name != "" {
+	if ns.isSet() {
 		return nil, fmt.Errorf("network namespaces are only supported on Linux")
 	}
 	lc := net.ListenConfig{Control: opts.dialerControl()}
@@ -34,7 +45,7 @@ func ListenInNetNS(ctx context.Context, ns *NetNS, network, address string, opts
 
 // ListenPacketInNetNS creates a net.PacketConn in the given network namespace.
 func ListenPacketInNetNS(ctx context.Context, ns *NetNS, network, address string, opts SocketOptions) (net.PacketConn, error) {
-	if ns != nil && ns.Name != "" {
+	if ns.isSet() {
 		return nil, fmt.Errorf("network namespaces are only supported on Linux")
 	}
 	lc := net.ListenConfig{Control: opts.dialerControl()}
@@ -43,7 +54,7 @@ func ListenPacketInNetNS(ctx context.Context, ns *NetNS, network, address string
 
 // ListenUDPInNetNS creates a *net.UDPConn in the given network namespace.
 func ListenUDPInNetNS(ctx context.Context, ns *NetNS, network string, laddr *net.UDPAddr, opts SocketOptions) (*net.UDPConn, error) {
-	if ns != nil && ns.Name != "" {
+	if ns.isSet() {
 		return nil, fmt.Errorf("network namespaces are only supported on Linux")
 	}
 	lc := net.ListenConfig{Control: opts.dialerControl()}
@@ -61,7 +72,7 @@ func ListenUDPInNetNS(ctx context.Context, ns *NetNS, network string, laddr *net
 
 // DialInNetNS dials a connection in the given network namespace.
 func DialInNetNS(ns *NetNS, network, address string, dialer *net.Dialer) (net.Conn, error) {
-	if ns != nil && ns.Name != "" {
+	if ns.isSet() {
 		return nil, fmt.Errorf("network namespaces are only supported on Linux")
 	}
 	return dialer.Dial(network, address)

--- a/odohlistener.go
+++ b/odohlistener.go
@@ -88,8 +88,9 @@ func NewODoHListener(id, addr string, opt ODoHListenerOptions, resolver Resolver
 	}
 
 	dohOpt := DoHListenerOptions{
-		TLSConfig: opt.TLSConfig,
-		customMux: mux,
+		TLSConfig:     opt.TLSConfig,
+		ListenOptions: opt.ListenOptions,
+		customMux:     mux,
 	}
 	dohListen, err := NewDoHListener(id, addr, dohOpt, resolver)
 	if err != nil {

--- a/sockopts_linux.go
+++ b/sockopts_linux.go
@@ -42,27 +42,3 @@ func (s SocketOptions) dialerControl() func(string, string, syscall.RawConn) err
 		return sockErr
 	}
 }
-
-// applyToConn applies socket options to an existing connection or listener.
-// The argument must implement syscall.Conn (e.g. *net.UDPConn, *net.TCPListener).
-func (s SocketOptions) applyToConn(conn any) error {
-	if !s.active() {
-		return nil
-	}
-	sc, ok := conn.(syscall.Conn)
-	if !ok {
-		return fmt.Errorf("cannot apply socket options: %T does not implement syscall.Conn", conn)
-	}
-	rawConn, err := sc.SyscallConn()
-	if err != nil {
-		return fmt.Errorf("failed to get raw connection: %w", err)
-	}
-	var sockErr error
-	err = rawConn.Control(func(fd uintptr) {
-		sockErr = s.applyToFd(fd)
-	})
-	if err != nil {
-		return err
-	}
-	return sockErr
-}

--- a/sockopts_other.go
+++ b/sockopts_other.go
@@ -15,10 +15,3 @@ func (s SocketOptions) dialerControl() func(string, string, syscall.RawConn) err
 		return fmt.Errorf("socket options (fwmark, bind-interface) are only supported on Linux")
 	}
 }
-
-func (s SocketOptions) applyToConn(conn any) error {
-	if !s.active() {
-		return nil
-	}
-	return fmt.Errorf("socket options (fwmark, bind-interface) are only supported on Linux")
-}

--- a/socks5.go
+++ b/socks5.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/txthinking/socks5"
@@ -47,21 +46,6 @@ type Socks5DialerOptions struct {
 
 var _ Dialer = (*Socks5Dialer)(nil)
 
-// The underlying socks5 package creates the sockets used to reach the proxy
-// itself, via the overridable package-level socks5.DialTCP/DialUDP hooks. To
-// reach a proxy through an xsocket-server (a network namespace we can't enter
-// with setns), those hooks must be swapped for xsocket-backed dialers for the
-// duration of the dial. Since the hooks are process-wide, all socks5 dials are
-// serialized through socks5DialMu while any xsocket-backed dialer exists, so a
-// swapped-in hook can never leak into an unrelated dial.
-var (
-	socks5XSocketActive atomic.Bool
-	socks5DialMu        sync.Mutex
-	socks5DefaultsOnce  sync.Once
-	socks5DefaultTCP    func(network, laddr, raddr string) (net.Conn, error)
-	socks5DefaultUDP    func(network, laddr, raddr string) (net.Conn, error)
-)
-
 func NewSocks5Dialer(addr string, opt Socks5DialerOptions) *Socks5Dialer {
 	client, _ := socks5.NewClient(
 		addr,
@@ -71,11 +55,19 @@ func NewSocks5Dialer(addr string, opt Socks5DialerOptions) *Socks5Dialer {
 		int(opt.UDPTimeout.Seconds()),
 	)
 	if opt.NetNS.usesXSocket() {
-		socks5DefaultsOnce.Do(func() {
-			socks5DefaultTCP = socks5.DialTCP
-			socks5DefaultUDP = socks5.DialUDP
-		})
-		socks5XSocketActive.Store(true)
+		// Reach the proxy through an xsocket-server (a network namespace we
+		// can't enter with setns) by overriding the client's socket creation.
+		// These per-client hooks avoid the process-wide effect of the
+		// package-level socks5.DialTCP/DialUDP variables. Socket options are
+		// applied to the proxy socket inside dialXSocket.
+		path := opt.NetNS.XSocket
+		sockOpts := opt.SocketOptions
+		client.DialTCP = func(network, laddr, raddr string) (net.Conn, error) {
+			return dialXSocket(path, network, raddr, sockOpts, socks5LocalIP(laddr), opt.TCPTimeout)
+		}
+		client.DialUDP = func(network, laddr, raddr string) (net.Conn, error) {
+			return dialXSocket(path, network, raddr, sockOpts, socks5LocalIP(laddr), opt.UDPTimeout)
+		}
 	}
 	return &Socks5Dialer{Client: client, opt: opt}
 }
@@ -122,49 +114,15 @@ func (d *Socks5Dialer) Dial(network string, address string) (net.Conn, error) {
 	})
 
 	localAddr := selectLocalAddr(d.addr, d.opt.LocalAddr, d.opt.LocalAddrV4, d.opt.LocalAddrV6)
-	dial := func() (net.Conn, error) {
-		if localAddr != nil {
-			// The socks5 library resolves the source address with
-			// net.ResolveTCPAddr, which requires a host:port. Bind the
-			// configured local IP with port 0 so the OS picks the source port;
-			// a bare IP would fail with "missing port in address".
-			src := net.JoinHostPort(localAddr.String(), "0")
-			return d.Client.DialWithLocalAddr(network, src, d.addr, nil)
-		}
-		return d.Client.Dial(network, d.addr)
+	if localAddr != nil {
+		// The socks5 library resolves the source address with
+		// net.ResolveTCPAddr, which requires a host:port. Bind the configured
+		// local IP with port 0 so the OS picks the source port; a bare IP would
+		// fail with "missing port in address".
+		src := net.JoinHostPort(localAddr.String(), "0")
+		return d.Client.DialWithLocalAddr(network, src, d.addr, nil)
 	}
-
-	// Fast path: no xsocket-backed proxy is configured anywhere, so the global
-	// dial hooks are never swapped and don't need to be guarded.
-	if !socks5XSocketActive.Load() {
-		return dial()
-	}
-
-	// Serialize against any concurrent dial that swaps the global hooks.
-	socks5DialMu.Lock()
-	defer socks5DialMu.Unlock()
-	if d.opt.NetNS.usesXSocket() {
-		tcp, udp := d.xsocketHooks()
-		socks5.DialTCP, socks5.DialUDP = tcp, udp
-		defer func() {
-			socks5.DialTCP, socks5.DialUDP = socks5DefaultTCP, socks5DefaultUDP
-		}()
-	}
-	return dial()
-}
-
-// xsocketHooks returns replacements for socks5.DialTCP/DialUDP that obtain the
-// socket reaching the proxy from this dialer's xsocket-server.
-func (d *Socks5Dialer) xsocketHooks() (tcp, udp func(network, laddr, raddr string) (net.Conn, error)) {
-	path := d.opt.NetNS.XSocket
-	opts := d.opt.SocketOptions
-	tcp = func(network, laddr, raddr string) (net.Conn, error) {
-		return dialXSocket(path, network, raddr, opts, socks5LocalIP(laddr), d.opt.TCPTimeout)
-	}
-	udp = func(network, laddr, raddr string) (net.Conn, error) {
-		return dialXSocket(path, network, raddr, opts, socks5LocalIP(laddr), d.opt.UDPTimeout)
-	}
-	return tcp, udp
+	return d.Client.Dial(network, d.addr)
 }
 
 // socks5LocalIP extracts a local bind IP from the address string the socks5

--- a/socks5.go
+++ b/socks5.go
@@ -3,6 +3,7 @@ package rdns
 import (
 	"context"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,7 +55,8 @@ func NewSocks5Dialer(addr string, opt Socks5DialerOptions) *Socks5Dialer {
 		int(opt.TCPTimeout.Seconds()),
 		int(opt.UDPTimeout.Seconds()),
 	)
-	if opt.NetNS.usesXSocket() {
+	switch {
+	case opt.NetNS.usesXSocket():
 		// Reach the proxy through an xsocket-server (a network namespace we
 		// can't enter with setns) by overriding the client's socket creation.
 		// These per-client hooks avoid the process-wide effect of the
@@ -68,8 +70,36 @@ func NewSocks5Dialer(addr string, opt Socks5DialerOptions) *Socks5Dialer {
 		client.DialUDP = func(network, laddr, raddr string) (net.Conn, error) {
 			return dialXSocket(path, network, raddr, sockOpts, socks5LocalIP(laddr), opt.UDPTimeout)
 		}
+	case opt.SocketOptions.active():
+		// Apply socket options (fwmark, bind-if) when creating the sockets
+		// reaching the proxy. They must be set before connect for
+		// SO_BINDTODEVICE to affect routing, and post-connect application
+		// isn't possible anyway: the socks5 client conn doesn't expose the
+		// underlying descriptor.
+		client.DialTCP = socks5SockOptsDialer(opt.SocketOptions, opt.TCPTimeout)
+		client.DialUDP = socks5SockOptsDialer(opt.SocketOptions, opt.UDPTimeout)
 	}
 	return &Socks5Dialer{Client: client, opt: opt}
+}
+
+// socks5SockOptsDialer returns a dial hook mirroring the socks5 package's
+// default dialers, but applying the socket options at socket creation.
+func socks5SockOptsDialer(sockOpts SocketOptions, timeout time.Duration) func(network, laddr, raddr string) (net.Conn, error) {
+	return func(network, laddr, raddr string) (net.Conn, error) {
+		nd := net.Dialer{Timeout: timeout, Control: sockOpts.dialerControl()}
+		if laddr != "" {
+			var err error
+			if strings.HasPrefix(network, "udp") {
+				nd.LocalAddr, err = net.ResolveUDPAddr(network, laddr)
+			} else {
+				nd.LocalAddr, err = net.ResolveTCPAddr(network, laddr)
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+		return nd.Dial(network, raddr)
+	}
 }
 
 func (d *Socks5Dialer) Dial(network string, address string) (net.Conn, error) {

--- a/socks5.go
+++ b/socks5.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/txthinking/socks5"
@@ -31,9 +32,35 @@ type Socks5DialerOptions struct {
 	// name will be resolved either on the local system, or via the bootstrap-resolver
 	// if one is setup.
 	ResolveLocal bool
+
+	// Linux network namespace for the connection to the SOCKS5 proxy. Only the
+	// xsocket mechanism is handled here; setns-based namespaces are entered by
+	// the caller (which wraps Dial in RunInNetNS). A nil or empty value reaches
+	// the proxy from the current namespace.
+	NetNS *NetNS
+
+	// Linux socket options (fwmark, interface binding) applied to the socket
+	// used to reach the proxy. Only honoured when dialing the proxy via xsocket;
+	// other paths apply them around Dial.
+	SocketOptions SocketOptions
 }
 
 var _ Dialer = (*Socks5Dialer)(nil)
+
+// The underlying socks5 package creates the sockets used to reach the proxy
+// itself, via the overridable package-level socks5.DialTCP/DialUDP hooks. To
+// reach a proxy through an xsocket-server (a network namespace we can't enter
+// with setns), those hooks must be swapped for xsocket-backed dialers for the
+// duration of the dial. Since the hooks are process-wide, all socks5 dials are
+// serialized through socks5DialMu while any xsocket-backed dialer exists, so a
+// swapped-in hook can never leak into an unrelated dial.
+var (
+	socks5XSocketActive atomic.Bool
+	socks5DialMu        sync.Mutex
+	socks5DefaultsOnce  sync.Once
+	socks5DefaultTCP    func(network, laddr, raddr string) (net.Conn, error)
+	socks5DefaultUDP    func(network, laddr, raddr string) (net.Conn, error)
+)
 
 func NewSocks5Dialer(addr string, opt Socks5DialerOptions) *Socks5Dialer {
 	client, _ := socks5.NewClient(
@@ -43,6 +70,13 @@ func NewSocks5Dialer(addr string, opt Socks5DialerOptions) *Socks5Dialer {
 		int(opt.TCPTimeout.Seconds()),
 		int(opt.UDPTimeout.Seconds()),
 	)
+	if opt.NetNS.usesXSocket() {
+		socks5DefaultsOnce.Do(func() {
+			socks5DefaultTCP = socks5.DialTCP
+			socks5DefaultUDP = socks5.DialUDP
+		})
+		socks5XSocketActive.Store(true)
+	}
 	return &Socks5Dialer{Client: client, opt: opt}
 }
 
@@ -88,13 +122,60 @@ func (d *Socks5Dialer) Dial(network string, address string) (net.Conn, error) {
 	})
 
 	localAddr := selectLocalAddr(d.addr, d.opt.LocalAddr, d.opt.LocalAddrV4, d.opt.LocalAddrV6)
-	if localAddr != nil {
-		// The socks5 library resolves the source address with
-		// net.ResolveTCPAddr, which requires a host:port. Bind the configured
-		// local IP with port 0 so the OS picks the source port; a bare IP would
-		// fail with "missing port in address".
-		src := net.JoinHostPort(localAddr.String(), "0")
-		return d.Client.DialWithLocalAddr(network, src, d.addr, nil)
+	dial := func() (net.Conn, error) {
+		if localAddr != nil {
+			// The socks5 library resolves the source address with
+			// net.ResolveTCPAddr, which requires a host:port. Bind the
+			// configured local IP with port 0 so the OS picks the source port;
+			// a bare IP would fail with "missing port in address".
+			src := net.JoinHostPort(localAddr.String(), "0")
+			return d.Client.DialWithLocalAddr(network, src, d.addr, nil)
+		}
+		return d.Client.Dial(network, d.addr)
 	}
-	return d.Client.Dial(network, d.addr)
+
+	// Fast path: no xsocket-backed proxy is configured anywhere, so the global
+	// dial hooks are never swapped and don't need to be guarded.
+	if !socks5XSocketActive.Load() {
+		return dial()
+	}
+
+	// Serialize against any concurrent dial that swaps the global hooks.
+	socks5DialMu.Lock()
+	defer socks5DialMu.Unlock()
+	if d.opt.NetNS.usesXSocket() {
+		tcp, udp := d.xsocketHooks()
+		socks5.DialTCP, socks5.DialUDP = tcp, udp
+		defer func() {
+			socks5.DialTCP, socks5.DialUDP = socks5DefaultTCP, socks5DefaultUDP
+		}()
+	}
+	return dial()
+}
+
+// xsocketHooks returns replacements for socks5.DialTCP/DialUDP that obtain the
+// socket reaching the proxy from this dialer's xsocket-server.
+func (d *Socks5Dialer) xsocketHooks() (tcp, udp func(network, laddr, raddr string) (net.Conn, error)) {
+	path := d.opt.NetNS.XSocket
+	opts := d.opt.SocketOptions
+	tcp = func(network, laddr, raddr string) (net.Conn, error) {
+		return dialXSocket(path, network, raddr, opts, socks5LocalIP(laddr), d.opt.TCPTimeout)
+	}
+	udp = func(network, laddr, raddr string) (net.Conn, error) {
+		return dialXSocket(path, network, raddr, opts, socks5LocalIP(laddr), d.opt.UDPTimeout)
+	}
+	return tcp, udp
+}
+
+// socks5LocalIP extracts a local bind IP from the address string the socks5
+// package passes to its dial hooks. It accepts "ip:port", a bare "ip", or an
+// empty string (no binding).
+func socks5LocalIP(laddr string) net.IP {
+	if laddr == "" {
+		return nil
+	}
+	if host, _, err := net.SplitHostPort(laddr); err == nil {
+		laddr = host
+	}
+	return net.ParseIP(laddr)
 }

--- a/socks5_test.go
+++ b/socks5_test.go
@@ -148,3 +148,27 @@ func TestSocks5DialerLocalAddr(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ping", string(buf))
 }
+
+func TestSocks5LocalIP(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string // "" means nil
+	}{
+		{"", ""},
+		{"1.2.3.4", "1.2.3.4"},
+		{"1.2.3.4:0", "1.2.3.4"},
+		{"1.2.3.4:5353", "1.2.3.4"},
+		{"[::1]:53", "::1"},
+		{"::1", "::1"},
+		{"bogus", ""},
+	}
+	for _, tc := range tests {
+		got := socks5LocalIP(tc.in)
+		if tc.want == "" {
+			assert.Nil(t, got, "socks5LocalIP(%q)", tc.in)
+			continue
+		}
+		require.NotNil(t, got, "socks5LocalIP(%q)", tc.in)
+		assert.True(t, got.Equal(net.ParseIP(tc.want)), "socks5LocalIP(%q) = %v, want %s", tc.in, got, tc.want)
+	}
+}

--- a/socks5_test.go
+++ b/socks5_test.go
@@ -149,6 +149,43 @@ func TestSocks5DialerLocalAddr(t *testing.T) {
 	assert.Equal(t, "ping", string(buf))
 }
 
+// TestSocks5SockOptsDialHooks verifies that socket options on a Socks5Dialer
+// install per-client dial hooks (applied at socket creation; the proxy conn
+// doesn't expose its descriptor for post-connect application), and that no
+// hooks are installed without them.
+func TestSocks5SockOptsDialHooks(t *testing.T) {
+	d := NewSocks5Dialer("127.0.0.1:1080", Socks5DialerOptions{})
+	assert.Nil(t, d.Client.DialTCP)
+	assert.Nil(t, d.Client.DialUDP)
+
+	d = NewSocks5Dialer("127.0.0.1:1080", Socks5DialerOptions{
+		SocketOptions: SocketOptions{FWMark: 1},
+	})
+	assert.NotNil(t, d.Client.DialTCP)
+	assert.NotNil(t, d.Client.DialUDP)
+}
+
+// TestSocks5SockOptsDialer exercises the dial hook itself, including local
+// address binding. Socket options requiring privileges (fwmark, bind-if) can't
+// be set in an unprivileged test, so this covers the dial/bind mechanics.
+func TestSocks5SockOptsDialer(t *testing.T) {
+	echo := startEchoTCPServer(t)
+	dial := socks5SockOptsDialer(SocketOptions{}, 2*time.Second)
+
+	for _, laddr := range []string{"", "127.0.0.1:0"} {
+		conn, err := dial("tcp", laddr, echo.Addr().String())
+		require.NoError(t, err, "laddr %q", laddr)
+		_, err = conn.Write([]byte("ping"))
+		require.NoError(t, err)
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+		buf := make([]byte, 4)
+		_, err = io.ReadFull(conn, buf)
+		require.NoError(t, err)
+		assert.Equal(t, "ping", string(buf))
+		conn.Close()
+	}
+}
+
 func TestSocks5LocalIP(t *testing.T) {
 	tests := []struct {
 		in   string

--- a/socks5_xsocket_linux_test.go
+++ b/socks5_xsocket_linux_test.go
@@ -1,0 +1,80 @@
+//go:build linux
+
+package rdns
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// startCountingXSocketServer is like startFakeXSocketServer but increments
+// *count for every fd request it serves, so a test can assert that a connection
+// was actually obtained via the xsocket-server rather than the default dialer.
+func startCountingXSocketServer(t *testing.T, count *int64) string {
+	t.Helper()
+	name := fmt.Sprintf("@rdns-socks5-xsocket-test-%d-%d", os.Getpid(), atomic.AddUint64(&xsocketTestSeq, 1))
+
+	lfd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
+	require.NoError(t, err, "server socket")
+	if err := unix.Bind(lfd, &unix.SockaddrUnix{Name: name}); err != nil {
+		unix.Close(lfd)
+		t.Fatalf("server bind: %v", err)
+	}
+	if err := unix.Listen(lfd, 16); err != nil {
+		unix.Close(lfd)
+		t.Fatalf("server listen: %v", err)
+	}
+	t.Cleanup(func() { unix.Close(lfd) })
+
+	go func() {
+		for {
+			cfd, _, err := unix.Accept(lfd)
+			if err != nil {
+				return
+			}
+			atomic.AddInt64(count, 1)
+			go serveFakeXSocket(cfd, 0)
+		}
+	}()
+	return name
+}
+
+// TestSocks5DialerXSocket verifies that a Socks5Dialer configured with an
+// xsocket-server reaches the proxy through that server (not the default dialer)
+// and still relays data end-to-end.
+func TestSocks5DialerXSocket(t *testing.T) {
+	echo := startEchoTCPServer(t)
+	proxyAddr := startMinimalSocks5Proxy(t)
+
+	var fdRequests int64
+	xsPath := startCountingXSocketServer(t, &fdRequests)
+
+	d := NewSocks5Dialer(proxyAddr, Socks5DialerOptions{
+		TCPTimeout: 2 * time.Second,
+		UDPTimeout: 2 * time.Second,
+		NetNS:      &NetNS{XSocket: xsPath},
+	})
+
+	conn, err := d.Dial("tcp", echo.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte("ping"))
+	require.NoError(t, err)
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	buf := make([]byte, 4)
+	_, err = io.ReadFull(conn, buf)
+	require.NoError(t, err)
+	assert.Equal(t, "ping", string(buf))
+
+	assert.NotZero(t, atomic.LoadInt64(&fdRequests),
+		"expected the proxy connection to be obtained via the xsocket-server")
+}

--- a/xsocket_linux.go
+++ b/xsocket_linux.go
@@ -1,0 +1,361 @@
+//go:build linux
+
+package rdns
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// xsocket protocol signatures, see https://github.com/koro666/xsocket. All
+// protocol fields are 32-bit and exchanged in network byte order over an
+// AF_UNIX/SOCK_SEQPACKET connection.
+const (
+	xsProtocolRequest  uint32 = 0x58533031 // "XS01"
+	xsProtocolResponse uint32 = 0x58533032 // "XS02"
+)
+
+// xsocketGetFd asks the xsocket-server listening on the given Unix socket path
+// to create a socket(domain, typ, proto) in its network namespace and return
+// the resulting (unbound) file descriptor via SCM_RIGHTS. The caller owns the
+// returned fd and is responsible for closing it. Abstract sockets are supported
+// by prefixing the path with '@'.
+func xsocketGetFd(path string, domain, typ, proto int) (int, error) {
+	cfd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return -1, os.NewSyscallError("socket", err)
+	}
+	defer unix.Close(cfd)
+
+	// SockaddrUnix translates a leading '@' into the NUL byte that denotes an
+	// abstract socket, so the path can be passed through unchanged.
+	if err := unix.Connect(cfd, &unix.SockaddrUnix{Name: path}); err != nil {
+		return -1, fmt.Errorf("connecting to xsocket-server %q: %w", path, err)
+	}
+
+	req := make([]byte, 16)
+	binary.BigEndian.PutUint32(req[0:], xsProtocolRequest)
+	binary.BigEndian.PutUint32(req[4:], uint32(domain))
+	binary.BigEndian.PutUint32(req[8:], uint32(typ))
+	binary.BigEndian.PutUint32(req[12:], uint32(proto))
+	if err := unix.Send(cfd, req, 0); err != nil {
+		return -1, os.NewSyscallError("send", err)
+	}
+	// Half-close the write side to signal the end of the request.
+	_ = unix.Shutdown(cfd, unix.SHUT_WR)
+
+	resp := make([]byte, 8)
+	oob := make([]byte, unix.CmsgSpace(4)) // room for a single fd
+	n, oobn, _, _, err := unix.Recvmsg(cfd, resp, oob, unix.MSG_CMSG_CLOEXEC)
+	if err != nil {
+		return -1, os.NewSyscallError("recvmsg", err)
+	}
+	if n < len(resp) {
+		return -1, fmt.Errorf("xsocket: short response (%d bytes)", n)
+	}
+	if sig := binary.BigEndian.Uint32(resp[0:]); sig != xsProtocolResponse {
+		return -1, fmt.Errorf("xsocket: invalid response signature %#x", sig)
+	}
+
+	// Always parse any descriptors that came back so we never leak one, even
+	// when the server also reported an error.
+	var fds []int
+	if scms, perr := unix.ParseSocketControlMessage(oob[:oobn]); perr == nil {
+		for i := range scms {
+			if rights, rerr := unix.ParseUnixRights(&scms[i]); rerr == nil {
+				fds = append(fds, rights...)
+			}
+		}
+	}
+	if errno := binary.BigEndian.Uint32(resp[4:]); errno != 0 {
+		for _, fd := range fds {
+			unix.Close(fd)
+		}
+		return -1, fmt.Errorf("xsocket-server returned error: %w", unix.Errno(errno))
+	}
+	if len(fds) == 0 {
+		return -1, fmt.Errorf("xsocket: no file descriptor in response")
+	}
+	// Defensive: close any unexpected extra descriptors.
+	for _, fd := range fds[1:] {
+		unix.Close(fd)
+	}
+	return fds[0], nil
+}
+
+// listenXSocket obtains a TCP socket from the xsocket-server, binds it to
+// address and starts listening, returning a net.Listener backed by that fd.
+func listenXSocket(path, network, address string, opts SocketOptions) (net.Listener, error) {
+	domain, sa, err := sockaddrFor(network, address)
+	if err != nil {
+		return nil, err
+	}
+	fd, err := xsocketGetFd(path, domain, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, err
+	}
+	if err := setupListenSocket(fd, domain, network, opts); err != nil {
+		unix.Close(fd)
+		return nil, err
+	}
+	if err := unix.Bind(fd, sa); err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("binding xsocket fd to %q: %w", address, err)
+	}
+	if err := unix.Listen(fd, unix.SOMAXCONN); err != nil {
+		unix.Close(fd)
+		return nil, os.NewSyscallError("listen", err)
+	}
+	f := os.NewFile(uintptr(fd), "xsocket:"+address)
+	ln, err := net.FileListener(f)
+	f.Close() // FileListener dups the fd; release our copy.
+	if err != nil {
+		return nil, err
+	}
+	return ln, nil
+}
+
+// listenPacketXSocket obtains a UDP socket from the xsocket-server, binds it to
+// address and returns a net.PacketConn backed by that fd.
+func listenPacketXSocket(path, network, address string, opts SocketOptions) (net.PacketConn, error) {
+	domain, sa, err := sockaddrFor(network, address)
+	if err != nil {
+		return nil, err
+	}
+	fd, err := xsocketGetFd(path, domain, unix.SOCK_DGRAM, 0)
+	if err != nil {
+		return nil, err
+	}
+	if err := setupListenSocket(fd, domain, network, opts); err != nil {
+		unix.Close(fd)
+		return nil, err
+	}
+	if err := unix.Bind(fd, sa); err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("binding xsocket fd to %q: %w", address, err)
+	}
+	f := os.NewFile(uintptr(fd), "xsocket:"+address)
+	pc, err := net.FilePacketConn(f)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	return pc, nil
+}
+
+// listenUDPXSocket is like listenPacketXSocket but returns the concrete
+// *net.UDPConn type used by the QUIC-based transports.
+func listenUDPXSocket(path, network string, laddr *net.UDPAddr, opts SocketOptions) (*net.UDPConn, error) {
+	address := ":0"
+	if laddr != nil {
+		address = laddr.String()
+	}
+	pc, err := listenPacketXSocket(path, network, address, opts)
+	if err != nil {
+		return nil, err
+	}
+	conn, ok := pc.(*net.UDPConn)
+	if !ok {
+		pc.Close()
+		return nil, fmt.Errorf("expected *net.UDPConn, got %T", pc)
+	}
+	return conn, nil
+}
+
+// dialXSocket obtains a socket from the xsocket-server and connects it to the
+// remote address, optionally binding to localAddr first. The connect honours
+// timeout (0 means no timeout).
+func dialXSocket(path, network, address string, opts SocketOptions, localAddr net.IP, timeout time.Duration) (net.Conn, error) {
+	domain, sa, err := sockaddrFor(network, address)
+	if err != nil {
+		return nil, err
+	}
+	var typ int
+	switch {
+	case strings.HasPrefix(network, "tcp"):
+		typ = unix.SOCK_STREAM
+	case strings.HasPrefix(network, "udp"):
+		typ = unix.SOCK_DGRAM
+	default:
+		return nil, fmt.Errorf("unsupported network %q for xsocket dial", network)
+	}
+	fd, err := xsocketGetFd(path, domain, typ, 0)
+	if err != nil {
+		return nil, err
+	}
+	if err := opts.applyToFd(uintptr(fd)); err != nil {
+		unix.Close(fd)
+		return nil, err
+	}
+	if localAddr != nil && !localAddr.IsUnspecified() {
+		_, lsa := sockaddrFromIP(localAddr, 0)
+		if err := unix.Bind(fd, lsa); err != nil {
+			unix.Close(fd)
+			return nil, fmt.Errorf("binding to local address %s: %w", localAddr, err)
+		}
+	}
+	if err := connectFd(fd, sa, timeout); err != nil {
+		unix.Close(fd)
+		return nil, err
+	}
+	f := os.NewFile(uintptr(fd), "xsocket:"+address)
+	conn, err := net.FileConn(f)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+// setupListenSocket applies socket options (before bind) and the defaults the
+// Go net package sets on listening sockets: SO_REUSEADDR, and for IPv6 sockets
+// the IPV6_V6ONLY flag matching the requested network family.
+func setupListenSocket(fd, domain int, network string, opts SocketOptions) error {
+	if err := opts.applyToFd(uintptr(fd)); err != nil {
+		return err
+	}
+	if err := unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); err != nil {
+		return os.NewSyscallError("setsockopt SO_REUSEADDR", err)
+	}
+	if domain == unix.AF_INET6 {
+		v6only := 0
+		if networkIPVersion(network) == 6 {
+			v6only = 1
+		}
+		if err := unix.SetsockoptInt(fd, unix.IPPROTO_IPV6, unix.IPV6_V6ONLY, v6only); err != nil {
+			return os.NewSyscallError("setsockopt IPV6_V6ONLY", err)
+		}
+	}
+	return nil
+}
+
+// connectFd performs a non-blocking connect honouring the given timeout.
+func connectFd(fd int, sa unix.Sockaddr, timeout time.Duration) error {
+	if err := unix.SetNonblock(fd, true); err != nil {
+		return os.NewSyscallError("setnonblock", err)
+	}
+	err := unix.Connect(fd, sa)
+	if err == nil {
+		return nil
+	}
+	if err != unix.EINPROGRESS && err != unix.EINTR {
+		return os.NewSyscallError("connect", err)
+	}
+
+	timeoutMs := -1
+	if timeout > 0 {
+		if timeoutMs = int(timeout / time.Millisecond); timeoutMs == 0 {
+			timeoutMs = 1
+		}
+	}
+	pfd := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLOUT}}
+	for {
+		n, perr := unix.Poll(pfd, timeoutMs)
+		if perr == unix.EINTR {
+			continue
+		}
+		if perr != nil {
+			return os.NewSyscallError("poll", perr)
+		}
+		if n == 0 {
+			return &net.OpError{Op: "dial", Err: os.ErrDeadlineExceeded}
+		}
+		break
+	}
+	soErr, err := unix.GetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_ERROR)
+	if err != nil {
+		return os.NewSyscallError("getsockopt", err)
+	}
+	if soErr != 0 {
+		return os.NewSyscallError("connect", unix.Errno(soErr))
+	}
+	return nil
+}
+
+// sockaddrFor resolves a network/address pair (as used by net.Listen/net.Dial)
+// into the socket domain and a unix.Sockaddr. Hostnames are resolved in the
+// current (routedns) network namespace. An empty host binds to the wildcard
+// address; the family follows an explicit "4"/"6" network suffix, defaulting to
+// IPv6 (dual-stack) otherwise.
+func sockaddrFor(network, address string) (int, unix.Sockaddr, error) {
+	host, portStr, err := net.SplitHostPort(address)
+	if err != nil {
+		return 0, nil, err
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0, nil, fmt.Errorf("invalid port %q in %q: %w", portStr, address, err)
+	}
+	ipVersion := networkIPVersion(network)
+
+	var ip net.IP
+	switch {
+	case host == "":
+		if ipVersion == 4 {
+			ip = net.IPv4zero
+		} else {
+			ip = net.IPv6unspecified
+		}
+	default:
+		if ip = net.ParseIP(host); ip == nil {
+			lookupNet := "ip"
+			switch ipVersion {
+			case 4:
+				lookupNet = "ip4"
+			case 6:
+				lookupNet = "ip6"
+			}
+			ips, err := net.DefaultResolver.LookupIP(context.Background(), lookupNet, host)
+			if err != nil {
+				return 0, nil, fmt.Errorf("resolving %q: %w", host, err)
+			}
+			if len(ips) == 0 {
+				return 0, nil, fmt.Errorf("no addresses found for %q", host)
+			}
+			ip = ips[0]
+		}
+	}
+
+	if ipVersion == 4 && ip.To4() == nil {
+		return 0, nil, fmt.Errorf("address %q is not IPv4 but network is %q", address, network)
+	}
+	if ipVersion == 6 && ip.To4() != nil {
+		return 0, nil, fmt.Errorf("address %q is not IPv6 but network is %q", address, network)
+	}
+
+	domain, sa := sockaddrFromIP(ip, port)
+	return domain, sa, nil
+}
+
+// sockaddrFromIP builds a unix.Sockaddr (and its domain) for an IP and port.
+func sockaddrFromIP(ip net.IP, port int) (int, unix.Sockaddr) {
+	if ip4 := ip.To4(); ip4 != nil {
+		sa := &unix.SockaddrInet4{Port: port}
+		copy(sa.Addr[:], ip4)
+		return unix.AF_INET, sa
+	}
+	sa := &unix.SockaddrInet6{Port: port}
+	copy(sa.Addr[:], ip.To16())
+	return unix.AF_INET6, sa
+}
+
+// networkIPVersion returns 4 or 6 for an explicit "tcp4"/"udp6" style suffix,
+// or 0 when the network is family-agnostic ("tcp"/"udp").
+func networkIPVersion(network string) int {
+	switch {
+	case strings.HasSuffix(network, "4"):
+		return 4
+	case strings.HasSuffix(network, "6"):
+		return 6
+	default:
+		return 0
+	}
+}

--- a/xsocket_linux_test.go
+++ b/xsocket_linux_test.go
@@ -1,0 +1,249 @@
+//go:build linux
+
+package rdns
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+var xsocketTestSeq uint64
+
+// startFakeXSocketServer starts an in-process stand-in for xsocket-server on an
+// abstract Unix socket and returns its path. It speaks the xsocket protocol: it
+// reads the 16-byte request, creates the requested socket (in this process's own
+// namespace, which is sufficient to exercise the fd-passing/bind/connect logic)
+// and returns it via SCM_RIGHTS. If forceErr is non-zero it instead replies with
+// that errno and no descriptor.
+func startFakeXSocketServer(t *testing.T, forceErr unix.Errno) string {
+	t.Helper()
+	name := fmt.Sprintf("@rdns-xsocket-test-%d-%d", os.Getpid(), atomic.AddUint64(&xsocketTestSeq, 1))
+
+	lfd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("server socket: %v", err)
+	}
+	if err := unix.Bind(lfd, &unix.SockaddrUnix{Name: name}); err != nil {
+		unix.Close(lfd)
+		t.Fatalf("server bind: %v", err)
+	}
+	if err := unix.Listen(lfd, 16); err != nil {
+		unix.Close(lfd)
+		t.Fatalf("server listen: %v", err)
+	}
+	t.Cleanup(func() { unix.Close(lfd) })
+
+	go func() {
+		for {
+			cfd, _, err := unix.Accept(lfd)
+			if err != nil {
+				return // listener closed
+			}
+			go serveFakeXSocket(cfd, forceErr)
+		}
+	}()
+	return name
+}
+
+func serveFakeXSocket(cfd int, forceErr unix.Errno) {
+	defer unix.Close(cfd)
+
+	req := make([]byte, 16)
+	n, _, _, _, err := unix.Recvmsg(cfd, req, nil, 0)
+	if err != nil || n < len(req) {
+		return
+	}
+	if binary.BigEndian.Uint32(req[0:]) != xsProtocolRequest {
+		return
+	}
+	domain := int(int32(binary.BigEndian.Uint32(req[4:])))
+	typ := int(int32(binary.BigEndian.Uint32(req[8:])))
+	proto := int(int32(binary.BigEndian.Uint32(req[12:])))
+
+	resp := make([]byte, 8)
+	binary.BigEndian.PutUint32(resp[0:], xsProtocolResponse)
+
+	if forceErr != 0 {
+		binary.BigEndian.PutUint32(resp[4:], uint32(forceErr))
+		_ = unix.Sendmsg(cfd, resp, nil, nil, 0)
+		return
+	}
+
+	nfd, serr := unix.Socket(domain, typ, proto)
+	if serr != nil {
+		if e, ok := serr.(unix.Errno); ok {
+			binary.BigEndian.PutUint32(resp[4:], uint32(e))
+		}
+		_ = unix.Sendmsg(cfd, resp, nil, nil, 0)
+		return
+	}
+	defer unix.Close(nfd)
+	_ = unix.Sendmsg(cfd, resp, unix.UnixRights(nfd), nil, 0)
+}
+
+func TestXSocketGetFd(t *testing.T) {
+	path := startFakeXSocketServer(t, 0)
+	fd, err := xsocketGetFd(path, unix.AF_INET, unix.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("xsocketGetFd: %v", err)
+	}
+	// The returned fd should be a usable socket.
+	if _, err := unix.GetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_TYPE); err != nil {
+		t.Errorf("returned fd is not a socket: %v", err)
+	}
+	unix.Close(fd)
+}
+
+func TestXSocketGetFdError(t *testing.T) {
+	path := startFakeXSocketServer(t, unix.EACCES)
+	_, err := xsocketGetFd(path, unix.AF_INET, unix.SOCK_STREAM, 0)
+	if err == nil {
+		t.Fatal("expected an error from the server")
+	}
+	if !errors.Is(err, unix.EACCES) {
+		t.Errorf("expected EACCES, got %v", err)
+	}
+}
+
+func TestListenXSocketTCP(t *testing.T) {
+	path := startFakeXSocketServer(t, 0)
+	ln, err := listenXSocket(path, "tcp", "127.0.0.1:0", SocketOptions{})
+	if err != nil {
+		t.Fatalf("listenXSocket: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		buf := make([]byte, 4)
+		if _, err := io.ReadFull(c, buf); err == nil {
+			c.Write(buf)
+		}
+	}()
+
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+	if _, err := c.Write([]byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(c, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Errorf("got %q, want \"ping\"", buf)
+	}
+}
+
+func TestListenUDPXSocket(t *testing.T) {
+	path := startFakeXSocketServer(t, 0)
+	conn, err := listenUDPXSocket(path, "udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}, SocketOptions{})
+	if err != nil {
+		t.Fatalf("listenUDPXSocket: %v", err)
+	}
+	defer conn.Close()
+
+	client, err := net.DialUDP("udp", nil, conn.LocalAddr().(*net.UDPAddr))
+	if err != nil {
+		t.Fatalf("dial udp: %v", err)
+	}
+	defer client.Close()
+	if _, err := client.Write([]byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 16)
+	n, _, err := conn.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf[:n]) != "ping" {
+		t.Errorf("got %q, want \"ping\"", buf[:n])
+	}
+}
+
+func TestDialXSocket(t *testing.T) {
+	// Local echo server to connect to.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		buf := make([]byte, 4)
+		if _, err := io.ReadFull(c, buf); err == nil {
+			c.Write(buf)
+		}
+	}()
+
+	path := startFakeXSocketServer(t, 0)
+	conn, err := dialXSocket(path, "tcp", ln.Addr().String(), SocketOptions{}, nil, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dialXSocket: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("pong")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != "pong" {
+		t.Errorf("got %q, want \"pong\"", buf)
+	}
+}
+
+func TestSockaddrFor(t *testing.T) {
+	tests := []struct {
+		network, address string
+		wantDomain       int
+		wantErr          bool
+	}{
+		{"tcp", "127.0.0.1:53", unix.AF_INET, false},
+		{"tcp", "[::1]:53", unix.AF_INET6, false},
+		{"udp", ":53", unix.AF_INET6, false}, // wildcard defaults to IPv6 (dual-stack)
+		{"udp4", ":53", unix.AF_INET, false}, // explicit v4 wildcard
+		{"tcp4", "[::1]:53", 0, true},        // v4 network with v6 address
+		{"tcp", "127.0.0.1:bogus", 0, true},  // bad port
+	}
+	for _, tc := range tests {
+		domain, _, err := sockaddrFor(tc.network, tc.address)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("sockaddrFor(%q, %q): expected error", tc.network, tc.address)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("sockaddrFor(%q, %q): %v", tc.network, tc.address, err)
+			continue
+		}
+		if domain != tc.wantDomain {
+			t.Errorf("sockaddrFor(%q, %q): domain = %d, want %d", tc.network, tc.address, domain, tc.wantDomain)
+		}
+	}
+}

--- a/xsocket_other.go
+++ b/xsocket_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package rdns
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+// dialXSocket is referenced from platform-agnostic code. xsocket relies on
+// Linux-specific facilities (network namespaces, SCM_RIGHTS fd passing into a
+// namespace), so it is unsupported elsewhere.
+func dialXSocket(path, network, address string, opts SocketOptions, localAddr net.IP, timeout time.Duration) (net.Conn, error) {
+	return nil, fmt.Errorf("xsocket is only supported on Linux")
+}


### PR DESCRIPTION
Implements xsocket support as suggested in #559.

## Background

The existing `netns` option uses `setns(2)`, which requires the RouteDNS process to hold `CAP_SYS_ADMIN`. [xsocket](https://github.com/koro666/xsocket) is an alternative: a small privileged `xsocket-server` runs inside the target namespace and listens on a Unix socket. RouteDNS connects to it, asks for a socket created in that namespace, and receives the file descriptor back over the Unix socket (`SCM_RIGHTS`). RouteDNS then binds/connects that descriptor itself — so only the tiny server needs privileges, not RouteDNS.

The `libxbind.so` LD_PRELOAD shim can't work with Go (Go issues `socket`/`bind` via direct syscalls, not libc), and the referenced `lysekrone` is a C shim rather than a Go module, so the protocol is implemented in-tree.

## Usage

```toml
[resolvers.res]
address = "9.9.9.9:53"
protocol = "udp"
xsocket = "/var/tmp/xsocket/ns1"

[listeners.local-udp]
address = "[::]:1053"
protocol = "udp"
resolver = "res"
xsocket = "/var/tmp/xsocket/ns2"
```

A leading `@` denotes an abstract socket (e.g. `xsocket = "@xsocket-ns1"`).

## Design

`XSocket` is folded into the existing `NetNS` type, so the option rides inside the `*NetNS` pointer every component already carries — no helper signatures or `*ClientOptions`/`ListenOptions` structs change. The three `Listen*InNetNS` helpers branch internally on the new `usesXSocket()`; the two dial sites (`dnsclient.go`, `dohclient.go`) branch explicitly since they have `SocketOptions`/local address in scope.

New `xsocket_linux.go` implements the wire protocol (16-byte request / 8-byte response, big-endian, over `AF_UNIX`/`SOCK_SEQPACKET`) plus the listen/dial helpers, with a non-blocking connect that honours `query-timeout`, `SO_REUSEADDR`/`IPV6_V6ONLY` matching the Go net defaults, and `fwmark`/`bind-if` applied to the fd before bind.

## Scope & limitations

- `xsocket` and `netns` are mutually exclusive on a component.
- Supported for `udp`/`tcp`, `dot`, `doh` (incl. DoH/3 QUIC) and `doq`, on both listeners and resolvers.
- DTLS listeners/clients and SOCKS5-proxied resolvers return a clear error when `xsocket` is set (they create their own sockets internally — no fd to inject). This mirrors the existing "DTLS doesn't support socket options" limitation.
- Upstream resolver hostnames are resolved in RouteDNS's own namespace; prefer IPs.
- `fwmark`/`bind-if` still require `CAP_NET_ADMIN`/`CAP_NET_RAW` in the RouteDNS process.
- Linux only (non-Linux returns an error, consistent with `netns`).

## Verification

Builds on linux/darwin/windows, `go vet` and `gofmt` clean, full suite passes (incl. `-race`). New `xsocket_linux_test.go` uses an in-process fake xsocket-server (no root/namespaces required) to exercise the protocol, fd passing, bind/listen/connect and `net.File*` wrapping for TCP/UDP listen and dial, plus the error-response path. Note: an end-to-end test against a real `xsocket-server` in a separate namespace isn't included.
