### PR TITLE
Enforce RRSIG validity period in DNSSEC validation

### DIFF
--- a/dnssec/denial.go
+++ b/dnssec/denial.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -17,7 +18,7 @@ var ErrBogusDenial = errors.New("dnssec: unauthenticated denial of DS")
 // verifyDSDenial checks that resp's authority section carries NSEC or NSEC3
 // records, signed by one of the supplied parent-zone keys, that prove no DS
 // RRset exists at name. RFC 4035 §5.2 / RFC 5155 §8.
-func verifyDSDenial(resp *dns.Msg, name string, parentKeys []*dns.DNSKEY) error {
+func verifyDSDenial(resp *dns.Msg, name string, parentKeys []*dns.DNSKEY, now time.Time) error {
 	name = dns.CanonicalName(name)
 	rrsets, sigs := groupRRsByTypeAndName(resp.Ns)
 
@@ -29,7 +30,7 @@ func verifyDSDenial(resp *dns.Msg, name string, parentKeys []*dns.DNSKEY) error 
 		if !ok {
 			continue
 		}
-		if err := verifyRRSIG(sig, parentKeys, rrset); err != nil {
+		if err := verifyRRSIG(sig, parentKeys, rrset, now); err != nil {
 			continue
 		}
 		for _, rr := range rrset {

--- a/dnssec/validator.go
+++ b/dnssec/validator.go
@@ -15,6 +15,7 @@ var (
 	ErrNoSignature        = errors.New("dnssec: no RRSIG for RRset")
 	ErrNoKey              = errors.New("dnssec: no matching DNSKEY")
 	ErrSignatureInvalid   = errors.New("dnssec: signature verification failed")
+	ErrSignatureExpired   = errors.New("dnssec: RRSIG outside its validity period")
 	ErrDSMismatch         = errors.New("dnssec: DNSKEY doesn't match DS")
 	ErrNoTrustAnchor        = errors.New("dnssec: no trust anchor")
 	ErrInsecureDelegation   = errors.New("dnssec: insecure delegation")
@@ -150,7 +151,7 @@ func (v *Validator) proveNoDS(zone string) (bool, error) {
 		}
 		return false, err
 	}
-	if err := verifyDSDenial(resp, zone, parentZSK); err != nil {
+	if err := verifyDSDenial(resp, zone, parentZSK, v.now()); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -174,7 +175,7 @@ func (v *Validator) validateRRset(rrset []dns.RR, sig *dns.RRSIG) error {
 	if err != nil {
 		return err
 	}
-	return verifyRRSIG(sig, zsk, rrset)
+	return verifyRRSIG(sig, zsk, rrset, v.now())
 }
 
 // buildChainOfTrust recursively builds a DNSSEC chain of trust from
@@ -230,7 +231,7 @@ func (v *Validator) buildChainOfTrust(zone string) (zsk, ksk []*dns.DNSKEY, err 
 		}
 
 		if len(dsRecords) == 0 {
-			if err := verifyDSDenial(dsResp, zone, parentZSK); err != nil {
+			if err := verifyDSDenial(dsResp, zone, parentZSK, v.now()); err != nil {
 				return nil, nil, err
 			}
 			return nil, nil, fmt.Errorf("%w: %s", ErrInsecureDelegation, zone)
@@ -245,7 +246,7 @@ func (v *Validator) buildChainOfTrust(zone string) (zsk, ksk []*dns.DNSKEY, err 
 		}
 		var verified bool
 		for _, dsSig := range dsSigs {
-			if err := verifyRRSIG(dsSig, parentZSK, dsRRset); err == nil {
+			if err := verifyRRSIG(dsSig, parentZSK, dsRRset, v.now()); err == nil {
 				verified = true
 				break
 			}
@@ -269,7 +270,7 @@ func (v *Validator) buildChainOfTrust(zone string) (zsk, ksk []*dns.DNSKEY, err 
 			continue
 		}
 		sigSeen = true
-		if err := verifyRRSIG(sig, trustedKSK, allKeys); err == nil {
+		if err := verifyRRSIG(sig, trustedKSK, allKeys, v.now()); err == nil {
 			sigVerified = true
 			break
 		}
@@ -376,7 +377,16 @@ func findKeysByTag(keys []*dns.DNSKEY, tag uint16, alg uint8) []*dns.DNSKEY {
 
 // verifyRRSIG attempts to verify an RRSIG against a set of keys and an RRset.
 // It returns nil on the first successful verification.
-func verifyRRSIG(sig *dns.RRSIG, keys []*dns.DNSKEY, rrset []dns.RR) error {
+//
+// miekg/dns RRSIG.Verify() performs only the cryptographic check and
+// deliberately ignores the signature's validity period (RFC 4035 §5.3.1
+// step 3 is the caller's responsibility), so the Inception/Expiration window
+// is enforced separately here against now. Without this, an attacker could
+// replay a previously legitimate but expired signature.
+func verifyRRSIG(sig *dns.RRSIG, keys []*dns.DNSKEY, rrset []dns.RR, now time.Time) error {
+	if !sig.ValidityPeriod(now) {
+		return fmt.Errorf("%w: inception=%d expiration=%d", ErrSignatureExpired, sig.Inception, sig.Expiration)
+	}
 	matching := findKeysByTag(keys, sig.KeyTag, sig.Algorithm)
 	if len(matching) == 0 {
 		return fmt.Errorf("%w: tag=%d alg=%d", ErrNoKey, sig.KeyTag, sig.Algorithm)

--- a/dnssec/validator_chain_test.go
+++ b/dnssec/validator_chain_test.go
@@ -447,6 +447,66 @@ func TestValidateAcceptsAncestorSignerName(t *testing.T) {
 	require.NoError(t, v.Validate(answer))
 }
 
+// TestValidateRejectsExpiredRRSIG reproduces the signature-replay scenario
+// where an on-path attacker (or malicious upstream) serves a previously
+// legitimate answer whose covering RRSIG has since expired. The cryptographic
+// signature still verifies, but its validity period has elapsed, so it MUST be
+// rejected. The chain of trust (DNSKEY self-signature, DS) remains current so
+// the test isolates the answer RRSIG's expiry.
+func TestValidateRejectsExpiredRRSIG(t *testing.T) {
+	now := time.Now()
+
+	rootKSK, rootKSKpriv := genKey(t, ".", 257)
+	rootZSK, rootZSKpriv := genKey(t, ".", 256)
+	rootDNSKEYSig := signRRset(t, rootKSK, rootKSKpriv, now, []dns.RR{rootZSK, rootKSK})
+
+	childKSK, childKSKpriv := genKey(t, "child.", 257)
+	childZSK, childZSKpriv := genKey(t, "child.", 256)
+	childDNSKEYSig := signRRset(t, childKSK, childKSKpriv, now, []dns.RR{childZSK, childKSK})
+
+	childDS := childKSK.ToDS(dns.SHA256)
+	require.NotNil(t, childDS)
+	childDSSig := signRRset(t, rootZSK, rootZSKpriv, now, []dns.RR{childDS})
+
+	// The answer is signed with a validity window two hours in the past
+	// ([-3h, -1h] relative to now), so it is cryptographically valid but
+	// expired from the validator's perspective.
+	childA, _ := dns.NewRR("child. 300 IN A 1.2.3.4")
+	childASig := signRRset(t, childZSK, childZSKpriv, now.Add(-2*time.Hour), []dns.RR{childA})
+
+	resolver := func(q *dns.Msg) (*dns.Msg, error) {
+		a := new(dns.Msg)
+		a.SetReply(q)
+		name := dns.CanonicalName(q.Question[0].Name)
+		switch q.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			switch name {
+			case ".":
+				a.Answer = []dns.RR{rootZSK, rootKSK, rootDNSKEYSig}
+			case "child.":
+				a.Answer = []dns.RR{childZSK, childKSK, childDNSKEYSig}
+			}
+		case dns.TypeDS:
+			if name == "child." {
+				a.Answer = []dns.RR{childDS, childDSSig}
+			}
+		}
+		return a, nil
+	}
+
+	v := NewValidator(WithResolver(resolver), WithTime(func() time.Time { return now }))
+	rootAnchor := rootKSK.ToDS(dns.SHA256)
+	v.SetAnchor(".", rootAnchor.KeyTag, rootAnchor.Algorithm, rootAnchor.DigestType, rootAnchor.Digest)
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("child.", dns.TypeA)
+	answer.Answer = []dns.RR{childA, childASig}
+
+	err := v.Validate(answer)
+	require.ErrorIs(t, err, ErrSignatureExpired,
+		"an RRSIG outside its validity period must be rejected; got %v", err)
+}
+
 // genKey creates an ECDSAP256SHA256 DNSKEY for the given owner and flags
 // (256 = ZSK, 257 = KSK) and returns the public DNSKEY plus its private signer.
 func genKey(t *testing.T, owner string, flags uint16) (*dns.DNSKEY, crypto.Signer) {


### PR DESCRIPTION
## Problem

The DNSSEC validator verified RRSIGs purely cryptographically via miekg/dns `RRSIG.Verify()`, which by design performs only the signature check and ignores the signature's `Inception`/`Expiration` window (RFC 4035 §5.3.1 step 3 is the caller's responsibility). The validator never called `RRSIG.ValidityPeriod(now)`, even though it already carried a `now func() time.Time` field used elsewhere for keystore TTL.

As a result, expired (or not-yet-valid) RRSIGs were accepted as authentic, and the response was marked `AuthenticatedData=true`. This defeats DNSSEC's signature-expiration replay protection: an on-path attacker or malicious upstream could replay a previously legitimate but now-expired signed RRset (e.g. captured before a record changed, or signed by a since-retired key) and have it validate.

## Fix

- Enforce `sig.ValidityPeriod(now)` at the top of `verifyRRSIG`, returning a new `ErrSignatureExpired` when the signature is outside its window.
- Thread the validator's clock (`v.now()`) through every call site so the check covers the full chain of trust: the answer RRset, the DNSKEY self-signature, the DS RRSIG, and the NSEC/NSEC3 denial-of-existence path (`verifyDSDenial`).

## Tests

Adds `TestValidateRejectsExpiredRRSIG`, which builds a valid chain of trust with fresh DNSKEY/DS signatures but an answer RRSIG whose validity window is two hours in the past. The signature verifies cryptographically but is expired; the validator must reject it with `ErrSignatureExpired`. This test fails before the fix and passes after. The existing dnssec suite continues to pass (including under `-race`).