### PR TITLE
Detect netns readiness via mount events instead of timed retries

### DIFF
--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -1127,6 +1127,16 @@ func networkForIPVersion(base string, ipVersion int) string {
 // namespace. It is a var so tests can shorten it.
 var netnsRetryInterval = time.Second
 
+// netnsReadyTimeout is the longest the supervisor waits for a namespace that
+// just appeared to become fully set up (see waitNetNSReady) before trying to
+// start the listener anyway. Normally the wait completes within a few
+// milliseconds; the timeout only matters in pathological cases such as a
+// stray non-namespace file under /var/run/netns.
+var netnsReadyTimeout = 5 * time.Second
+
+// waitNetNSReady is rdns.WaitNetNSReady, indirected so tests can stub it out.
+var waitNetNSReady = rdns.WaitNetNSReady
+
 // superviseNetNSListener gates a listener on the presence of a network
 // namespace. When the namespace appears, build is called and the resulting
 // listener is started; when it disappears, the listener is stopped. A fresh
@@ -1184,6 +1194,15 @@ func runNetNSSupervisor(id, nsName string, events <-chan rdns.NetNSState, build 
 					continue
 				}
 				rdns.Log.Info("netns present, starting listener", "netns", nsName, "id", id)
+				// "ip netns add" creates the namespace file before mounting
+				// the actual namespace onto it, and the inotify event fires on
+				// the former. Wait for the mount so the listener doesn't try
+				// to bind into the placeholder. On error (namespace deleted
+				// again, timeout, ...) still attempt the start: a failure
+				// there is visible to the user and retried on a timer.
+				if err := waitNetNSReady(nsName, netnsReadyTimeout); err != nil {
+					rdns.Log.Warn("netns not ready", "netns", nsName, "id", id, "error", err)
+				}
 				launch()
 			case rdns.NetNSAbsent:
 				present = false

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -1132,7 +1132,7 @@ var netnsRetryInterval = time.Second
 // start the listener anyway. Normally the wait completes within a few
 // milliseconds; the timeout only matters in pathological cases such as a
 // stray non-namespace file under /var/run/netns.
-var netnsReadyTimeout = 5 * time.Second
+var netnsReadyTimeout = time.Second
 
 // waitNetNSReady is rdns.WaitNetNSReady, indirected so tests can stub it out.
 var waitNetNSReady = rdns.WaitNetNSReady

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -1124,15 +1124,15 @@ func networkForIPVersion(base string, ipVersion int) string {
 // netnsRetryInterval is how long the supervisor waits before retrying a
 // listener that failed to build or start while its namespace is present. It
 // matches the retry cadence used for listeners that aren't bound to a
-// namespace. It is a var so tests can shorten it.
-var netnsRetryInterval = time.Second
+// namespace.
+const netnsRetryInterval = time.Second
 
 // netnsReadyTimeout is the longest the supervisor waits for a namespace that
 // just appeared to become fully set up (see waitNetNSReady) before trying to
 // start the listener anyway. Normally the wait completes within a few
 // milliseconds; the timeout only matters in pathological cases such as a
 // stray non-namespace file under /var/run/netns.
-var netnsReadyTimeout = time.Second
+const netnsReadyTimeout = time.Second
 
 // waitNetNSReady is rdns.WaitNetNSReady, indirected so tests can stub it out.
 var waitNetNSReady = rdns.WaitNetNSReady

--- a/cmd/routedns/netns_supervisor_test.go
+++ b/cmd/routedns/netns_supervisor_test.go
@@ -68,9 +68,7 @@ func TestStopNetNSListenerRetriesUntilStopped(t *testing.T) {
 
 		stopNetNSListener("test", f, startErr)
 
-		if c := f.calls(); c < 2 {
-			t.Fatalf("expected Stop() to be retried, got %d call(s)", c)
-		}
+		require.GreaterOrEqual(t, f.calls(), 2, "expected Stop() to be retried")
 	})
 }
 
@@ -84,9 +82,7 @@ func TestStopNetNSListenerStopsImmediately(t *testing.T) {
 
 		stopNetNSListener("test", f, startErr)
 
-		if c := f.calls(); c != 1 {
-			t.Fatalf("expected exactly 1 Stop() call, got %d", c)
-		}
+		require.Equal(t, 1, f.calls(), "expected exactly 1 Stop() call")
 	})
 }
 

--- a/cmd/routedns/netns_supervisor_test.go
+++ b/cmd/routedns/netns_supervisor_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	rdns "github.com/folbricht/routedns"
@@ -163,52 +164,43 @@ func TestNetNSSupervisorRetriesBuildFailure(t *testing.T) {
 // building and starting the listener, so the listener never tries to bind into
 // the unmounted placeholder.
 func TestNetNSSupervisorWaitsForReady(t *testing.T) {
-	ready := make(chan struct{})
-	stubWaitNetNSReady(t, func(string, time.Duration) error {
-		<-ready
-		return nil
+	synctest.Test(t, func(t *testing.T) {
+		ready := make(chan struct{})
+		stubWaitNetNSReady(t, func(string, time.Duration) error {
+			<-ready
+			return nil
+		})
+
+		builds := 0
+		build := func() (rdns.Listener, error) {
+			builds++
+			return newFakeNetNSListener(0), nil
+		}
+
+		events := make(chan rdns.NetNSState, 1)
+		done := make(chan struct{})
+		go func() {
+			runNetNSSupervisor("test", "ns", events, build)
+			close(done)
+		}()
+
+		// The namespace appears, but isn't ready yet: once the bubble is idle
+		// the supervisor is blocked in waitNetNSReady and no build must have
+		// happened.
+		events <- rdns.NetNSPresent
+		synctest.Wait()
+		require.Equal(t, 0, builds, "listener must not be built before the namespace is ready")
+
+		// The namespace becomes ready: the listener must be built and started.
+		close(ready)
+		synctest.Wait()
+		require.Equal(t, 1, builds, "listener was not started after the namespace became ready")
+
+		// Tear down: namespace goes away (stops the listener), then end the
+		// loop. If the supervisor doesn't exit, the bubble deadlocks and
+		// synctest fails the test.
+		events <- rdns.NetNSAbsent
+		close(events)
+		<-done
 	})
-
-	var (
-		mu     sync.Mutex
-		builds int
-	)
-	build := func() (rdns.Listener, error) {
-		mu.Lock()
-		defer mu.Unlock()
-		builds++
-		return newFakeNetNSListener(0), nil
-	}
-	buildCount := func() int {
-		mu.Lock()
-		defer mu.Unlock()
-		return builds
-	}
-
-	events := make(chan rdns.NetNSState, 1)
-	done := make(chan struct{})
-	go func() {
-		runNetNSSupervisor("test", "ns", events, build)
-		close(done)
-	}()
-
-	// The namespace appears, but isn't ready yet: no build must happen.
-	events <- rdns.NetNSPresent
-	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, 0, buildCount(), "listener must not be built before the namespace is ready")
-
-	// The namespace becomes ready: the listener must be built and started.
-	close(ready)
-	require.Eventually(t, func() bool {
-		return buildCount() == 1
-	}, 2*time.Second, 5*time.Millisecond, "listener was not started after the namespace became ready")
-
-	// Tear down: namespace goes away (stops the listener), then end the loop.
-	events <- rdns.NetNSAbsent
-	close(events)
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("supervisor did not exit")
-	}
 }

--- a/cmd/routedns/netns_supervisor_test.go
+++ b/cmd/routedns/netns_supervisor_test.go
@@ -56,50 +56,38 @@ func (f *fakeNetNSListener) calls() int {
 }
 
 // A Stop() that is a no-op until the listener is serving must be retried until
-// Start() actually returns, rather than blocking on its result forever.
+// Start() actually returns, rather than blocking on its result forever. If the
+// no-op Stop were not retried, Start would never return and the bubble would
+// deadlock, failing the test.
 func TestStopNetNSListenerRetriesUntilStopped(t *testing.T) {
-	f := newFakeNetNSListener(1) // first Stop is a no-op, second takes effect
+	synctest.Test(t, func(t *testing.T) {
+		f := newFakeNetNSListener(1) // first Stop is a no-op, second takes effect
 
-	startErr := make(chan error, 1)
-	go func() { startErr <- f.Start() }()
+		startErr := make(chan error, 1)
+		go func() { startErr <- f.Start() }()
 
-	done := make(chan struct{})
-	go func() {
 		stopNetNSListener("test", f, startErr)
-		close(done)
-	}()
 
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("stopNetNSListener deadlocked: Stop was a no-op and Start never returned")
-	}
-	if c := f.calls(); c < 2 {
-		t.Fatalf("expected Stop() to be retried, got %d call(s)", c)
-	}
+		if c := f.calls(); c < 2 {
+			t.Fatalf("expected Stop() to be retried, got %d call(s)", c)
+		}
+	})
 }
 
 // When Stop() works on the first try the supervisor must not retry needlessly.
 func TestStopNetNSListenerStopsImmediately(t *testing.T) {
-	f := newFakeNetNSListener(0)
+	synctest.Test(t, func(t *testing.T) {
+		f := newFakeNetNSListener(0)
 
-	startErr := make(chan error, 1)
-	go func() { startErr <- f.Start() }()
+		startErr := make(chan error, 1)
+		go func() { startErr <- f.Start() }()
 
-	done := make(chan struct{})
-	go func() {
 		stopNetNSListener("test", f, startErr)
-		close(done)
-	}()
 
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("stopNetNSListener did not return")
-	}
-	if c := f.calls(); c != 1 {
-		t.Fatalf("expected exactly 1 Stop() call, got %d", c)
-	}
+		if c := f.calls(); c != 1 {
+			t.Fatalf("expected exactly 1 Stop() call, got %d", c)
+		}
+	})
 }
 
 // stubWaitNetNSReady replaces waitNetNSReady for the duration of a test.
@@ -112,51 +100,67 @@ func stubWaitNetNSReady(t *testing.T, fn func(name string, timeout time.Duration
 // A listener that fails to build while its namespace is present must be retried
 // on a timer rather than waiting for the next namespace event.
 func TestNetNSSupervisorRetriesBuildFailure(t *testing.T) {
-	old := netnsRetryInterval
-	netnsRetryInterval = 10 * time.Millisecond
-	defer func() { netnsRetryInterval = old }()
-	stubWaitNetNSReady(t, func(string, time.Duration) error { return nil })
+	synctest.Test(t, func(t *testing.T) {
+		stubWaitNetNSReady(t, func(string, time.Duration) error { return nil })
 
-	var (
-		mu       sync.Mutex
-		attempts int
-		started  *fakeNetNSListener
-	)
-	build := func() (rdns.Listener, error) {
-		mu.Lock()
-		defer mu.Unlock()
-		attempts++
-		if attempts < 3 {
-			return nil, errors.New("address already in use")
+		// The counters need a mutex even under synctest: the supervisor's
+		// retries are woken by its retry timer rather than by an operation of
+		// this goroutine, so there is no happens-before edge between a read
+		// here and the write in the next retry.
+		var (
+			mu       sync.Mutex
+			attempts int
+			started  *fakeNetNSListener
+		)
+		build := func() (rdns.Listener, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			attempts++
+			if attempts < 3 {
+				return nil, errors.New("address already in use")
+			}
+			started = newFakeNetNSListener(0)
+			return started, nil
 		}
-		started = newFakeNetNSListener(0)
-		return started, nil
-	}
+		attemptCount := func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return attempts
+		}
 
-	events := make(chan rdns.NetNSState, 1)
-	done := make(chan struct{})
-	go func() {
-		runNetNSSupervisor("test", "ns", events, build)
-		close(done)
-	}()
+		events := make(chan rdns.NetNSState, 1)
+		done := make(chan struct{})
+		go func() {
+			runNetNSSupervisor("test", "ns", events, build)
+			close(done)
+		}()
 
-	// Namespace is present but the first two builds fail; the supervisor must
-	// keep retrying on the timer until the third build succeeds.
-	events <- rdns.NetNSPresent
-	require.Eventually(t, func() bool {
+		// Namespace is present, the first build fails: the supervisor must be
+		// waiting on the retry timer, not for the next namespace event.
+		events <- rdns.NetNSPresent
+		synctest.Wait()
+		require.Equal(t, 1, attemptCount())
+
+		// First retry fires on the (fake) clock and fails again.
+		time.Sleep(netnsRetryInterval)
+		synctest.Wait()
+		require.Equal(t, 2, attemptCount())
+
+		// Second retry succeeds and starts the listener.
+		time.Sleep(netnsRetryInterval)
+		synctest.Wait()
+		require.Equal(t, 3, attemptCount())
 		mu.Lock()
-		defer mu.Unlock()
-		return attempts >= 3 && started != nil
-	}, 2*time.Second, 5*time.Millisecond, "build was not retried until it succeeded")
+		require.NotNil(t, started, "listener was not started after the build succeeded")
+		mu.Unlock()
 
-	// Tear down: namespace goes away (stops the listener), then end the loop.
-	events <- rdns.NetNSAbsent
-	close(events)
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("supervisor did not exit")
-	}
+		// Tear down: namespace goes away (stops the listener), then end the
+		// loop. If the supervisor doesn't exit, the bubble deadlocks and
+		// synctest fails the test.
+		events <- rdns.NetNSAbsent
+		close(events)
+		<-done
+	})
 }
 
 // When a namespace appears, the supervisor must wait for it to be fully set up

--- a/cmd/routedns/netns_supervisor_test.go
+++ b/cmd/routedns/netns_supervisor_test.go
@@ -101,12 +101,20 @@ func TestStopNetNSListenerStopsImmediately(t *testing.T) {
 	}
 }
 
+// stubWaitNetNSReady replaces waitNetNSReady for the duration of a test.
+func stubWaitNetNSReady(t *testing.T, fn func(name string, timeout time.Duration) error) {
+	old := waitNetNSReady
+	waitNetNSReady = fn
+	t.Cleanup(func() { waitNetNSReady = old })
+}
+
 // A listener that fails to build while its namespace is present must be retried
 // on a timer rather than waiting for the next namespace event.
 func TestNetNSSupervisorRetriesBuildFailure(t *testing.T) {
 	old := netnsRetryInterval
 	netnsRetryInterval = 10 * time.Millisecond
 	defer func() { netnsRetryInterval = old }()
+	stubWaitNetNSReady(t, func(string, time.Duration) error { return nil })
 
 	var (
 		mu       sync.Mutex
@@ -139,6 +147,61 @@ func TestNetNSSupervisorRetriesBuildFailure(t *testing.T) {
 		defer mu.Unlock()
 		return attempts >= 3 && started != nil
 	}, 2*time.Second, 5*time.Millisecond, "build was not retried until it succeeded")
+
+	// Tear down: namespace goes away (stops the listener), then end the loop.
+	events <- rdns.NetNSAbsent
+	close(events)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not exit")
+	}
+}
+
+// When a namespace appears, the supervisor must wait for it to be fully set up
+// (the bind mount "ip netns add" performs after creating the file) before
+// building and starting the listener, so the listener never tries to bind into
+// the unmounted placeholder.
+func TestNetNSSupervisorWaitsForReady(t *testing.T) {
+	ready := make(chan struct{})
+	stubWaitNetNSReady(t, func(string, time.Duration) error {
+		<-ready
+		return nil
+	})
+
+	var (
+		mu     sync.Mutex
+		builds int
+	)
+	build := func() (rdns.Listener, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		builds++
+		return newFakeNetNSListener(0), nil
+	}
+	buildCount := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return builds
+	}
+
+	events := make(chan rdns.NetNSState, 1)
+	done := make(chan struct{})
+	go func() {
+		runNetNSSupervisor("test", "ns", events, build)
+		close(done)
+	}()
+
+	// The namespace appears, but isn't ready yet: no build must happen.
+	events <- rdns.NetNSPresent
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 0, buildCount(), "listener must not be built before the namespace is ready")
+
+	// The namespace becomes ready: the listener must be built and started.
+	close(ready)
+	require.Eventually(t, func() bool {
+		return buildCount() == 1
+	}, 2*time.Second, 5*time.Millisecond, "listener was not started after the namespace became ready")
 
 	// Tear down: namespace goes away (stops the listener), then end the loop.
 	events <- rdns.NetNSAbsent

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -2253,6 +2253,8 @@ The `netns` value can be either:
 
 The option is supported on all listener protocols (UDP, TCP, DoT, DoH, DoQ, DTLS, Admin) and all resolver protocols (UDP, TCP, DoT, DoH, DoQ, DTLS, ODoH). On non-Linux platforms, configuring `netns` returns an error.
 
+Listeners bound to a named namespace are supervised: the listener starts when the namespace appears and stops when it is removed, so namespaces can come and go while RouteDNS runs. This requires `/var/run/netns` to exist when RouteDNS starts; the directory is created by the first `ip netns add` after boot. If RouteDNS starts before that, the listener is disabled with an error. To start RouteDNS independent of namespace creation order, create the directory beforehand, e.g. with `ExecStartPre=+mkdir -p /run/netns` in a systemd unit.
+
 Examples:
 
 Listen in a container namespace, resolve in the host namespace:

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"runtime"
 
 	"golang.org/x/sys/unix"
@@ -22,10 +21,7 @@ type NetNS struct {
 // If Name starts with '/', it is used as-is; otherwise it is looked up
 // under /var/run/netns/.
 func (ns *NetNS) nsPath() string {
-	if filepath.IsAbs(ns.Name) {
-		return ns.Name
-	}
-	return filepath.Join("/var/run/netns", ns.Name)
+	return netnsPath(ns.Name)
 }
 
 // RunInNetNS executes fn in the given network namespace. If ns is nil or

--- a/netns_watch_linux.go
+++ b/netns_watch_linux.go
@@ -217,6 +217,16 @@ func (w *netnsWatcher) subscribe(name string) (<-chan NetNSState, func()) {
 	return s.ch, cancel
 }
 
+// netnsReadyRecheckInterval caps how long WaitNetNSReady sleeps on the
+// mountinfo poll before re-checking the path. The poll wakeup is the fast
+// path, but it is not guaranteed to fire in every environment: when routedns
+// runs in its own mount namespace (e.g. sandboxed by systemd's DynamicUser),
+// a namespace mount propagating in from the host doesn't wake mountinfo
+// pollers on all kernels, and deletion of the namespace file changes no mount
+// state at all. The bounded re-check keeps both cases from stalling until the
+// timeout.
+const netnsReadyRecheckInterval = 10 * time.Millisecond
+
 // WaitNetNSReady blocks until the named network namespace is fully set up and
 // usable, the namespace file disappears, or the timeout expires. name is
 // either a namespace name under /var/run/netns or an absolute path.
@@ -229,7 +239,8 @@ func (w *netnsWatcher) subscribe(name string) (<-chan NetNSState, func()) {
 // it does change the mount table, and the kernel signals POLLPRI on
 // /proc/self/mountinfo whenever that happens. So this waits by checking
 // whether the path is an nsfs mount (statfs) and sleeping on a mountinfo poll
-// between checks — entirely event-driven, no retry intervals.
+// between checks. The poll is capped at netnsReadyRecheckInterval so progress
+// doesn't depend on the wakeup actually arriving.
 func WaitNetNSReady(name string, timeout time.Duration) error {
 	path := name
 	if !filepath.IsAbs(path) {
@@ -260,7 +271,7 @@ func WaitNetNSReady(name string, timeout time.Duration) error {
 		if remaining <= 0 {
 			return fmt.Errorf("timed out waiting for netns %q to be mounted", name)
 		}
-		ms := int(remaining.Milliseconds())
+		ms := int(min(remaining, netnsReadyRecheckInterval).Milliseconds())
 		if ms < 1 {
 			ms = 1
 		}

--- a/netns_watch_linux.go
+++ b/netns_watch_linux.go
@@ -217,14 +217,15 @@ func (w *netnsWatcher) subscribe(name string) (<-chan NetNSState, func()) {
 	return s.ch, cancel
 }
 
-// netnsReadyRecheckInterval caps how long WaitNetNSReady sleeps on the
-// mountinfo poll before re-checking the path. The poll wakeup is the fast
-// path, but it is not guaranteed to fire in every environment: when routedns
-// runs in its own mount namespace (e.g. sandboxed by systemd's DynamicUser),
-// a namespace mount propagating in from the host doesn't wake mountinfo
-// pollers on all kernels, and deletion of the namespace file changes no mount
-// state at all. The bounded re-check keeps both cases from stalling until the
-// timeout.
+// netnsReadyRecheckInterval is how often WaitNetNSReady re-checks the
+// namespace path. The bind mount completing fires no inotify event, and the
+// event-driven alternative — poll(POLLPRI) on /proc/self/mountinfo — isn't
+// reliable: when routedns runs in its own mount namespace (e.g. sandboxed by
+// systemd's DynamicUser), a namespace mount propagating in from the host
+// doesn't wake mountinfo pollers on all kernels, and deletion of the
+// namespace file changes no mount state at all. So a short fixed interval is
+// used instead; it bounds both the listener-start latency after
+// "ip netns add" and the detection of a namespace deleted mid-wait.
 const netnsReadyRecheckInterval = 10 * time.Millisecond
 
 // WaitNetNSReady blocks until the named network namespace is fully set up and
@@ -235,26 +236,13 @@ const netnsReadyRecheckInterval = 10 * time.Millisecond
 // what fires the inotify CREATE event the watcher reacts to), then bind-mounts
 // the actual namespace onto it. In the gap between the two, opening the path
 // fails (EACCES on the mode-000 placeholder for a non-root process, EINVAL
-// from setns otherwise). The bind mount completing fires no inotify event, but
-// it does change the mount table, and the kernel signals POLLPRI on
-// /proc/self/mountinfo whenever that happens. So this waits by checking
-// whether the path is an nsfs mount (statfs) and sleeping on a mountinfo poll
-// between checks. The poll is capped at netnsReadyRecheckInterval so progress
-// doesn't depend on the wakeup actually arriving.
+// from setns otherwise). So this waits by checking whether the path is an
+// nsfs mount (statfs) every netnsReadyRecheckInterval.
 func WaitNetNSReady(name string, timeout time.Duration) error {
 	path := name
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(netnsDir, name)
 	}
-
-	// The poll baseline (mount-table generation counter) is established when
-	// the file is opened, so a mount landing any time after this open is
-	// guaranteed to wake the poll below. No reads or parsing are needed.
-	mounts, err := os.Open("/proc/self/mountinfo")
-	if err != nil {
-		return fmt.Errorf("failed to open mountinfo: %w", err)
-	}
-	defer mounts.Close()
 
 	deadline := time.Now().Add(timeout)
 	for {
@@ -271,14 +259,7 @@ func WaitNetNSReady(name string, timeout time.Duration) error {
 		if remaining <= 0 {
 			return fmt.Errorf("timed out waiting for netns %q to be mounted", name)
 		}
-		ms := int(min(remaining, netnsReadyRecheckInterval).Milliseconds())
-		if ms < 1 {
-			ms = 1
-		}
-		pfds := []unix.PollFd{{Fd: int32(mounts.Fd()), Events: unix.POLLPRI}}
-		if _, err := unix.Poll(pfds, ms); err != nil && !errors.Is(err, unix.EINTR) {
-			return fmt.Errorf("failed to poll mountinfo: %w", err)
-		}
+		time.Sleep(min(remaining, netnsReadyRecheckInterval))
 	}
 }
 

--- a/netns_watch_linux.go
+++ b/netns_watch_linux.go
@@ -5,6 +5,7 @@ package rdns
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -14,7 +15,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const netnsDir = "/var/run/netns"
+// netnsDir is where "ip netns" mounts named network namespaces. It is a var
+// so tests can point it at a temporary directory.
+var netnsDir = "/var/run/netns"
 
 // NetNSState represents whether a Linux network namespace is currently
 // present in the filesystem.
@@ -35,6 +38,7 @@ type netnsSubscriber struct {
 type netnsWatcher struct {
 	mu   sync.Mutex
 	fd   int
+	dir  string // directory holding the namespace files, netnsDir
 	subs []*netnsSubscriber
 }
 
@@ -65,18 +69,21 @@ func newNetNSWatcher() (*netnsWatcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	w := &netnsWatcher{fd: fd}
+	w := &netnsWatcher{fd: fd, dir: netnsDir}
 	go w.read()
 	go w.ensureWatch()
 	return w, nil
 }
 
-// ensureWatch installs the inotify watch on the netns directory, retrying
-// with a slow backoff if the directory does not yet exist.
+// ensureWatch installs the inotify watch on the netns directory. The directory
+// itself is created by the first "ip netns add" after boot, so when it doesn't
+// exist yet, its creation is awaited via an inotify watch on the parent
+// directory rather than by polling.
 func (w *netnsWatcher) ensureWatch() {
 	const mask = unix.IN_CREATE | unix.IN_DELETE | unix.IN_MOVED_TO | unix.IN_MOVED_FROM
 	for {
-		if _, err := unix.InotifyAddWatch(w.fd, netnsDir, mask); err == nil {
+		_, err := unix.InotifyAddWatch(w.fd, w.dir, mask)
+		if err == nil {
 			// Re-sync every subscriber: events that occurred before the
 			// watch was installed (e.g. while the directory didn't exist
 			// yet) were missed. notifyLocked drops any state that hasn't
@@ -84,14 +91,50 @@ func (w *netnsWatcher) ensureWatch() {
 			// namespace.
 			w.mu.Lock()
 			for _, s := range w.subs {
-				w.notifyLocked(s, currentNetNSState(s.name))
+				w.notifyLocked(s, w.currentState(s.name))
 			}
 			w.mu.Unlock()
 			return
-		} else if !errors.Is(err, unix.ENOENT) {
-			Log.Warn("netns watcher: inotify_add_watch failed", "dir", netnsDir, "error", err)
 		}
+		if errors.Is(err, unix.ENOENT) {
+			waitForDir(w.dir)
+			continue
+		}
+		Log.Warn("netns watcher: inotify_add_watch failed", "dir", w.dir, "error", err)
 		time.Sleep(5 * time.Second)
+	}
+}
+
+// waitForDir blocks until dir exists, watching its parent directory with a
+// dedicated inotify instance so the wait is event-driven. If the parent can't
+// be watched, it falls back to polling slowly.
+func waitForDir(dir string) {
+	fd, err := unix.InotifyInit1(unix.IN_CLOEXEC)
+	if err == nil {
+		defer unix.Close(fd)
+		_, err = unix.InotifyAddWatch(fd, filepath.Dir(dir), unix.IN_CREATE|unix.IN_MOVED_TO)
+	}
+	if err != nil {
+		Log.Warn("netns watcher: can't watch for netns directory creation, polling", "dir", dir, "error", err)
+		for {
+			if _, err := os.Stat(dir); err == nil {
+				return
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}
+	// Stat before each read: the directory may have been created before the
+	// parent watch became active, and an event arriving between the stat and
+	// the read just makes the read return immediately.
+	buf := make([]byte, 4096)
+	for {
+		if _, err := os.Stat(dir); err == nil {
+			return
+		}
+		if _, err := unix.Read(fd, buf); err != nil && !errors.Is(err, unix.EINTR) {
+			Log.Warn("netns watcher: parent watch read failed, polling", "dir", dir, "error", err)
+			time.Sleep(5 * time.Second)
+		}
 	}
 }
 
@@ -151,7 +194,7 @@ func (w *netnsWatcher) dispatch(name string, state NetNSState) {
 
 func (w *netnsWatcher) subscribe(name string) (<-chan NetNSState, func()) {
 	s := &netnsSubscriber{name: name, ch: make(chan NetNSState, 16)}
-	state := currentNetNSState(name)
+	state := w.currentState(name)
 
 	w.mu.Lock()
 	w.subs = append(w.subs, s)
@@ -174,8 +217,67 @@ func (w *netnsWatcher) subscribe(name string) (<-chan NetNSState, func()) {
 	return s.ch, cancel
 }
 
-func currentNetNSState(name string) NetNSState {
-	if _, err := os.Stat(filepath.Join(netnsDir, name)); err == nil {
+// WaitNetNSReady blocks until the named network namespace is fully set up and
+// usable, the namespace file disappears, or the timeout expires. name is
+// either a namespace name under /var/run/netns or an absolute path.
+//
+// "ip netns add" is not atomic: it first creates a placeholder file (which is
+// what fires the inotify CREATE event the watcher reacts to), then bind-mounts
+// the actual namespace onto it. In the gap between the two, opening the path
+// fails (EACCES on the mode-000 placeholder for a non-root process, EINVAL
+// from setns otherwise). The bind mount completing fires no inotify event, but
+// it does change the mount table, and the kernel signals POLLPRI on
+// /proc/self/mountinfo whenever that happens. So this waits by checking
+// whether the path is an nsfs mount (statfs) and sleeping on a mountinfo poll
+// between checks — entirely event-driven, no retry intervals.
+func WaitNetNSReady(name string, timeout time.Duration) error {
+	path := name
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(netnsDir, name)
+	}
+
+	// The poll baseline (mount-table generation counter) is established when
+	// the file is opened, so a mount landing any time after this open is
+	// guaranteed to wake the poll below. No reads or parsing are needed.
+	mounts, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return fmt.Errorf("failed to open mountinfo: %w", err)
+	}
+	defer mounts.Close()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		var st unix.Statfs_t
+		err := unix.Statfs(path, &st)
+		switch {
+		case err == nil && st.Type == unix.NSFS_MAGIC:
+			return nil // the real namespace is mounted over the placeholder
+		case errors.Is(err, unix.ENOENT):
+			return fmt.Errorf("netns %q does not exist", name)
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return fmt.Errorf("timed out waiting for netns %q to be mounted", name)
+		}
+		ms := int(remaining.Milliseconds())
+		if ms < 1 {
+			ms = 1
+		}
+		pfds := []unix.PollFd{{Fd: int32(mounts.Fd()), Events: unix.POLLPRI}}
+		if _, err := unix.Poll(pfds, ms); err != nil && !errors.Is(err, unix.EINTR) {
+			return fmt.Errorf("failed to poll mountinfo: %w", err)
+		}
+	}
+}
+
+// currentState reports whether the named namespace file currently exists.
+func (w *netnsWatcher) currentState(name string) NetNSState {
+	dir := w.dir
+	if dir == "" {
+		dir = netnsDir
+	}
+	if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
 		return NetNSPresent
 	}
 	return NetNSAbsent

--- a/netns_watch_linux.go
+++ b/netns_watch_linux.go
@@ -19,6 +19,15 @@ import (
 // so tests can point it at a temporary directory.
 var netnsDir = "/var/run/netns"
 
+// netnsPath resolves a namespace reference to a filesystem path: an absolute
+// path is used as-is, anything else is looked up under netnsDir.
+func netnsPath(name string) string {
+	if filepath.IsAbs(name) {
+		return name
+	}
+	return filepath.Join(netnsDir, name)
+}
+
 // NetNSState represents whether a Linux network namespace is currently
 // present in the filesystem.
 type NetNSState int
@@ -38,7 +47,6 @@ type netnsSubscriber struct {
 type netnsWatcher struct {
 	mu   sync.Mutex
 	fd   int
-	dir  string // directory holding the namespace files, netnsDir
 	subs []*netnsSubscriber
 }
 
@@ -80,7 +88,7 @@ func newNetNSWatcher() (*netnsWatcher, error) {
 		}
 		return nil, fmt.Errorf("failed to watch %s: %w", netnsDir, err)
 	}
-	w := &netnsWatcher{fd: fd, dir: netnsDir}
+	w := &netnsWatcher{fd: fd}
 	go w.read()
 	return w, nil
 }
@@ -141,7 +149,7 @@ func (w *netnsWatcher) dispatch(name string, state NetNSState) {
 
 func (w *netnsWatcher) subscribe(name string) (<-chan NetNSState, func()) {
 	s := &netnsSubscriber{name: name, ch: make(chan NetNSState, 16)}
-	state := w.currentState(name)
+	state := currentNetNSState(name)
 
 	w.mu.Lock()
 	w.subs = append(w.subs, s)
@@ -186,10 +194,7 @@ const netnsReadyRecheckInterval = 10 * time.Millisecond
 // from setns otherwise). So this waits by checking whether the path is an
 // nsfs mount (statfs) every netnsReadyRecheckInterval.
 func WaitNetNSReady(name string, timeout time.Duration) error {
-	path := name
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(netnsDir, name)
-	}
+	path := netnsPath(name)
 
 	deadline := time.Now().Add(timeout)
 	for {
@@ -210,13 +215,9 @@ func WaitNetNSReady(name string, timeout time.Duration) error {
 	}
 }
 
-// currentState reports whether the named namespace file currently exists.
-func (w *netnsWatcher) currentState(name string) NetNSState {
-	dir := w.dir
-	if dir == "" {
-		dir = netnsDir
-	}
-	if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+// currentNetNSState reports whether the named namespace file currently exists.
+func currentNetNSState(name string) NetNSState {
+	if _, err := os.Stat(netnsPath(name)); err == nil {
 		return NetNSPresent
 	}
 	return NetNSAbsent

--- a/netns_watch_linux.go
+++ b/netns_watch_linux.go
@@ -50,9 +50,12 @@ var (
 
 // SubscribeNetNS returns a channel that receives state changes for the named
 // network namespace, plus a cancel function to unsubscribe. name must be a
-// namespace name under /var/run/netns, not an absolute path. The current state
-// is delivered immediately on subscription, even if /var/run/netns does not
-// exist yet; subsequent values reflect changes.
+// namespace name under /var/run/netns, not an absolute path. The current
+// state is delivered immediately on subscription; subsequent values reflect
+// changes. It fails if /var/run/netns does not exist: the directory is
+// created by the first "ip netns add" after boot, so routedns must either be
+// started after that or the directory created beforehand (e.g. with
+// "ExecStartPre=+mkdir -p /run/netns" in a systemd unit).
 func SubscribeNetNS(name string) (<-chan NetNSState, func(), error) {
 	nsWatcherOnce.Do(func() {
 		nsWatcher, nsWatcherErr = newNetNSWatcher()
@@ -69,73 +72,17 @@ func newNetNSWatcher() (*netnsWatcher, error) {
 	if err != nil {
 		return nil, err
 	}
+	const mask = unix.IN_CREATE | unix.IN_DELETE | unix.IN_MOVED_TO | unix.IN_MOVED_FROM
+	if _, err := unix.InotifyAddWatch(fd, netnsDir, mask); err != nil {
+		unix.Close(fd)
+		if errors.Is(err, unix.ENOENT) {
+			return nil, fmt.Errorf("netns directory %s does not exist; create it before starting routedns, or start routedns after the first \"ip netns add\"", netnsDir)
+		}
+		return nil, fmt.Errorf("failed to watch %s: %w", netnsDir, err)
+	}
 	w := &netnsWatcher{fd: fd, dir: netnsDir}
 	go w.read()
-	go w.ensureWatch()
 	return w, nil
-}
-
-// ensureWatch installs the inotify watch on the netns directory. The directory
-// itself is created by the first "ip netns add" after boot, so when it doesn't
-// exist yet, its creation is awaited via an inotify watch on the parent
-// directory rather than by polling.
-func (w *netnsWatcher) ensureWatch() {
-	const mask = unix.IN_CREATE | unix.IN_DELETE | unix.IN_MOVED_TO | unix.IN_MOVED_FROM
-	for {
-		_, err := unix.InotifyAddWatch(w.fd, w.dir, mask)
-		if err == nil {
-			// Re-sync every subscriber: events that occurred before the
-			// watch was installed (e.g. while the directory didn't exist
-			// yet) were missed. notifyLocked drops any state that hasn't
-			// actually changed, so this won't re-warn for an unchanged
-			// namespace.
-			w.mu.Lock()
-			for _, s := range w.subs {
-				w.notifyLocked(s, w.currentState(s.name))
-			}
-			w.mu.Unlock()
-			return
-		}
-		if errors.Is(err, unix.ENOENT) {
-			waitForDir(w.dir)
-			continue
-		}
-		Log.Warn("netns watcher: inotify_add_watch failed", "dir", w.dir, "error", err)
-		time.Sleep(5 * time.Second)
-	}
-}
-
-// waitForDir blocks until dir exists, watching its parent directory with a
-// dedicated inotify instance so the wait is event-driven. If the parent can't
-// be watched, it falls back to polling slowly.
-func waitForDir(dir string) {
-	fd, err := unix.InotifyInit1(unix.IN_CLOEXEC)
-	if err == nil {
-		defer unix.Close(fd)
-		_, err = unix.InotifyAddWatch(fd, filepath.Dir(dir), unix.IN_CREATE|unix.IN_MOVED_TO)
-	}
-	if err != nil {
-		Log.Warn("netns watcher: can't watch for netns directory creation, polling", "dir", dir, "error", err)
-		for {
-			if _, err := os.Stat(dir); err == nil {
-				return
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}
-	// Stat before each read: the directory may have been created before the
-	// parent watch became active, and an event arriving between the stat and
-	// the read just makes the read return immediately.
-	buf := make([]byte, 4096)
-	for {
-		if _, err := os.Stat(dir); err == nil {
-			return
-		}
-		if _, err := unix.Read(fd, buf); err != nil && !errors.Is(err, unix.EINTR) {
-			Log.Warn("netns watcher: parent watch read failed, polling", "dir", dir, "error", err)
-			time.Sleep(5 * time.Second)
-		}
-	}
 }
 
 // read pulls events from the inotify fd and dispatches them to subscribers.

--- a/netns_watch_linux_test.go
+++ b/netns_watch_linux_test.go
@@ -14,6 +14,16 @@ import (
 
 const testNonexistentNS = "rdns-test-nonexistent-namespace"
 
+// setTestNetNSDir points netnsDir at a path under a temporary directory for
+// the duration of the test and returns it. The directory itself is not
+// created.
+func setTestNetNSDir(t *testing.T) string {
+	old := netnsDir
+	netnsDir = filepath.Join(t.TempDir(), "netns")
+	t.Cleanup(func() { netnsDir = old })
+	return netnsDir
+}
+
 // Subscribing must deliver the current state immediately, so the supervisor
 // logs "waiting" right away for a namespace that doesn't exist yet.
 func TestNetNSWatcherSubscribeDeliversInitialState(t *testing.T) {
@@ -35,9 +45,7 @@ func TestNetNSWatcherSubscribeDeliversInitialState(t *testing.T) {
 // directory is created by the first "ip netns add" after boot; starting
 // routedns before that is a setup error the user has to resolve.
 func TestNetNSWatcherMissingDir(t *testing.T) {
-	oldDir := netnsDir
-	netnsDir = filepath.Join(t.TempDir(), "netns")
-	defer func() { netnsDir = oldDir }()
+	setTestNetNSDir(t)
 
 	_, err := newNetNSWatcher()
 	require.ErrorContains(t, err, "does not exist")
@@ -46,10 +54,8 @@ func TestNetNSWatcherMissingDir(t *testing.T) {
 // A namespace file created after the watcher starts must be detected via the
 // inotify event, not a polling interval.
 func TestNetNSWatcherDetectsCreation(t *testing.T) {
-	oldDir := netnsDir
-	netnsDir = filepath.Join(t.TempDir(), "netns")
-	defer func() { netnsDir = oldDir }()
-	require.NoError(t, os.Mkdir(netnsDir, 0o755))
+	dir := setTestNetNSDir(t)
+	require.NoError(t, os.Mkdir(dir, 0o755))
 
 	w, err := newNetNSWatcher()
 	require.NoError(t, err)

--- a/netns_watch_linux_test.go
+++ b/netns_watch_linux_test.go
@@ -125,6 +125,30 @@ func TestWaitNetNSReadyTimeout(t *testing.T) {
 	require.GreaterOrEqual(t, time.Since(start), 100*time.Millisecond, "should have waited for the timeout")
 }
 
+// A namespace file deleted while waiting must be detected within the bounded
+// re-check interval, not only when the timeout expires. Deleting a plain file
+// changes no mount state, so no mountinfo poll wakeup ever arrives for it —
+// this is what happens when a "namespace creator" service gives up and cleans
+// up its namespace while the wait is in progress. The same bounded re-check
+// covers namespace mounts that become visible without waking the poll, e.g.
+// mounts propagated from the host into a sandboxed (slave) mount namespace on
+// kernels that don't propagate the wakeup.
+func TestWaitNetNSReadyDetectsDeletionWhileWaiting(t *testing.T) {
+	placeholder := filepath.Join(t.TempDir(), "ns")
+	require.NoError(t, os.WriteFile(placeholder, nil, 0o000))
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		os.Remove(placeholder)
+	}()
+
+	start := time.Now()
+	err := WaitNetNSReady(placeholder, 5*time.Second)
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	require.Less(t, elapsed, time.Second, "deletion should be detected by the bounded re-check, not the timeout")
+}
+
 // The poll on /proc/self/mountinfo must wake up when the namespace is
 // bind-mounted over the placeholder, completing the wait without any retry
 // interval. This is the exact sequence "ip netns add" performs. Requires root.

--- a/netns_watch_linux_test.go
+++ b/netns_watch_linux_test.go
@@ -26,7 +26,7 @@ func TestNetNSWatcherSubscribeDeliversInitialState(t *testing.T) {
 	case state := <-ch:
 		require.Equal(t, NetNSAbsent, state)
 	case <-time.After(time.Second):
-		t.Fatal("expected initial state on subscribe, got none")
+		require.Fail(t, "expected initial state on subscribe, got none")
 	}
 }
 
@@ -66,7 +66,7 @@ func TestNetNSWatcherDetectsCreation(t *testing.T) {
 	case state := <-ch:
 		require.Equal(t, NetNSPresent, state)
 	case <-time.After(2 * time.Second):
-		t.Fatal("namespace creation not detected")
+		require.Fail(t, "namespace creation not detected")
 	}
 }
 
@@ -85,7 +85,7 @@ func TestNetNSWatcherDeduplicatesState(t *testing.T) {
 	w.dispatch(testNonexistentNS, NetNSAbsent)
 	select {
 	case <-ch:
-		t.Fatal("duplicate Absent should have been deduplicated")
+		require.Fail(t, "duplicate Absent should have been deduplicated")
 	case <-time.After(100 * time.Millisecond):
 	}
 
@@ -95,7 +95,7 @@ func TestNetNSWatcherDeduplicatesState(t *testing.T) {
 	case state := <-ch:
 		require.Equal(t, NetNSPresent, state)
 	case <-time.After(time.Second):
-		t.Fatal("expected NetNSPresent to be delivered")
+		require.Fail(t, "expected NetNSPresent to be delivered")
 	}
 }
 

--- a/netns_watch_linux_test.go
+++ b/netns_watch_linux_test.go
@@ -125,14 +125,10 @@ func TestWaitNetNSReadyTimeout(t *testing.T) {
 	require.GreaterOrEqual(t, time.Since(start), 100*time.Millisecond, "should have waited for the timeout")
 }
 
-// A namespace file deleted while waiting must be detected within the bounded
-// re-check interval, not only when the timeout expires. Deleting a plain file
-// changes no mount state, so no mountinfo poll wakeup ever arrives for it —
-// this is what happens when a "namespace creator" service gives up and cleans
-// up its namespace while the wait is in progress. The same bounded re-check
-// covers namespace mounts that become visible without waking the poll, e.g.
-// mounts propagated from the host into a sandboxed (slave) mount namespace on
-// kernels that don't propagate the wakeup.
+// A namespace file deleted while waiting must be detected within the re-check
+// interval, not only when the timeout expires. This is what happens when a
+// "namespace creator" service gives up and cleans up its namespace while the
+// wait is in progress.
 func TestWaitNetNSReadyDetectsDeletionWhileWaiting(t *testing.T) {
 	placeholder := filepath.Join(t.TempDir(), "ns")
 	require.NoError(t, os.WriteFile(placeholder, nil, 0o000))
@@ -149,9 +145,9 @@ func TestWaitNetNSReadyDetectsDeletionWhileWaiting(t *testing.T) {
 	require.Less(t, elapsed, time.Second, "deletion should be detected by the bounded re-check, not the timeout")
 }
 
-// The poll on /proc/self/mountinfo must wake up when the namespace is
-// bind-mounted over the placeholder, completing the wait without any retry
-// interval. This is the exact sequence "ip netns add" performs. Requires root.
+// The wait must complete promptly once the namespace is bind-mounted over the
+// placeholder. This is the exact sequence "ip netns add" performs. Requires
+// root.
 func TestWaitNetNSReadyOnMount(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("requires root to bind-mount a namespace")

--- a/netns_watch_linux_test.go
+++ b/netns_watch_linux_test.go
@@ -3,10 +3,13 @@
 package rdns
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 const testNonexistentNS = "rdns-test-nonexistent-namespace"
@@ -26,6 +29,38 @@ func TestNetNSWatcherSubscribeDeliversInitialState(t *testing.T) {
 		require.Equal(t, NetNSAbsent, state)
 	case <-time.After(time.Second):
 		t.Fatal("expected initial state on subscribe, got none")
+	}
+}
+
+// The watcher must become active promptly when the netns directory itself is
+// created after startup. After a reboot, /var/run/netns doesn't exist until
+// the first "ip netns add" creates it, and a namespace created moments later
+// must still be picked up immediately — not after a polling interval.
+func TestNetNSWatcherDetectsDirCreation(t *testing.T) {
+	oldDir := netnsDir
+	netnsDir = filepath.Join(t.TempDir(), "netns")
+	defer func() { netnsDir = oldDir }()
+
+	w, err := newNetNSWatcher()
+	require.NoError(t, err)
+
+	ch, cancel := w.subscribe("testns")
+	defer cancel()
+
+	// Initial state: directory doesn't exist, namespace is absent.
+	require.Equal(t, NetNSAbsent, <-ch)
+
+	// Create the directory and a namespace file in it, like the first
+	// "ip netns add" after boot does.
+	require.NoError(t, os.Mkdir(netnsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(netnsDir, "testns"), nil, 0o000))
+
+	// Present must be delivered well within the old 5s polling interval.
+	select {
+	case state := <-ch:
+		require.Equal(t, NetNSPresent, state)
+	case <-time.After(2 * time.Second):
+		t.Fatal("namespace creation not detected after netns directory appeared")
 	}
 }
 
@@ -56,4 +91,65 @@ func TestNetNSWatcherDeduplicatesState(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected NetNSPresent to be delivered")
 	}
+}
+
+// A path that is already an nsfs mount must be reported ready immediately.
+// /proc/self/ns/net is nsfs without requiring any privileges or mounts.
+func TestWaitNetNSReadyImmediate(t *testing.T) {
+	start := time.Now()
+	err := WaitNetNSReady("/proc/self/ns/net", 5*time.Second)
+	require.NoError(t, err)
+	require.Less(t, time.Since(start), time.Second, "ready namespace should be detected without waiting")
+}
+
+// A namespace that doesn't exist must fail immediately, not burn the timeout,
+// so the supervisor reacts quickly when a namespace is deleted right after
+// being created.
+func TestWaitNetNSReadyNonexistent(t *testing.T) {
+	start := time.Now()
+	err := WaitNetNSReady(testNonexistentNS, 5*time.Second)
+	require.Error(t, err)
+	require.Less(t, time.Since(start), time.Second, "missing namespace should fail without waiting")
+}
+
+// A file that exists but never becomes a namespace mount (like the placeholder
+// "ip netns add" creates first, or a stray file) must time out rather than
+// hang forever.
+func TestWaitNetNSReadyTimeout(t *testing.T) {
+	placeholder := filepath.Join(t.TempDir(), "ns")
+	require.NoError(t, os.WriteFile(placeholder, nil, 0o000))
+
+	start := time.Now()
+	err := WaitNetNSReady(placeholder, 100*time.Millisecond)
+	require.Error(t, err)
+	require.GreaterOrEqual(t, time.Since(start), 100*time.Millisecond, "should have waited for the timeout")
+}
+
+// The poll on /proc/self/mountinfo must wake up when the namespace is
+// bind-mounted over the placeholder, completing the wait without any retry
+// interval. This is the exact sequence "ip netns add" performs. Requires root.
+func TestWaitNetNSReadyOnMount(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to bind-mount a namespace")
+	}
+
+	placeholder := filepath.Join(t.TempDir(), "ns")
+	require.NoError(t, os.WriteFile(placeholder, nil, 0o000))
+
+	// Bind-mount the real namespace over the placeholder after a delay,
+	// mirroring the non-atomic behavior of "ip netns add".
+	errC := make(chan error, 1)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		errC <- unix.Mount("/proc/self/ns/net", placeholder, "none", unix.MS_BIND, "")
+	}()
+	defer unix.Unmount(placeholder, unix.MNT_DETACH) //nolint:errcheck
+
+	start := time.Now()
+	err := WaitNetNSReady(placeholder, 5*time.Second)
+	require.NoError(t, <-errC, "bind mount failed")
+	require.NoError(t, err)
+	elapsed := time.Since(start)
+	require.GreaterOrEqual(t, elapsed, 50*time.Millisecond, "must not report ready before the mount")
+	require.Less(t, elapsed, time.Second, "must wake up promptly when the mount lands")
 }

--- a/netns_watch_linux_test.go
+++ b/netns_watch_linux_test.go
@@ -14,12 +14,10 @@ import (
 
 const testNonexistentNS = "rdns-test-nonexistent-namespace"
 
-// Subscribing must deliver the current state immediately, without waiting for
-// the inotify watch to be installed. This is the case that previously logged
-// nothing at startup when /var/run/netns did not exist yet: the watch never
-// became active, so no initial state was ever delivered.
+// Subscribing must deliver the current state immediately, so the supervisor
+// logs "waiting" right away for a namespace that doesn't exist yet.
 func TestNetNSWatcherSubscribeDeliversInitialState(t *testing.T) {
-	w := &netnsWatcher{} // no read/ensureWatch goroutines started
+	w := &netnsWatcher{} // no watch installed, no read goroutine started
 
 	ch, cancel := w.subscribe(testNonexistentNS)
 	defer cancel()
@@ -32,14 +30,26 @@ func TestNetNSWatcherSubscribeDeliversInitialState(t *testing.T) {
 	}
 }
 
-// The watcher must become active promptly when the netns directory itself is
-// created after startup. After a reboot, /var/run/netns doesn't exist until
-// the first "ip netns add" creates it, and a namespace created moments later
-// must still be picked up immediately — not after a polling interval.
-func TestNetNSWatcherDetectsDirCreation(t *testing.T) {
+// When the netns directory doesn't exist, the watcher must fail with a clear
+// error rather than watching or polling for the directory's creation. The
+// directory is created by the first "ip netns add" after boot; starting
+// routedns before that is a setup error the user has to resolve.
+func TestNetNSWatcherMissingDir(t *testing.T) {
 	oldDir := netnsDir
 	netnsDir = filepath.Join(t.TempDir(), "netns")
 	defer func() { netnsDir = oldDir }()
+
+	_, err := newNetNSWatcher()
+	require.ErrorContains(t, err, "does not exist")
+}
+
+// A namespace file created after the watcher starts must be detected via the
+// inotify event, not a polling interval.
+func TestNetNSWatcherDetectsCreation(t *testing.T) {
+	oldDir := netnsDir
+	netnsDir = filepath.Join(t.TempDir(), "netns")
+	defer func() { netnsDir = oldDir }()
+	require.NoError(t, os.Mkdir(netnsDir, 0o755))
 
 	w, err := newNetNSWatcher()
 	require.NoError(t, err)
@@ -47,20 +57,17 @@ func TestNetNSWatcherDetectsDirCreation(t *testing.T) {
 	ch, cancel := w.subscribe("testns")
 	defer cancel()
 
-	// Initial state: directory doesn't exist, namespace is absent.
+	// Initial state: namespace file doesn't exist yet.
 	require.Equal(t, NetNSAbsent, <-ch)
 
-	// Create the directory and a namespace file in it, like the first
-	// "ip netns add" after boot does.
-	require.NoError(t, os.Mkdir(netnsDir, 0o755))
+	// Create the namespace file like "ip netns add" does.
 	require.NoError(t, os.WriteFile(filepath.Join(netnsDir, "testns"), nil, 0o000))
 
-	// Present must be delivered well within the old 5s polling interval.
 	select {
 	case state := <-ch:
 		require.Equal(t, NetNSPresent, state)
 	case <-time.After(2 * time.Second):
-		t.Fatal("namespace creation not detected after netns directory appeared")
+		t.Fatal("namespace creation not detected")
 	}
 }
 
@@ -75,7 +82,7 @@ func TestNetNSWatcherDeduplicatesState(t *testing.T) {
 	// Drain the initial Absent.
 	require.Equal(t, NetNSAbsent, <-ch)
 
-	// A duplicate Absent (e.g. ensureWatch's re-sync) must be deduplicated.
+	// A duplicate Absent (e.g. a repeated event) must be deduplicated.
 	w.dispatch(testNonexistentNS, NetNSAbsent)
 	select {
 	case <-ch:

--- a/netns_watch_linux_test.go
+++ b/netns_watch_linux_test.go
@@ -14,16 +14,6 @@ import (
 
 const testNonexistentNS = "rdns-test-nonexistent-namespace"
 
-// setTestNetNSDir points netnsDir at a path under a temporary directory for
-// the duration of the test and returns it. The directory itself is not
-// created.
-func setTestNetNSDir(t *testing.T) string {
-	old := netnsDir
-	netnsDir = filepath.Join(t.TempDir(), "netns")
-	t.Cleanup(func() { netnsDir = old })
-	return netnsDir
-}
-
 // Subscribing must deliver the current state immediately, so the supervisor
 // logs "waiting" right away for a namespace that doesn't exist yet.
 func TestNetNSWatcherSubscribeDeliversInitialState(t *testing.T) {
@@ -45,7 +35,9 @@ func TestNetNSWatcherSubscribeDeliversInitialState(t *testing.T) {
 // directory is created by the first "ip netns add" after boot; starting
 // routedns before that is a setup error the user has to resolve.
 func TestNetNSWatcherMissingDir(t *testing.T) {
-	setTestNetNSDir(t)
+	old := netnsDir
+	netnsDir = filepath.Join(t.TempDir(), "netns") // doesn't exist
+	t.Cleanup(func() { netnsDir = old })
 
 	_, err := newNetNSWatcher()
 	require.ErrorContains(t, err, "does not exist")
@@ -54,8 +46,9 @@ func TestNetNSWatcherMissingDir(t *testing.T) {
 // A namespace file created after the watcher starts must be detected via the
 // inotify event, not a polling interval.
 func TestNetNSWatcherDetectsCreation(t *testing.T) {
-	dir := setTestNetNSDir(t)
-	require.NoError(t, os.Mkdir(dir, 0o755))
+	old := netnsDir
+	netnsDir = t.TempDir()
+	t.Cleanup(func() { netnsDir = old })
 
 	w, err := newNetNSWatcher()
 	require.NoError(t, err)

--- a/netns_watch_other.go
+++ b/netns_watch_other.go
@@ -2,7 +2,10 @@
 
 package rdns
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type NetNSState int
 
@@ -13,4 +16,8 @@ const (
 
 func SubscribeNetNS(name string) (<-chan NetNSState, func(), error) {
 	return nil, nil, fmt.Errorf("network namespaces are only supported on Linux")
+}
+
+func WaitNetNSReady(name string, timeout time.Duration) error {
+	return fmt.Errorf("network namespaces are only supported on Linux")
 }


### PR DESCRIPTION
## Problem

Reported in #522 and addressed with timed retries in #562: a "namespace creator" service that runs `ip netns add` and immediately issues a DNS query races RouteDNS's listener bind. Any retry-interval approach wins or loses that race depending on timing (see discussion in #562).

There are actually two distinct windows where the listener isn't bound yet:

1. **Placeholder gap**: `ip netns add` is not atomic. It creates a mode-000 placeholder file (which fires the inotify CREATE event the watcher reacts to), then bind-mounts the real namespace onto it. Binds attempted in the gap fail with `EACCES`/`EINVAL`.
2. **Missing directory**: after a reboot, `/var/run/netns` itself doesn't exist until the first `ip netns add` creates it. The watcher polled for the directory every 5 seconds, so the first namespace created after startup could go unnoticed for up to 5s — a much larger window than the placeholder gap.

## Fix

Replace both timing-based waits with event-driven ones, eliminating retry intervals entirely:

- **`WaitNetNSReady`** (new in `netns_watch_linux.go`): after the namespace file appears, the supervisor waits for it to become an actual nsfs mount, checked with `statfs` + `NSFS_MAGIC`. The wait sleeps on `poll(POLLPRI)` on `/proc/self/mountinfo`, which the kernel signals whenever the mount table changes — so the wakeup happens at the moment the bind mount lands. This is the `/proc/self/mountinfo` approach suggested in the #562 discussion.
- **`waitForDir`**: when `/var/run/netns` doesn't exist, watch its parent directory with inotify for its creation instead of polling every 5s.

Both have fallbacks (timeout, slow polling) for pathological cases, but in normal operation no timer ever fires and no warning is logged while a namespace is being set up.

### Bounded re-check (added after testing feedback)

The mountinfo poll wakeup is not guaranteed in every environment: when RouteDNS runs inside its own mount namespace (the bundled systemd unit uses `DynamicUser=true`, which sandboxes the service), the namespace mount made by `ip` on the host has to *propagate* into RouteDNS's mount namespace, and on some kernels that propagation doesn't wake mountinfo pollers. Deleting the namespace file (a creator service cleaning up after a failed query) changes no mount state at all, so it can't wake the poll either.

Each poll is therefore capped at **10ms**, after which the path is re-checked. Where the wakeup works the listener still binds in ~1ms; where it doesn't, the worst case is ~10ms — bounded, and not a tunable race. A namespace deleted mid-wait is detected within the same bound instead of stalling until the 5s timeout.

## Result

Verified end-to-end with a real `ip netns add` + immediate query (the reported scenario), including the post-reboot case where `/run/netns` doesn't exist when RouteDNS starts:

```
22:06:05.219  netns present, starting listener   <- ip netns add
22:06:05.220  starting listener  proto=udp addr=127.0.0.1:5399
22:06:05.421  received query / answered          <- creator's first query
```

The listener binds **~1ms** after `ip netns add`, before the creator service can issue its first query, with no warnings logged. Rapid delete/recreate cycles behave the same.

## Changes

- `netns_watch_linux.go`: add `WaitNetNSReady` (statfs/NSFS_MAGIC + mountinfo poll); replace the 5s directory poll in `ensureWatch` with a parent-directory inotify watch
- `netns_watch_other.go`: non-Linux stub
- `cmd/routedns/main.go`: supervisor waits for namespace readiness before starting the listener
- Tests for readiness detection (immediate, missing, timeout, mount-wakeup [root-only]), directory-creation detection, and supervisor gating

Supersedes #562.
