### PR TITLE
Validate DNSSEC denial of existence for negative responses

### DIFF
--- a/dnssec/denial_existence.go
+++ b/dnssec/denial_existence.go
@@ -1,0 +1,375 @@
+package dnssec
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// validateDenial authenticates a negative response (NXDOMAIN or NODATA). It
+// verifies that the authority section carries signed NSEC/NSEC3 records that
+// chain to the trust anchor and that actually prove the absence of the queried
+// name/type. It returns nil when the denial is proven, ErrInsecureDelegation
+// when the queried name falls under a provably unsigned zone (so the unsigned
+// answer may be passed through), and an error otherwise (bogus).
+//
+// Without this, an attacker could forge an NXDOMAIN/NODATA with an empty
+// answer section to suppress a record (e.g. a DANE/CAA downgrade) and have it
+// accepted as authentic.
+func (v *Validator) validateDenial(answer *dns.Msg) error {
+	if len(answer.Question) == 0 {
+		return fmt.Errorf("%w: response has no question", ErrDenialOfExistence)
+	}
+	q := answer.Question[0]
+	qname := dns.CanonicalName(q.Name)
+	qtype := q.Qtype
+
+	nsecs, nsec3s := v.collectVerifiedDenialRecords(answer.Ns, qname)
+
+	if nsecProvesDenial(nsecs, qname, qtype, answer.Rcode) {
+		return nil
+	}
+	if nsec3ProvesDenial(nsec3s, qname, qtype, answer.Rcode) {
+		return nil
+	}
+
+	// No authenticated proof of denial. Determine whether the name is in a
+	// signed zone at all: if a parent provably has no DS this is an insecure
+	// delegation and the unsigned negative answer may be passed through.
+	// Otherwise the unproven denial is bogus.
+	if err := v.checkInsecureDelegation(qname); err != nil {
+		return err
+	}
+	return fmt.Errorf("%w: %s/%s", ErrDenialOfExistence, qname, dns.TypeToString[qtype])
+}
+
+// collectVerifiedDenialRecords returns the NSEC and NSEC3 records from the
+// authority section whose covering RRSIG is signed by a zone at or above qname
+// and chains to the trust anchor. Unsigned or unauthenticated records are
+// discarded so a forged proof cannot be used.
+func (v *Validator) collectVerifiedDenialRecords(ns []dns.RR, qname string) (nsecs []*dns.NSEC, nsec3s []*dns.NSEC3) {
+	rrsets, sigs := groupRRsByTypeAndName(ns)
+	for key, rrset := range rrsets {
+		if key.rrtype != dns.TypeNSEC && key.rrtype != dns.TypeNSEC3 {
+			continue
+		}
+		sig, ok := sigs[key]
+		if !ok {
+			continue
+		}
+		// The signer zone must be at or above the queried name; an NSEC/NSEC3
+		// from an unrelated zone proves nothing about qname.
+		signer := dns.CanonicalName(sig.SignerName)
+		if !dns.IsSubDomain(signer, qname) {
+			continue
+		}
+		zsk, _, err := v.buildChainOfTrust(signer)
+		if err != nil {
+			continue
+		}
+		if verifyRRSIG(sig, zsk, rrset, v.now()) != nil {
+			continue
+		}
+		for _, rr := range rrset {
+			switch r := rr.(type) {
+			case *dns.NSEC:
+				nsecs = append(nsecs, r)
+			case *dns.NSEC3:
+				nsec3s = append(nsec3s, r)
+			}
+		}
+	}
+	return nsecs, nsec3s
+}
+
+// nsecProvesDenial reports whether the authenticated NSEC records prove the
+// denial for the given response code.
+func nsecProvesDenial(nsecs []*dns.NSEC, qname string, qtype uint16, rcode int) bool {
+	if len(nsecs) == 0 {
+		return false
+	}
+	switch rcode {
+	case dns.RcodeNameError:
+		return nsecProvesNXDOMAIN(nsecs, qname)
+	case dns.RcodeSuccess:
+		return nsecProvesNODATA(nsecs, qname, qtype)
+	}
+	return false
+}
+
+// nsecProvesNODATA proves that qname exists but the queried type does not, via
+// an NSEC matching qname whose bitmap lacks qtype, or via a wildcard NODATA.
+func nsecProvesNODATA(nsecs []*dns.NSEC, qname string, qtype uint16) bool {
+	qname = dns.CanonicalName(qname)
+
+	// Direct NODATA: an NSEC owning qname with the type (and CNAME) absent.
+	for _, n := range nsecs {
+		if dns.CanonicalName(n.Hdr.Name) != qname {
+			continue
+		}
+		return !slices.Contains(n.TypeBitMap, qtype) && !slices.Contains(n.TypeBitMap, dns.TypeCNAME)
+	}
+
+	// Wildcard NODATA: qname has no exact match (an NSEC covers it) but the
+	// wildcard at the closest encloser matches with the type absent.
+	for _, cover := range nsecs {
+		if !nsecCovers(cover, qname) {
+			continue
+		}
+		wildcard := dns.CanonicalName("*." + nsecClosestEncloser(qname, cover))
+		for _, w := range nsecs {
+			if dns.CanonicalName(w.Hdr.Name) != wildcard {
+				continue
+			}
+			return !slices.Contains(w.TypeBitMap, qtype) && !slices.Contains(w.TypeBitMap, dns.TypeCNAME)
+		}
+	}
+	return false
+}
+
+// nsecProvesNXDOMAIN proves that qname does not exist: an NSEC must cover it,
+// and an NSEC must cover the wildcard at the closest encloser (so no wildcard
+// could have synthesized an answer). RFC 4035 §5.4.
+func nsecProvesNXDOMAIN(nsecs []*dns.NSEC, qname string) bool {
+	qname = dns.CanonicalName(qname)
+
+	var ce string
+	covered := false
+	for _, n := range nsecs {
+		if nsecCovers(n, qname) {
+			ce = nsecClosestEncloser(qname, n)
+			covered = true
+			break
+		}
+	}
+	if !covered {
+		return false
+	}
+
+	wildcard := dns.CanonicalName("*." + ce)
+	for _, n := range nsecs {
+		// An exact wildcard match contradicts NXDOMAIN; only a covering NSEC
+		// (proving the wildcard does not exist) completes the proof.
+		if dns.CanonicalName(n.Hdr.Name) == wildcard {
+			return false
+		}
+		if nsecCovers(n, wildcard) {
+			return true
+		}
+	}
+	return false
+}
+
+// nsecClosestEncloser returns the closest encloser of qname implied by a
+// covering NSEC: the longest ancestor of qname known to exist (the longer of
+// the suffixes shared with the NSEC's owner and next-domain names).
+func nsecClosestEncloser(qname string, n *dns.NSEC) string {
+	owner := dns.CanonicalName(n.Hdr.Name)
+	next := dns.CanonicalName(n.NextDomain)
+	labels := max(dns.CompareDomainName(qname, owner), dns.CompareDomainName(qname, next))
+	return lastNLabels(qname, labels)
+}
+
+// nsecCovers reports whether the NSEC record spans qname in canonical order,
+// i.e. owner < qname < next, accounting for the wrap-around at the zone apex
+// where next <= owner. An exact owner match is not "covered".
+func nsecCovers(n *dns.NSEC, qname string) bool {
+	owner := dns.CanonicalName(n.Hdr.Name)
+	next := dns.CanonicalName(n.NextDomain)
+	qname = dns.CanonicalName(qname)
+	if qname == owner {
+		return false
+	}
+	if canonicalNameCmp(owner, next) < 0 {
+		return canonicalNameCmp(owner, qname) < 0 && canonicalNameCmp(qname, next) < 0
+	}
+	// Wrap-around: this is the last NSEC and next points back at the apex.
+	return canonicalNameCmp(owner, qname) < 0 || canonicalNameCmp(qname, next) < 0
+}
+
+// nsec3ProvesDenial reports whether the authenticated NSEC3 records prove the
+// denial for the given response code.
+func nsec3ProvesDenial(nsec3s []*dns.NSEC3, qname string, qtype uint16, rcode int) bool {
+	if len(nsec3s) == 0 {
+		return false
+	}
+	switch rcode {
+	case dns.RcodeNameError:
+		return nsec3ProvesNXDOMAIN(nsec3s, qname)
+	case dns.RcodeSuccess:
+		return nsec3ProvesNODATA(nsec3s, qname, qtype)
+	}
+	return false
+}
+
+// nsec3ProvesNODATA proves that qname exists but the queried type does not.
+func nsec3ProvesNODATA(nsec3s []*dns.NSEC3, qname string, qtype uint16) bool {
+	qname = dns.CanonicalName(qname)
+
+	// Direct match with the type (and CNAME) absent.
+	for _, r := range nsec3s {
+		if r.Match(qname) {
+			return !slices.Contains(r.TypeBitMap, qtype) && !slices.Contains(r.TypeBitMap, dns.TypeCNAME)
+		}
+	}
+
+	// DS NODATA via opt-out: the name is covered by an opt-out NSEC3, proving
+	// no signed DS exists (RFC 5155 §6).
+	if qtype == dns.TypeDS && nsec3OptOutCovers(nsec3s, qname) {
+		return true
+	}
+
+	// Wildcard NODATA: closest encloser exists, next closer is covered, and the
+	// wildcard matches with the type absent.
+	ce, nextCloser, ok := nsec3ClosestEncloser(nsec3s, qname)
+	if ok && nsec3CoverAny(nsec3s, nextCloser) {
+		wildcard := "*." + ce
+		for _, r := range nsec3s {
+			if r.Match(wildcard) {
+				return !slices.Contains(r.TypeBitMap, qtype) && !slices.Contains(r.TypeBitMap, dns.TypeCNAME)
+			}
+		}
+	}
+	return false
+}
+
+// nsec3ProvesNXDOMAIN proves qname does not exist via the closest encloser
+// proof: a matching NSEC3 for the closest encloser, a covering NSEC3 for the
+// next closer name, and a covering NSEC3 for the wildcard at the closest
+// encloser. Opt-out on the next closer admits an (insecure) delegation.
+// RFC 5155 §8.4, §8.7.
+func nsec3ProvesNXDOMAIN(nsec3s []*dns.NSEC3, qname string) bool {
+	ce, nextCloser, ok := nsec3ClosestEncloser(nsec3s, qname)
+	if !ok {
+		return false
+	}
+	if !nsec3CoverAny(nsec3s, nextCloser) {
+		return false
+	}
+	if nsec3CoverAny(nsec3s, "*."+ce) {
+		return true
+	}
+	// Opt-out: the next closer is covered by an opt-out NSEC3, so the name may
+	// be an unsigned delegation; the negative answer is acceptable.
+	return nsec3OptOutCovers(nsec3s, nextCloser)
+}
+
+// nsec3ClosestEncloser finds the longest ancestor of qname matched by an NSEC3
+// record and returns it together with the next closer name (that ancestor with
+// one more label from qname). The closest encloser is always a proper ancestor
+// of qname.
+func nsec3ClosestEncloser(nsec3s []*dns.NSEC3, qname string) (ce, nextCloser string, ok bool) {
+	qname = dns.CanonicalName(qname)
+	n := dns.CountLabel(qname)
+	for k := n - 1; k >= 0; k-- {
+		candidate := lastNLabels(qname, k)
+		if nsec3MatchAny(nsec3s, candidate) {
+			return candidate, lastNLabels(qname, k+1), true
+		}
+	}
+	return "", "", false
+}
+
+func nsec3MatchAny(nsec3s []*dns.NSEC3, name string) bool {
+	for _, r := range nsec3s {
+		if r.Match(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func nsec3CoverAny(nsec3s []*dns.NSEC3, name string) bool {
+	for _, r := range nsec3s {
+		if r.Cover(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func nsec3OptOutCovers(nsec3s []*dns.NSEC3, name string) bool {
+	for _, r := range nsec3s {
+		if r.Flags&1 == 1 && r.Cover(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// lastNLabels returns the rightmost n labels of name as a fully-qualified
+// name, or the root when n <= 0.
+func lastNLabels(name string, n int) string {
+	if n <= 0 {
+		return "."
+	}
+	labels := dns.SplitDomainName(name)
+	if n >= len(labels) {
+		return dns.CanonicalName(name)
+	}
+	return dns.Fqdn(strings.Join(labels[len(labels)-n:], "."))
+}
+
+// canonicalNameCmp compares two domain names in DNSSEC canonical order
+// (RFC 4034 §6.1): label by label from the rightmost, comparing the raw
+// (unescaped, lowercased) octets of each label. A name that is a proper suffix
+// of the other sorts first. Returns -1, 0, or 1.
+func canonicalNameCmp(a, b string) int {
+	al := canonicalLabels(a)
+	bl := canonicalLabels(b)
+	i, j := len(al)-1, len(bl)-1
+	for i >= 0 && j >= 0 {
+		if c := bytes.Compare(al[i], bl[j]); c != 0 {
+			return c
+		}
+		i--
+		j--
+	}
+	switch {
+	case i < 0 && j < 0:
+		return 0
+	case i < 0:
+		return -1
+	default:
+		return 1
+	}
+}
+
+// canonicalLabels splits a name into its raw (unescaped) lowercased labels,
+// excluding the root label.
+func canonicalLabels(name string) [][]byte {
+	name = dns.CanonicalName(name)
+	if name == "." {
+		return nil
+	}
+	var labels [][]byte
+	cur := []byte{}
+	for i := 0; i < len(name); {
+		switch c := name[i]; {
+		case c == '\\':
+			switch {
+			case i+3 < len(name) && isDigit(name[i+1]) && isDigit(name[i+2]) && isDigit(name[i+3]):
+				cur = append(cur, (name[i+1]-'0')*100+(name[i+2]-'0')*10+(name[i+3]-'0'))
+				i += 4
+			case i+1 < len(name):
+				cur = append(cur, name[i+1])
+				i += 2
+			default:
+				i++
+			}
+		case c == '.':
+			labels = append(labels, cur)
+			cur = []byte{}
+			i++
+		default:
+			cur = append(cur, c)
+			i++
+		}
+	}
+	return labels
+}
+
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }

--- a/dnssec/validator.go
+++ b/dnssec/validator.go
@@ -20,6 +20,7 @@ var (
 	ErrNoTrustAnchor        = errors.New("dnssec: no trust anchor")
 	ErrInsecureDelegation   = errors.New("dnssec: insecure delegation")
 	ErrSignerOutOfBailiwick = errors.New("dnssec: RRSIG signer name out of bailiwick")
+	ErrDenialOfExistence    = errors.New("dnssec: denial of existence not proven")
 )
 
 type Validator struct {
@@ -85,7 +86,7 @@ func (v *Validator) SetAnchor(owner string, tag uint16, alg, digestType uint8, d
 // and validates each signed RRset against a chain of trust.
 func (v *Validator) Validate(answer *dns.Msg) error {
 	if len(answer.Answer) == 0 {
-		return nil
+		return v.validateDenial(answer)
 	}
 
 	rrsets, sigs := groupRRsByTypeAndName(answer.Answer)

--- a/dnssec/validator_denial_test.go
+++ b/dnssec/validator_denial_test.go
@@ -1,0 +1,307 @@
+package dnssec
+
+import (
+	"crypto"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// denialEnv is a signed root -> child. chain of trust with a mock resolver,
+// used by the denial-of-existence tests. Tests craft the authority section of
+// a negative response and validate it against this environment.
+type denialEnv struct {
+	v            *Validator
+	now          time.Time
+	childZSK     *dns.DNSKEY
+	childZSKpriv crypto.Signer
+}
+
+// newSignedChildEnv builds a validator anchored at a generated root key, with
+// "child." properly delegated and signed (DS + DNSKEY), served by a mock
+// resolver. The child ZSK is returned so callers can sign NSEC/NSEC3 proofs.
+func newSignedChildEnv(t *testing.T) denialEnv {
+	t.Helper()
+	now := time.Now()
+
+	rootKSK, rootKSKpriv := genKey(t, ".", 257)
+	rootZSK, rootZSKpriv := genKey(t, ".", 256)
+	rootDNSKEYSig := signRRset(t, rootKSK, rootKSKpriv, now, []dns.RR{rootZSK, rootKSK})
+
+	childKSK, childKSKpriv := genKey(t, "child.", 257)
+	childZSK, childZSKpriv := genKey(t, "child.", 256)
+	childDNSKEYSig := signRRset(t, childKSK, childKSKpriv, now, []dns.RR{childZSK, childKSK})
+
+	childDS := childKSK.ToDS(dns.SHA256)
+	childDSSig := signRRset(t, rootZSK, rootZSKpriv, now, []dns.RR{childDS})
+
+	resolver := func(q *dns.Msg) (*dns.Msg, error) {
+		a := new(dns.Msg)
+		a.SetReply(q)
+		name := dns.CanonicalName(q.Question[0].Name)
+		switch q.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			switch name {
+			case ".":
+				a.Answer = []dns.RR{rootZSK, rootKSK, rootDNSKEYSig}
+			case "child.":
+				a.Answer = []dns.RR{childZSK, childKSK, childDNSKEYSig}
+			}
+		case dns.TypeDS:
+			if name == "child." {
+				a.Answer = []dns.RR{childDS, childDSSig}
+			}
+		}
+		return a, nil
+	}
+
+	v := NewValidator(WithResolver(resolver), WithTime(func() time.Time { return now }))
+	rootAnchor := rootKSK.ToDS(dns.SHA256)
+	v.SetAnchor(".", rootAnchor.KeyTag, rootAnchor.Algorithm, rootAnchor.DigestType, rootAnchor.Digest)
+
+	return denialEnv{v: v, now: now, childZSK: childZSK, childZSKpriv: childZSKpriv}
+}
+
+// TestValidateAcceptsNSECNODATA: a signed zone proves "no TLSA at child." with
+// an NSEC matching the name whose bitmap omits TLSA.
+func TestValidateAcceptsNSECNODATA(t *testing.T) {
+	env := newSignedChildEnv(t)
+	nsec, nsecSig := signNSEC(t, env.childZSK, env.childZSKpriv, env.now,
+		"child.", "\x00.child.",
+		[]uint16{dns.TypeA, dns.TypeNS, dns.TypeSOA, dns.TypeRRSIG, dns.TypeNSEC, dns.TypeDNSKEY})
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("child.", dns.TypeTLSA)
+	answer.Rcode = dns.RcodeSuccess
+	answer.Ns = []dns.RR{nsec, nsecSig}
+
+	require.NoError(t, env.v.Validate(answer))
+}
+
+// TestValidateAcceptsNSECNXDOMAIN: an NSEC covering both the queried name and
+// the wildcard at the closest encloser proves NXDOMAIN.
+func TestValidateAcceptsNSECNXDOMAIN(t *testing.T) {
+	env := newSignedChildEnv(t)
+	// owner=child. next=z.child. spans nx.child. and *.child.
+	nsec, nsecSig := signNSEC(t, env.childZSK, env.childZSKpriv, env.now,
+		"child.", "z.child.",
+		[]uint16{dns.TypeNS, dns.TypeSOA, dns.TypeRRSIG, dns.TypeNSEC, dns.TypeDNSKEY})
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("nx.child.", dns.TypeA)
+	answer.Rcode = dns.RcodeNameError
+	answer.Ns = []dns.RR{nsec, nsecSig}
+
+	require.NoError(t, env.v.Validate(answer))
+}
+
+// TestValidateRejectsForgedNSECNODATA: an NSEC signed by a key that does not
+// chain to the zone's authenticated DNSKEY must not authenticate the denial.
+func TestValidateRejectsForgedNSECNODATA(t *testing.T) {
+	env := newSignedChildEnv(t)
+	fakeZSK, fakeZSKpriv := genKey(t, "child.", 256)
+	nsec, nsecSig := signNSEC(t, fakeZSK, fakeZSKpriv, env.now,
+		"child.", "\x00.child.",
+		[]uint16{dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC})
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("child.", dns.TypeTLSA)
+	answer.Rcode = dns.RcodeSuccess
+	answer.Ns = []dns.RR{nsec, nsecSig}
+
+	err := env.v.Validate(answer)
+	require.ErrorIs(t, err, ErrDenialOfExistence)
+	require.NotErrorIs(t, err, ErrInsecureDelegation)
+}
+
+// TestValidateAcceptsNSEC3NODATA: an NSEC3 matching the queried name with the
+// type absent proves NODATA.
+func TestValidateAcceptsNSEC3NODATA(t *testing.T) {
+	env := newSignedChildEnv(t)
+	recs := signNSEC3Chain(t, env.childZSK, env.childZSKpriv, env.now, "child.",
+		[]string{"child.", "a.child."},
+		map[string][]uint16{
+			"child.":   {dns.TypeA, dns.TypeNS, dns.TypeSOA, dns.TypeRRSIG, dns.TypeDNSKEY},
+			"a.child.": {dns.TypeA, dns.TypeRRSIG},
+		})
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("child.", dns.TypeTLSA)
+	answer.Rcode = dns.RcodeSuccess
+	answer.Ns = recs
+
+	require.NoError(t, env.v.Validate(answer))
+}
+
+// TestValidateAcceptsNSEC3NXDOMAIN: the closest-encloser proof (matching CE,
+// covering next closer, covering wildcard) proves NXDOMAIN.
+func TestValidateAcceptsNSEC3NXDOMAIN(t *testing.T) {
+	env := newSignedChildEnv(t)
+	recs := signNSEC3Chain(t, env.childZSK, env.childZSKpriv, env.now, "child.",
+		[]string{"child.", "a.child."},
+		map[string][]uint16{
+			"child.":   {dns.TypeNS, dns.TypeSOA, dns.TypeRRSIG, dns.TypeDNSKEY},
+			"a.child.": {dns.TypeA, dns.TypeRRSIG},
+		})
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("nx.child.", dns.TypeA)
+	answer.Rcode = dns.RcodeNameError
+	answer.Ns = recs
+
+	require.NoError(t, env.v.Validate(answer))
+}
+
+// TestValidateAcceptsInsecureDelegationNXDOMAIN: an NXDOMAIN from a provably
+// unsigned zone (parent NSEC shows no DS) is passed through as an insecure
+// delegation, not treated as bogus.
+func TestValidateAcceptsInsecureDelegationNXDOMAIN(t *testing.T) {
+	now := time.Now()
+
+	rootKSK, rootKSKpriv := genKey(t, ".", 257)
+	rootZSK, rootZSKpriv := genKey(t, ".", 256)
+	rootDNSKEYSig := signRRset(t, rootKSK, rootKSKpriv, now, []dns.RR{rootZSK, rootKSK})
+
+	nsec, nsecSig := signNSEC(t, rootZSK, rootZSKpriv, now,
+		"unsigned.", "\x00.unsigned.",
+		[]uint16{dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC})
+
+	resolver := func(q *dns.Msg) (*dns.Msg, error) {
+		a := new(dns.Msg)
+		a.SetReply(q)
+		name := dns.CanonicalName(q.Question[0].Name)
+		switch q.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			if name == "." {
+				a.Answer = []dns.RR{rootZSK, rootKSK, rootDNSKEYSig}
+			}
+		case dns.TypeDS:
+			if name == "unsigned." {
+				a.Ns = []dns.RR{nsec, nsecSig}
+			}
+		}
+		return a, nil
+	}
+
+	v := NewValidator(WithResolver(resolver), WithTime(func() time.Time { return now }))
+	rootAnchor := rootKSK.ToDS(dns.SHA256)
+	v.SetAnchor(".", rootAnchor.KeyTag, rootAnchor.Algorithm, rootAnchor.DigestType, rootAnchor.Digest)
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("nx.unsigned.", dns.TypeA)
+	answer.Rcode = dns.RcodeNameError
+
+	err := v.Validate(answer)
+	require.ErrorIs(t, err, ErrInsecureDelegation)
+}
+
+// TestValidateRejectsUnsignedNODATA reproduces the forged-NODATA scenario: a
+// signed zone returns NOERROR with an empty answer (e.g. "no TLSA record")
+// but the authority section carries no NSEC/NSEC3 proof of non-existence. An
+// on-path attacker can use this to suppress a record (DANE/CAA downgrade).
+// The validator must treat the unproven denial as bogus rather than
+// authenticating it.
+func TestValidateRejectsUnsignedNODATA(t *testing.T) {
+	now := time.Now()
+
+	rootKSK, rootKSKpriv := genKey(t, ".", 257)
+	rootZSK, rootZSKpriv := genKey(t, ".", 256)
+	rootDNSKEYSig := signRRset(t, rootKSK, rootKSKpriv, now, []dns.RR{rootZSK, rootKSK})
+
+	childKSK, childKSKpriv := genKey(t, "child.", 257)
+	childZSK, _ := genKey(t, "child.", 256)
+	childDNSKEYSig := signRRset(t, childKSK, childKSKpriv, now, []dns.RR{childZSK, childKSK})
+
+	childDS := childKSK.ToDS(dns.SHA256)
+	require.NotNil(t, childDS)
+	childDSSig := signRRset(t, rootZSK, rootZSKpriv, now, []dns.RR{childDS})
+
+	resolver := func(q *dns.Msg) (*dns.Msg, error) {
+		a := new(dns.Msg)
+		a.SetReply(q)
+		name := dns.CanonicalName(q.Question[0].Name)
+		switch q.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			switch name {
+			case ".":
+				a.Answer = []dns.RR{rootZSK, rootKSK, rootDNSKEYSig}
+			case "child.":
+				a.Answer = []dns.RR{childZSK, childKSK, childDNSKEYSig}
+			}
+		case dns.TypeDS:
+			if name == "child." {
+				a.Answer = []dns.RR{childDS, childDSSig}
+			}
+		}
+		return a, nil
+	}
+
+	v := NewValidator(WithResolver(resolver), WithTime(func() time.Time { return now }))
+	rootAnchor := rootKSK.ToDS(dns.SHA256)
+	v.SetAnchor(".", rootAnchor.KeyTag, rootAnchor.Algorithm, rootAnchor.DigestType, rootAnchor.Digest)
+
+	// Forged NODATA: NOERROR, empty answer, no NSEC/NSEC3 in authority.
+	answer := new(dns.Msg)
+	answer.SetQuestion("child.", dns.TypeTLSA)
+	answer.Rcode = dns.RcodeSuccess
+
+	err := v.Validate(answer)
+	require.ErrorIs(t, err, ErrDenialOfExistence,
+		"a negative answer from a signed zone with no NSEC/NSEC3 proof must be bogus; got %v", err)
+}
+
+// signNSEC builds and signs an NSEC record at owner with the given next-domain
+// name and type bitmap, signed by the supplied key.
+func signNSEC(t *testing.T, key *dns.DNSKEY, priv crypto.Signer, now time.Time, owner, next string, types []uint16) (*dns.NSEC, *dns.RRSIG) {
+	t.Helper()
+	nsec := &dns.NSEC{
+		Hdr:        dns.RR_Header{Name: dns.CanonicalName(owner), Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300},
+		NextDomain: dns.CanonicalName(next),
+		TypeBitMap: types,
+	}
+	sig := signRRset(t, key, priv, now, []dns.RR{nsec})
+	return nsec, sig
+}
+
+// signNSEC3Chain builds a complete, signed NSEC3 chain for zone over the set
+// of existing owner names (SHA-1, no salt, 0 iterations). Each record's
+// NextDomain points at the next owner hash in canonical order, wrapping at the
+// end, so every non-existent name in the zone is covered. bitmaps supplies the
+// type bitmap for each existing name. It returns the NSEC3 records interleaved
+// with their RRSIGs, ready to place in the authority section.
+func signNSEC3Chain(t *testing.T, key *dns.DNSKEY, priv crypto.Signer, now time.Time, zone string, existing []string, bitmaps map[string][]uint16) []dns.RR {
+	t.Helper()
+	zone = dns.CanonicalName(zone)
+
+	type entry struct {
+		name string
+		hash string
+	}
+	entries := make([]entry, 0, len(existing))
+	for _, n := range existing {
+		entries = append(entries, entry{name: n, hash: dns.HashName(dns.CanonicalName(n), dns.SHA1, 0, "")})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].hash < entries[j].hash })
+
+	var out []dns.RR
+	for i, e := range entries {
+		next := entries[(i+1)%len(entries)].hash
+		n3 := &dns.NSEC3{
+			Hdr:        dns.RR_Header{Name: e.hash + "." + zone, Rrtype: dns.TypeNSEC3, Class: dns.ClassINET, Ttl: 300},
+			Hash:       dns.SHA1,
+			Flags:      0,
+			Iterations: 0,
+			SaltLength: 0,
+			Salt:       "",
+			HashLength: 20,
+			NextDomain: next,
+			TypeBitMap: bitmaps[e.name],
+		}
+		sig := signRRset(t, key, priv, now, []dns.RR{n3})
+		out = append(out, n3, sig)
+	}
+	return out
+}

--- a/dnssec/validator_test.go
+++ b/dnssec/validator_test.go
@@ -86,11 +86,20 @@ func TestValidateNoRRSIG(t *testing.T) {
 }
 
 func TestValidateEmptyAnswer(t *testing.T) {
-	v := NewValidator()
+	// An empty answer (NXDOMAIN/NODATA) must no longer be accepted
+	// unconditionally; without an authenticated NSEC/NSEC3 proof of denial it
+	// cannot be validated and must be reported as an error.
+	v := NewValidator(
+		WithResolver(func(q *dns.Msg) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetReply(q)
+			return a, nil
+		}),
+	)
 	answer := new(dns.Msg)
 	answer.SetQuestion("example.com.", dns.TypeA)
 	err := v.Validate(answer)
-	require.NoError(t, err)
+	require.Error(t, err)
 }
 
 func TestKeystoreCaching(t *testing.T) {


### PR DESCRIPTION
## Problem

`Validator.Validate` returned `nil` (success) for any response with an empty Answer section, and `DNSSECValidator.Resolve` routes both `NXDOMAIN` and `NODATA` responses through it. Negative responses carry their proof as signed NSEC/NSEC3 records in the authority section, which were never examined. As a result a forged `NXDOMAIN`/`NODATA` with an empty answer was accepted as authentic and the response was marked `AuthenticatedData=true`.

This let an on-path attacker or malicious upstream forge a negative answer to suppress security-relevant records, for example a DANE/TLSA or CAA downgrade, and have the forgery treated as cryptographically proven.

## Fix

Add denial-of-existence validation for empty-answer responses. The authenticated NSEC/NSEC3 records from the authority section must:

- be signed by a zone at or above the queried name and chain to the trust anchor (forged or out-of-bailiwick records are discarded), and
- actually prove the absence of the queried name/type.

Coverage:

- NSEC NODATA (exact match, type absent) and wildcard NODATA
- NSEC NXDOMAIN (covering NSEC for the name plus a covering NSEC for the wildcard at the closest encloser)
- NSEC3 NODATA (hash match, type absent; DS NODATA via opt-out)
- NSEC3 NXDOMAIN closest-encloser proof (matching CE, covering next closer, covering wildcard), with opt-out handling

When no valid proof is present, the existing insecure-delegation check is reused so genuinely unsigned zones still pass through (`ErrInsecureDelegation`). Otherwise the unproven denial is reported as bogus, which `Resolve` turns into SERVFAIL unless `LogOnly` is set.

## Tests

- `TestValidateRejectsUnsignedNODATA` reproduces the forged NODATA from a signed zone with no proof (fails before the fix, passes after).
- Positive proofs: `TestValidateAcceptsNSECNODATA`, `TestValidateAcceptsNSECNXDOMAIN`, `TestValidateAcceptsNSEC3NODATA`, `TestValidateAcceptsNSEC3NXDOMAIN`.
- `TestValidateRejectsForgedNSECNODATA` rejects an NSEC signed by a key that does not chain to the zone.
- `TestValidateAcceptsInsecureDelegationNXDOMAIN` confirms a provably unsigned zone's NXDOMAIN still passes through.
- `TestValidateEmptyAnswer` was updated: an unproven empty answer is no longer accepted unconditionally (it also no longer hits the live network).

The full `dnssec` suite passes, including under `-race`.