### PR TITLE
socks5: fix local-addr binding with a SOCKS5 proxy

### DIFF
--- a/socks5.go
+++ b/socks5.go
@@ -89,7 +89,12 @@ func (d *Socks5Dialer) Dial(network string, address string) (net.Conn, error) {
 
 	localAddr := selectLocalAddr(d.addr, d.opt.LocalAddr, d.opt.LocalAddrV4, d.opt.LocalAddrV6)
 	if localAddr != nil {
-		return d.Client.DialWithLocalAddr(network, localAddr.String(), d.addr, nil)
+		// The socks5 library resolves the source address with
+		// net.ResolveTCPAddr, which requires a host:port. Bind the configured
+		// local IP with port 0 so the OS picks the source port; a bare IP would
+		// fail with "missing port in address".
+		src := net.JoinHostPort(localAddr.String(), "0")
+		return d.Client.DialWithLocalAddr(network, src, d.addr, nil)
 	}
 	return d.Client.Dial(network, d.addr)
 }

--- a/socks5_test.go
+++ b/socks5_test.go
@@ -7,6 +7,9 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // startMinimalSocks5Proxy starts a no-auth SOCKS5 CONNECT proxy that relays to
@@ -15,9 +18,7 @@ import (
 func startMinimalSocks5Proxy(t *testing.T) string {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("proxy listen: %v", err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { ln.Close() })
 	go func() {
 		for {
@@ -99,9 +100,7 @@ func serveSocks5Connect(c net.Conn) {
 func startEchoTCPServer(t *testing.T) net.Listener {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("echo listen: %v", err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { ln.Close() })
 	go func() {
 		for {
@@ -133,29 +132,19 @@ func TestSocks5DialerLocalAddr(t *testing.T) {
 	})
 
 	conn, err := d.Dial("tcp", echo.Addr().String())
-	if err != nil {
-		t.Fatalf("Dial: %v", err)
-	}
+	require.NoError(t, err)
 	defer conn.Close()
 
 	// The connection to the proxy should be bound to the configured local IP.
 	host, _, err := net.SplitHostPort(conn.LocalAddr().String())
-	if err != nil {
-		t.Fatalf("parse local addr %q: %v", conn.LocalAddr(), err)
-	}
-	if host != "127.0.0.1" {
-		t.Errorf("connection bound to %q, want source IP 127.0.0.1", host)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", host, "connection should be bound to the configured source IP")
 
-	if _, err := conn.Write([]byte("ping")); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, err = conn.Write([]byte("ping"))
+	require.NoError(t, err)
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
 	buf := make([]byte, 4)
-	if _, err := io.ReadFull(conn, buf); err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	if string(buf) != "ping" {
-		t.Errorf("got %q, want \"ping\"", buf)
-	}
+	_, err = io.ReadFull(conn, buf)
+	require.NoError(t, err)
+	assert.Equal(t, "ping", string(buf))
 }

--- a/socks5_test.go
+++ b/socks5_test.go
@@ -1,0 +1,161 @@
+package rdns
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// startMinimalSocks5Proxy starts a no-auth SOCKS5 CONNECT proxy that relays to
+// the requested target. It supports IPv4 and domain destination address types,
+// which is all the socks5 client emits here.
+func startMinimalSocks5Proxy(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("proxy listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go serveSocks5Connect(c)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func serveSocks5Connect(c net.Conn) {
+	defer c.Close()
+
+	// Negotiation: VER, NMETHODS, METHODS...
+	hdr := make([]byte, 2)
+	if _, err := io.ReadFull(c, hdr); err != nil || hdr[0] != 0x05 {
+		return
+	}
+	if _, err := io.ReadFull(c, make([]byte, int(hdr[1]))); err != nil {
+		return
+	}
+	// Reply: no authentication required.
+	if _, err := c.Write([]byte{0x05, 0x00}); err != nil {
+		return
+	}
+
+	// Request: VER, CMD, RSV, ATYP, DST.ADDR, DST.PORT
+	req := make([]byte, 4)
+	if _, err := io.ReadFull(c, req); err != nil || req[1] != 0x01 { // CONNECT only
+		return
+	}
+	var host string
+	switch req[3] {
+	case 0x01: // IPv4
+		b := make([]byte, 4)
+		if _, err := io.ReadFull(c, b); err != nil {
+			return
+		}
+		host = net.IP(b).String()
+	case 0x03: // domain
+		l := make([]byte, 1)
+		if _, err := io.ReadFull(c, l); err != nil {
+			return
+		}
+		b := make([]byte, int(l[0]))
+		if _, err := io.ReadFull(c, b); err != nil {
+			return
+		}
+		host = string(b)
+	default:
+		return
+	}
+	pb := make([]byte, 2)
+	if _, err := io.ReadFull(c, pb); err != nil {
+		return
+	}
+	target := net.JoinHostPort(host, fmt.Sprintf("%d", binary.BigEndian.Uint16(pb)))
+
+	upstream, err := net.Dial("tcp", target)
+	if err != nil {
+		c.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0}) // general failure
+		return
+	}
+	defer upstream.Close()
+
+	// Reply: success, bound address 0.0.0.0:0.
+	if _, err := c.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+		return
+	}
+
+	go io.Copy(upstream, c)
+	io.Copy(c, upstream)
+}
+
+// startEchoTCPServer starts a TCP server that echoes back whatever it reads.
+func startEchoTCPServer(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				io.Copy(c, c)
+			}(c)
+		}
+	}()
+	return ln
+}
+
+// TestSocks5DialerLocalAddr verifies that a Socks5Dialer configured with a local
+// address dials successfully and binds the connection to the proxy to that
+// source IP. Without binding a port to the local IP, the underlying socks5
+// library rejects the bare IP with "missing port in address".
+func TestSocks5DialerLocalAddr(t *testing.T) {
+	echo := startEchoTCPServer(t)
+	proxyAddr := startMinimalSocks5Proxy(t)
+
+	d := NewSocks5Dialer(proxyAddr, Socks5DialerOptions{
+		TCPTimeout: 2 * time.Second,
+		UDPTimeout: 2 * time.Second,
+		LocalAddr:  net.ParseIP("127.0.0.1"),
+	})
+
+	conn, err := d.Dial("tcp", echo.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	// The connection to the proxy should be bound to the configured local IP.
+	host, _, err := net.SplitHostPort(conn.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("parse local addr %q: %v", conn.LocalAddr(), err)
+	}
+	if host != "127.0.0.1" {
+		t.Errorf("connection bound to %q, want source IP 127.0.0.1", host)
+	}
+
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Errorf("got %q, want \"ping\"", buf)
+	}
+}


### PR DESCRIPTION
## Problem

Combining a SOCKS5 proxy (`socks5-address`) with a local source address (`local-addr`, `local-addr-v4`, or `local-addr-v6`) on a resolver fails **every** dial with:

```
address 127.0.0.1: missing port in address
```

`Socks5Dialer.Dial` passed the configured local address as a bare IP (`localAddr.String()`, e.g. `"127.0.0.1"`) to the upstream library's `DialWithLocalAddr`. That library resolves the source via `net.ResolveTCPAddr`, which requires a `host:port` — a bare IP is rejected. This affects both the TCP and UDP code paths in the library, so SOCKS5 + any local-addr is currently non-functional.

## Fix

Bind the local IP with port `0` (`net.JoinHostPort(localAddr.String(), "0")`) so the OS picks the source port, which is the conventional way to bind only a source address.

## Test

Added `TestSocks5DialerLocalAddr`, which stands up a minimal in-process SOCKS5 CONNECT proxy and an echo server, dials through `Socks5Dialer` with `LocalAddr` set, and asserts the dial succeeds, the connection to the proxy is bound to the configured source IP, and data relays end-to-end. The test fails on the previous code with the "missing port" error.