### PR TITLE
Convert tests to testify and use synctest in fastest tests

### DIFF
--- a/cache-redis_test.go
+++ b/cache-redis_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
 )
 
 // The Redis cache key must distinguish CD=0 from CD=1 (RFC 4035 §4.7 /
@@ -21,9 +22,7 @@ func TestRedisKeyFromQuery(t *testing.T) {
 		q.CheckingDisabled = cd
 		return q
 	}
-	if b.keyFromQuery(queryCD(false)) == b.keyFromQuery(queryCD(true)) {
-		t.Fatal("CD=0 and CD=1 queries produced the same Redis cache key")
-	}
+	require.NotEqual(t, b.keyFromQuery(queryCD(false)), b.keyFromQuery(queryCD(true)), "CD=0 and CD=1 queries produced the same Redis cache key")
 
 	queryECS := func(mask uint8) *dns.Msg {
 		q := new(dns.Msg)
@@ -37,9 +36,7 @@ func TestRedisKeyFromQuery(t *testing.T) {
 		q.IsEdns0().Option = append(q.IsEdns0().Option, ecs)
 		return q
 	}
-	if b.keyFromQuery(queryECS(24)) == b.keyFromQuery(queryECS(16)) {
-		t.Fatal("ECS queries with different source-prefix lengths produced the same Redis cache key")
-	}
+	require.NotEqual(t, b.keyFromQuery(queryECS(24)), b.keyFromQuery(queryECS(16)), "ECS queries with different source-prefix lengths produced the same Redis cache key")
 }
 
 func TestEncodeDecode(t *testing.T) {
@@ -51,9 +48,7 @@ func TestEncodeDecode(t *testing.T) {
 
 	// Add an answer
 	rr, err := dns.NewRR("example.com. 300 IN A 192.0.2.1")
-	if err != nil {
-		t.Fatalf("failed to create RR: %v", err)
-	}
+	require.NoError(t, err)
 	msg.Answer = append(msg.Answer, rr)
 
 	// Create a cacheAnswer
@@ -66,53 +61,30 @@ func TestEncodeDecode(t *testing.T) {
 
 	// Encode
 	encoded, err := encodeCacheAnswer(original)
-	if err != nil {
-		t.Fatalf("encodeCacheAnswer failed: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Verify format
-	if len(encoded) < headerSize {
-		t.Fatalf("encoded data too short: %d bytes", len(encoded))
-	}
+	require.GreaterOrEqual(t, len(encoded), headerSize, "encoded data too short")
 
 	// Check version byte
-	if encoded[0] != binaryFormatVersion {
-		t.Errorf("version byte = %d, want %d", encoded[0], binaryFormatVersion)
-	}
+	require.Equal(t, byte(binaryFormatVersion), encoded[0], "version byte")
 
 	// Check flags byte
 	expectedFlags := byte(flagPrefetchBit)
-	if encoded[1] != expectedFlags {
-		t.Errorf("flags byte = %d, want %d", encoded[1], expectedFlags)
-	}
+	require.Equal(t, expectedFlags, encoded[1], "flags byte")
 
 	// Decode
 	decoded, err := decodeCacheAnswer(encoded)
-	if err != nil {
-		t.Fatalf("decodeCacheAnswer failed: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Verify fields
-	if decoded.Timestamp.Unix() != original.Timestamp.Unix() {
-		t.Errorf("timestamp = %v, want %v", decoded.Timestamp, original.Timestamp)
-	}
-
-	if decoded.PrefetchEligible != original.PrefetchEligible {
-		t.Errorf("prefetchEligible = %v, want %v", decoded.PrefetchEligible, original.PrefetchEligible)
-	}
+	require.Equal(t, original.Timestamp.Unix(), decoded.Timestamp.Unix())
+	require.Equal(t, original.PrefetchEligible, decoded.PrefetchEligible)
 
 	// Verify DNS message
-	if len(decoded.Msg.Answer) != len(original.Msg.Answer) {
-		t.Errorf("answer count = %d, want %d", len(decoded.Msg.Answer), len(original.Msg.Answer))
-	}
-
-	if decoded.Msg.Question[0].Name != original.Msg.Question[0].Name {
-		t.Errorf("question name = %s, want %s", decoded.Msg.Question[0].Name, original.Msg.Question[0].Name)
-	}
-
-	if decoded.Msg.Question[0].Qtype != original.Msg.Question[0].Qtype {
-		t.Errorf("question type = %d, want %d", decoded.Msg.Question[0].Qtype, original.Msg.Question[0].Qtype)
-	}
+	require.Len(t, decoded.Msg.Answer, len(original.Msg.Answer))
+	require.Equal(t, original.Msg.Question[0].Name, decoded.Msg.Question[0].Name)
+	require.Equal(t, original.Msg.Question[0].Qtype, decoded.Msg.Question[0].Qtype)
 }
 
 func TestEncodeDecodeNoPrefetch(t *testing.T) {
@@ -130,24 +102,16 @@ func TestEncodeDecodeNoPrefetch(t *testing.T) {
 
 	// Encode
 	encoded, err := encodeCacheAnswer(original)
-	if err != nil {
-		t.Fatalf("encodeCacheAnswer failed: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Check flags byte (should be 0)
-	if encoded[1] != 0 {
-		t.Errorf("flags byte = %d, want 0", encoded[1])
-	}
+	require.Equal(t, byte(0), encoded[1], "flags byte")
 
 	// Decode
 	decoded, err := decodeCacheAnswer(encoded)
-	if err != nil {
-		t.Fatalf("decodeCacheAnswer failed: %v", err)
-	}
+	require.NoError(t, err)
 
-	if decoded.PrefetchEligible != false {
-		t.Errorf("prefetchEligible = %v, want false", decoded.PrefetchEligible)
-	}
+	require.False(t, decoded.PrefetchEligible)
 }
 
 func TestDecodeInvalidData(t *testing.T) {
@@ -163,9 +127,7 @@ func TestDecodeInvalidData(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := decodeCacheAnswer(tt.data)
-			if err == nil {
-				t.Error("expected error, got nil")
-			}
+			require.Error(t, err)
 		})
 	}
 }
@@ -185,24 +147,16 @@ func TestEncodeDecodePooling(t *testing.T) {
 	// Encode multiple times to test pool reuse
 	for i := range 100 {
 		encoded, err := encodeCacheAnswer(item)
-		if err != nil {
-			t.Fatalf("iteration %d: encodeCacheAnswer failed: %v", i, err)
-		}
+		require.NoError(t, err, "iteration %d", i)
 
 		// Verify first byte is always version
-		if encoded[0] != binaryFormatVersion {
-			t.Errorf("iteration %d: version byte = %d, want %d", i, encoded[0], binaryFormatVersion)
-		}
+		require.Equal(t, byte(binaryFormatVersion), encoded[0], "iteration %d: version byte", i)
 
 		// Decode to verify correctness
 		decoded, err := decodeCacheAnswer(encoded)
-		if err != nil {
-			t.Fatalf("iteration %d: decodeCacheAnswer failed: %v", i, err)
-		}
+		require.NoError(t, err, "iteration %d", i)
 
-		if decoded.Msg.Question[0].Name != "pool.test." {
-			t.Errorf("iteration %d: corrupted data", i)
-		}
+		require.Equal(t, "pool.test.", decoded.Msg.Question[0].Name, "iteration %d: corrupted data", i)
 	}
 }
 
@@ -220,9 +174,7 @@ func TestEncodeReturnsIndependentSlice(t *testing.T) {
 
 	// First encode
 	encoded1, err := encodeCacheAnswer(item)
-	if err != nil {
-		t.Fatalf("first encode failed: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Save a copy of the original encoded data
 	original := make([]byte, len(encoded1))
@@ -235,36 +187,20 @@ func TestEncodeReturnsIndependentSlice(t *testing.T) {
 
 	// Verify the mutated buffer is now garbage and fails to decode
 	_, err = decodeCacheAnswer(encoded1)
-	if err == nil {
-		t.Error("expected decode of mutated buffer to fail, but it succeeded")
-	}
+	require.Error(t, err, "expected decode of mutated buffer to fail")
 
 	// Second encode - should succeed and produce the same result as the first
 	encoded2, err := encodeCacheAnswer(item)
-	if err != nil {
-		t.Fatalf("second encode failed: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Verify second encode matches the original (not corrupted by mutation)
-	if len(encoded2) != len(original) {
-		t.Fatalf("length mismatch: got %d, want %d", len(encoded2), len(original))
-	}
-
-	for i := range original {
-		if encoded2[i] != original[i] {
-			t.Errorf("byte %d: got %02x, want %02x (mutation leaked into pool)", i, encoded2[i], original[i])
-		}
-	}
+	require.Equal(t, original, encoded2, "mutation leaked into pool")
 
 	// Verify we can still decode the second result
 	decoded, err := decodeCacheAnswer(encoded2)
-	if err != nil {
-		t.Fatalf("decode after mutation failed: %v", err)
-	}
+	require.NoError(t, err)
 
-	if decoded.Msg.Question[0].Name != "independent.test." {
-		t.Errorf("decoded name = %s, want independent.test.", decoded.Msg.Question[0].Name)
-	}
+	require.Equal(t, "independent.test.", decoded.Msg.Question[0].Name)
 }
 
 func TestEncodeConcurrent(t *testing.T) {
@@ -324,6 +260,6 @@ func TestEncodeConcurrent(t *testing.T) {
 	close(errs)
 
 	for err := range errs {
-		t.Fatalf("concurrent encode/decode failed: %v", err)
+		require.NoError(t, err, "concurrent encode/decode failed")
 	}
 }

--- a/dnssec-iana_test.go
+++ b/dnssec-iana_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestFetchTrustAnchorsXML(t *testing.T) {
@@ -37,31 +39,17 @@ func TestFetchTrustAnchorsXML(t *testing.T) {
 	defer srv.Close()
 
 	anchors, err := FetchTrustAnchorsFromURL(srv.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Should have 2 anchors: KSK-2017 (no validUntil) and KSK-2024 (validUntil in 2099).
 	// KSK-2010 should be filtered out (validUntil 2019).
-	if len(anchors) != 2 {
-		t.Fatalf("expected 2 anchors, got %d", len(anchors))
-	}
+	require.Len(t, anchors, 2)
 
-	if anchors[0].KeyTag != 20326 {
-		t.Errorf("expected first anchor key-tag 20326, got %d", anchors[0].KeyTag)
-	}
-	if anchors[0].Owner != "." {
-		t.Errorf("expected owner '.', got %q", anchors[0].Owner)
-	}
-	if anchors[1].KeyTag != 38696 {
-		t.Errorf("expected second anchor key-tag 38696, got %d", anchors[1].KeyTag)
-	}
-	if anchors[1].Algorithm != 8 {
-		t.Errorf("expected algorithm 8, got %d", anchors[1].Algorithm)
-	}
-	if anchors[1].DigestType != 2 {
-		t.Errorf("expected digest-type 2, got %d", anchors[1].DigestType)
-	}
+	require.Equal(t, uint16(20326), anchors[0].KeyTag)
+	require.Equal(t, ".", anchors[0].Owner)
+	require.Equal(t, uint16(38696), anchors[1].KeyTag)
+	require.Equal(t, uint8(8), anchors[1].Algorithm)
+	require.Equal(t, uint8(2), anchors[1].DigestType)
 }
 
 func TestIsIANAAnchorValid(t *testing.T) {
@@ -80,9 +68,7 @@ func TestIsIANAAnchorValid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			kd := ianaKeyDigest{ValidUntil: tt.validUntil}
-			if got := isIANAAnchorValid(kd, now); got != tt.want {
-				t.Errorf("isIANAAnchorValid() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, isIANAAnchorValid(kd, now))
 		})
 	}
 }
@@ -94,7 +80,5 @@ func TestFetchTrustAnchorsHTTPError(t *testing.T) {
 	defer srv.Close()
 
 	_, err := FetchTrustAnchorsFromURL(srv.URL)
-	if err == nil {
-		t.Fatal("expected error for HTTP 500, got nil")
-	}
+	require.Error(t, err, "expected error for HTTP 500")
 }

--- a/doqlistener_test.go
+++ b/doqlistener_test.go
@@ -34,7 +34,7 @@ func TestDoQListenerStartStop(t *testing.T) {
 	case err := <-stopped:
 		require.NoError(t, err)
 	case <-time.After(5 * time.Second):
-		t.Fatal("Start did not return after Stop; listener is spinning on Accept")
+		require.FailNow(t, "Start did not return after Stop; listener is spinning on Accept")
 	}
 }
 
@@ -67,7 +67,7 @@ func TestDoQListenerStopRaceDuringStart(t *testing.T) {
 			return
 		case <-time.After(20 * time.Millisecond):
 		case <-deadline:
-			t.Fatal("Start did not return while Stop was retried")
+			require.FailNow(t, "Start did not return while Stop was retried")
 		}
 	}
 }

--- a/fastest-tcp_test.go
+++ b/fastest-tcp_test.go
@@ -25,7 +25,7 @@ func waitForGoroutines(t *testing.T, target int, timeout time.Duration) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("probe goroutines did not terminate: have %d, want <= %d", runtime.NumGoroutine(), target)
+	require.LessOrEqual(t, runtime.NumGoroutine(), target, "probe goroutines did not terminate")
 }
 
 // TestFastestTCPNoGoroutineLeak verifies that probe goroutines always

--- a/fastest_test.go
+++ b/fastest_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/miekg/dns"
@@ -11,116 +12,126 @@ import (
 )
 
 func TestFastest(t *testing.T) {
-	// Build 2 resolvers that count the number of invocations
-	var ci ClientInfo
-	r1 := &TestResolver{ // slow resolver, with one A record in the response
-		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-			time.Sleep(10 * time.Millisecond)
-			a := new(dns.Msg)
-			a.SetReply(q)
-			a.Answer = []dns.RR{
-				&dns.A{
-					Hdr: dns.RR_Header{
-						Name:   q.Question[0].Name,
-						Rrtype: dns.TypeA,
-						Class:  dns.ClassINET,
+	synctest.Test(t, func(t *testing.T) {
+		// Build 2 resolvers that count the number of invocations
+		var ci ClientInfo
+		r1 := &TestResolver{ // slow resolver, with one A record in the response
+			ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+				time.Sleep(10 * time.Millisecond)
+				a := new(dns.Msg)
+				a.SetReply(q)
+				a.Answer = []dns.RR{
+					&dns.A{
+						Hdr: dns.RR_Header{
+							Name:   q.Question[0].Name,
+							Rrtype: dns.TypeA,
+							Class:  dns.ClassINET,
+						},
+						A: net.IP{127, 0, 0, 1},
 					},
-					A: net.IP{127, 0, 0, 1},
-				},
-			}
-			return a, nil
+				}
+				return a, nil
 
-		},
-	}
-	r2 := new(TestResolver) // fast resolver
+			},
+		}
+		r2 := new(TestResolver) // fast resolver
 
-	g := NewFastest("fastest", r1, r2)
-	q := new(dns.Msg)
-	q.SetQuestion("test.com.", dns.TypeA)
+		g := NewFastest("fastest", r1, r2)
+		q := new(dns.Msg)
+		q.SetQuestion("test.com.", dns.TypeA)
 
-	// Send the first query, it should go to both and the fast response (with A record) should come back.
-	a, err := g.Resolve(q, ci)
-	require.NoError(t, err)
+		// Send the first query, it should go to both and the fast response (with A record) should come back.
+		a, err := g.Resolve(q, ci)
+		require.NoError(t, err)
 
-	time.Sleep(time.Millisecond) // Wait to make sure both resolvers are actually hit before checking the hit-count
+		// Let the (virtual) clock run past the slow resolver's sleep so its
+		// goroutine completes and exits before the bubble ends, then wait for
+		// it to settle before checking the hit-count.
+		time.Sleep(10 * time.Millisecond)
+		synctest.Wait()
 
-	require.Equal(t, 1, r1.HitCount())
-	require.Equal(t, 1, r2.HitCount())
-	require.Equal(t, 0, len(a.Answer))
+		require.Equal(t, 1, r1.HitCount())
+		require.Equal(t, 1, r2.HitCount())
+		require.Equal(t, 0, len(a.Answer))
+	})
 }
 
 func TestFastestFail(t *testing.T) {
-	var ci ClientInfo
+	synctest.Test(t, func(t *testing.T) {
+		var ci ClientInfo
 
-	// Fast resolver that fails
-	opt := StaticResolverOptions{
-		RCode: dns.RcodeServerFailure,
-	}
-	r1, err := NewStaticResolver("test-static", opt)
-	require.NoError(t, err)
+		// Fast resolver that fails
+		opt := StaticResolverOptions{
+			RCode: dns.RcodeServerFailure,
+		}
+		r1, err := NewStaticResolver("test-static", opt)
+		require.NoError(t, err)
 
-	// Slow resolver that succeeds
-	r2 := &TestResolver{
-		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-			time.Sleep(10 * time.Millisecond)
-			a := new(dns.Msg)
-			a.SetReply(q)
-			a.Answer = []dns.RR{
-				&dns.A{
-					Hdr: dns.RR_Header{
-						Name:   q.Question[0].Name,
-						Rrtype: dns.TypeA,
-						Class:  dns.ClassINET,
+		// Slow resolver that succeeds
+		r2 := &TestResolver{
+			ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+				time.Sleep(10 * time.Millisecond)
+				a := new(dns.Msg)
+				a.SetReply(q)
+				a.Answer = []dns.RR{
+					&dns.A{
+						Hdr: dns.RR_Header{
+							Name:   q.Question[0].Name,
+							Rrtype: dns.TypeA,
+							Class:  dns.ClassINET,
+						},
+						A: net.IP{127, 0, 0, 1},
 					},
-					A: net.IP{127, 0, 0, 1},
-				},
-			}
-			return a, nil
+				}
+				return a, nil
 
-		},
-	}
+			},
+		}
 
-	g := NewFastest("fastest", r1, r2)
-	q := new(dns.Msg)
-	q.SetQuestion("test.com.", dns.TypeA)
+		g := NewFastest("fastest", r1, r2)
+		q := new(dns.Msg)
+		q.SetQuestion("test.com.", dns.TypeA)
 
-	// We have a fast failing, and a slow succeeding one. Expect success
-	a, err := g.Resolve(q, ci)
-	require.NoError(t, err)
+		// We have a fast failing, and a slow succeeding one. Expect success
+		a, err := g.Resolve(q, ci)
+		require.NoError(t, err)
 
-	require.Equal(t, 1, r2.HitCount())
-	require.Equal(t, 1, len(a.Answer))
-
+		require.Equal(t, 1, r2.HitCount())
+		require.Equal(t, 1, len(a.Answer))
+	})
 }
+
 func TestFastestFailAll(t *testing.T) {
-	var ci ClientInfo
+	synctest.Test(t, func(t *testing.T) {
+		var ci ClientInfo
 
-	// Fast resolver that fails with an error
-	r1 := &TestResolver{
-		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-			return nil, errors.New("failed")
-		},
-	}
+		// Fast resolver that fails with an error
+		r1 := &TestResolver{
+			ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+				return nil, errors.New("failed")
+			},
+		}
 
-	// Slow resolver that fails with SERVFAIL
-	r2 := &TestResolver{
-		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-			time.Sleep(10 * time.Millisecond)
-			a := new(dns.Msg)
-			a.SetRcode(q, dns.RcodeServerFailure)
-			return a, nil
-		},
-	}
+		// Slow resolver that fails with SERVFAIL
+		r2 := &TestResolver{
+			ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+				time.Sleep(10 * time.Millisecond)
+				a := new(dns.Msg)
+				a.SetRcode(q, dns.RcodeServerFailure)
+				return a, nil
+			},
+		}
 
-	g := NewFastest("fastest", r1, r2)
-	q := new(dns.Msg)
-	q.SetQuestion("test.com.", dns.TypeA)
+		g := NewFastest("fastest", r1, r2)
+		q := new(dns.Msg)
+		q.SetQuestion("test.com.", dns.TypeA)
 
-	// Expect the response to be from the slow SERVFAIL
-	a, err := g.Resolve(q, ci)
-	require.NoError(t, err)
+		// Expect the response to be from the slow SERVFAIL
+		a, err := g.Resolve(q, ci)
+		require.NoError(t, err)
 
-	require.Equal(t, 1, r1.HitCount())
-	require.Equal(t, 1, r2.HitCount())
-	require.Equal(t, dns.RcodeServerFailure, a.Rcode)
+		require.Equal(t, 1, r1.HitCount())
+		require.Equal(t, 1, r2.HitCount())
+		require.Equal(t, dns.RcodeServerFailure, a.Rcode)
+	})
 }


### PR DESCRIPTION
Converts the four remaining test files that used raw stdlib `t.Fatal`/`t.Error` calls (`dnssec-iana_test.go`, `cache-redis_test.go`, `fastest-tcp_test.go`, `doqlistener_test.go`) to testify's `require` package, matching the convention used by the other 43 test files in the suite.

Also wraps the three fastest group tests in `synctest.Test` so the simulated resolver latencies run on the virtual clock. This makes the fastest-resolver-wins assertions deterministic rather than depending on real 10ms sleeps outpacing scheduler jitter, replaces the 1ms fudge sleep in `TestFastest` with a deterministic virtual sleep plus `synctest.Wait()`, and drops the tests' wall time to ~0s.

Notes:
- The error checks inside the `TestEncodeConcurrent` goroutines intentionally remain plain channel sends since testify must not be called from non-test goroutines; only the final drain loop uses `require`.
- In `TestFastest` the virtual clock must run past the slow resolver's sleep before the test returns, since a synctest bubble fails if goroutines are still blocked when it ends.

Full test suite passes, and the converted tests pass repeated runs under `-race`.