### PR TITLE
Apply EDNS0 UDP size to the query copy in setUDPSize

### DIFF
--- a/message.go
+++ b/message.go
@@ -89,7 +89,7 @@ func setUDPSize(q *dns.Msg, size uint16) *dns.Msg {
 	if edns0 != nil {
 		edns0.SetUDPSize(size)
 	} else {
-		q.SetEdns0(size, false)
+		copy.SetEdns0(size, false)
 	}
 	return copy
 }

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,49 @@
+package rdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetUDPSizeWithoutEDNS0(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	out := setUDPSize(q, 1232)
+
+	// The returned copy must have an OPT record with the new size
+	edns0 := out.IsEdns0()
+	require.NotNil(t, edns0)
+	require.Equal(t, uint16(1232), edns0.UDPSize())
+
+	// The original query must not have been modified
+	require.Nil(t, q.IsEdns0())
+}
+
+func TestSetUDPSizeWithEDNS0(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	q.SetEdns0(512, false)
+
+	out := setUDPSize(q, 1232)
+
+	// The returned copy must have the updated size
+	edns0 := out.IsEdns0()
+	require.NotNil(t, edns0)
+	require.Equal(t, uint16(1232), edns0.UDPSize())
+
+	// The original query must keep its size
+	require.Equal(t, uint16(512), q.IsEdns0().UDPSize())
+}
+
+func TestSetUDPSizeDisabled(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	// Size 0 leaves the query untouched
+	out := setUDPSize(q, 0)
+	require.Same(t, q, out)
+	require.Nil(t, out.IsEdns0())
+}


### PR DESCRIPTION
setUDPSize makes a copy of the query and is supposed to return that copy with the EDNS0 UDP size applied. When the incoming query had no EDNS0 record, the OPT record was added to the original query instead of the copy. The returned copy, which is what gets sent upstream by the plain DNS and DTLS clients, therefore never carried the configured edns0-udp-size, and the caller's message was mutated as a side effect.

This changes the call to add the OPT record to the copy, and adds tests covering both paths (query with and without an existing EDNS0 record) as well as the size=0 passthrough.