### PR TITLE
Fast-retry netns listener start to handle non-atomic ip netns add

### DIFF
--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -1121,11 +1121,26 @@ func networkForIPVersion(base string, ipVersion int) string {
 	return base + strconv.Itoa(ipVersion)
 }
 
-// netnsRetryInterval is how long the supervisor waits before retrying a
-// listener that failed to build or start while its namespace is present. It
-// matches the retry cadence used for listeners that aren't bound to a
-// namespace. It is a var so tests can shorten it.
+// netnsRetryInterval is the upper bound on how long the supervisor waits
+// before retrying a listener that failed to build or start while its namespace
+// is present. It matches the retry cadence used for listeners that aren't
+// bound to a namespace. It is a var so tests can shorten it.
 var netnsRetryInterval = time.Second
+
+// netnsInitialRetryInterval is the first (shortest) retry delay after a start
+// or build failure while the namespace is present. Retries back off
+// exponentially from here up to netnsRetryInterval.
+//
+// "ip netns add" is not atomic: it first creates a mode-000 placeholder file
+// (which is what fires the inotify CREATE event we react to), then a moment
+// later bind-mounts the real namespace onto it. In the gap between the two,
+// opening the path fails (EACCES on the placeholder for a non-root process, or
+// EINVAL once setns sees a non-namespace fd). No inotify event marks the bind
+// mount completing, so we can't wait for a "ready" signal — we just retry
+// quickly. The namespace becomes usable within a millisecond or two, so a short
+// first delay binds the listener well before a namespace creator that issues
+// its first query (and tears the namespace down on failure) gives up.
+var netnsInitialRetryInterval = 25 * time.Millisecond
 
 // superviseNetNSListener gates a listener on the presence of a network
 // namespace. When the namespace appears, build is called and the resulting
@@ -1154,14 +1169,26 @@ func runNetNSSupervisor(id, nsName string, events <-chan rdns.NetNSState, build 
 		startErr chan error
 		present  bool
 		retryC   <-chan time.Time // non-nil while a (re)start is pending
+		backoff  = netnsInitialRetryInterval
 	)
+
+	// scheduleRetry arms the retry timer using the current backoff, then grows
+	// the backoff toward the netnsRetryInterval cap for the next failure. The
+	// backoff is reset to netnsInitialRetryInterval whenever the namespace
+	// transitions present/absent, so each fresh appearance retries fast again.
+	scheduleRetry := func() {
+		retryC = time.After(backoff)
+		if backoff *= 2; backoff > netnsRetryInterval {
+			backoff = netnsRetryInterval
+		}
+	}
 
 	launch := func() {
 		retryC = nil
 		inner, err := build()
 		if err != nil {
 			rdns.Log.Warn("failed to build listener, retrying", "id", id, "error", err)
-			retryC = time.After(netnsRetryInterval)
+			scheduleRetry()
 			return
 		}
 		ln = inner
@@ -1183,10 +1210,12 @@ func runNetNSSupervisor(id, nsName string, events <-chan rdns.NetNSState, build 
 				if ln != nil {
 					continue
 				}
+				backoff = netnsInitialRetryInterval // fresh appearance: retry fast
 				rdns.Log.Info("netns present, starting listener", "netns", nsName, "id", id)
 				launch()
 			case rdns.NetNSAbsent:
 				present = false
+				backoff = netnsInitialRetryInterval
 				retryC = nil // namespace is gone; cancel any pending retry
 				if ln == nil {
 					rdns.Log.Warn("netns not present, waiting", "netns", nsName, "id", id)
@@ -1204,9 +1233,10 @@ func runNetNSSupervisor(id, nsName string, events <-chan rdns.NetNSState, build 
 				rdns.Log.Warn("listener exited", "id", id, "error", err)
 			}
 			// The listener stopped on its own while the namespace is still
-			// present (crash or transient bind failure); retry on a timer.
+			// present (crash, or a transient open/bind failure because the
+			// namespace isn't fully mounted yet); retry on a backoff timer.
 			if present {
-				retryC = time.After(netnsRetryInterval)
+				scheduleRetry()
 			}
 		case <-retryC:
 			retryC = nil

--- a/cmd/routedns/netns_supervisor_test.go
+++ b/cmd/routedns/netns_supervisor_test.go
@@ -101,12 +101,88 @@ func TestStopNetNSListenerStopsImmediately(t *testing.T) {
 	}
 }
 
+// flakyStartListener fails its first failStarts Start() calls (mirroring the
+// EACCES seen while "ip netns add" has only created the mode-000 placeholder
+// but not yet bind-mounted the namespace), then blocks like a healthy listener.
+type flakyStartListener struct {
+	mu         sync.Mutex
+	startCalls int
+	failStarts int
+	stop       chan struct{}
+}
+
+func (f *flakyStartListener) Start() error {
+	f.mu.Lock()
+	f.startCalls++
+	n := f.startCalls
+	f.mu.Unlock()
+	if n <= f.failStarts {
+		return errors.New("failed to open target netns \"ns\": permission denied")
+	}
+	<-f.stop
+	return nil
+}
+
+func (f *flakyStartListener) Stop() error {
+	select {
+	case <-f.stop:
+	default:
+		close(f.stop)
+	}
+	return nil
+}
+
+func (f *flakyStartListener) String() string { return "flaky" }
+
+func (f *flakyStartListener) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.startCalls
+}
+
+// When a freshly-created namespace isn't mounted yet, the first start fails;
+// the supervisor must retry on the short initial interval and bind successfully
+// once the namespace becomes usable, rather than waiting a full second.
+func TestNetNSSupervisorRetriesStartFailureFast(t *testing.T) {
+	oldMax, oldInit := netnsRetryInterval, netnsInitialRetryInterval
+	netnsRetryInterval = 50 * time.Millisecond
+	netnsInitialRetryInterval = 2 * time.Millisecond
+	defer func() { netnsRetryInterval, netnsInitialRetryInterval = oldMax, oldInit }()
+
+	ln := &flakyStartListener{failStarts: 2, stop: make(chan struct{})}
+	build := func() (rdns.Listener, error) { return ln, nil }
+
+	events := make(chan rdns.NetNSState, 1)
+	done := make(chan struct{})
+	go func() {
+		runNetNSSupervisor("test", "ns", events, build)
+		close(done)
+	}()
+
+	events <- rdns.NetNSPresent
+	// Two fast retries (2ms + 4ms) plus scheduling overhead must land well
+	// under the 50ms cap; require completion inside a window far shorter than
+	// three full-interval retries would take.
+	require.Eventually(t, func() bool {
+		return ln.calls() >= 3
+	}, 200*time.Millisecond, 1*time.Millisecond, "start was not retried quickly enough")
+
+	events <- rdns.NetNSAbsent
+	close(events)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not exit")
+	}
+}
+
 // A listener that fails to build while its namespace is present must be retried
 // on a timer rather than waiting for the next namespace event.
 func TestNetNSSupervisorRetriesBuildFailure(t *testing.T) {
-	old := netnsRetryInterval
+	oldMax, oldInit := netnsRetryInterval, netnsInitialRetryInterval
 	netnsRetryInterval = 10 * time.Millisecond
-	defer func() { netnsRetryInterval = old }()
+	netnsInitialRetryInterval = 2 * time.Millisecond
+	defer func() { netnsRetryInterval, netnsInitialRetryInterval = oldMax, oldInit }()
 
 	var (
 		mu       sync.Mutex


### PR DESCRIPTION
## Problem

Reported in #522 (review comment): after a reboot, a "namespace creator" service that creates a netns and immediately issues a DNS query races RouteDNS's listener bind and fails every time, unless an arbitrary sleep is inserted.

Root cause: `ip netns add NAME` is **not atomic**. It first creates a mode-`000` placeholder file at `/run/netns/NAME` (which is what fires the inotify `CREATE` event the supervisor reacts to), then a moment later `unshare(CLONE_NEWNET)` + bind-mounts the real namespace onto that path. In the gap between the two:

- opening the path fails with `EACCES` for a non-root process (the placeholder is mode `000`; `CAP_SYS_ADMIN` does not bypass DAC), or `EINVAL` once `setns` sees a non-namespace fd.

Crucially, **no inotify event marks the bind mount completing** — `CREATE`, `OPEN`, and `CLOSE_NOWRITE` all fire on the placeholder *before* the mount, which is why watching `CLOSE` instead of `CREATE` didn't help. There is no "ready" signal to wait for.

The supervisor reacted to `CREATE`, tried to bind, hit `EACCES`, and then retried on a flat 1s interval — leaving the listener down for up to a second. A creator service that gives up and deletes the namespace within that window loses the race.

## Fix

Retry the listener start with an exponential backoff from a short initial interval (`25ms`) up to the existing 1s cap, instead of a flat 1s. The backoff resets on every namespace present/absent transition so each fresh appearance retries fast again. The namespace becomes usable within a millisecond or two of `CREATE`, so the listener now binds within tens of milliseconds rather than up to a second — comfortably before a creator service issues its first query.

## Changes

- `cmd/routedns/main.go`: add `netnsInitialRetryInterval`, replace the flat retry with a `scheduleRetry` backoff helper used by both the build-failure and start-failure paths; reset backoff on present/absent transitions.
- `cmd/routedns/netns_supervisor_test.go`: add `TestNetNSSupervisorRetriesStartFailureFast` covering the placeholder-window `EACCES` race; update the existing build-retry test to set both intervals.