### PR TITLE
Harden response handling against nil and malformed messages

### DIFF
--- a/cache-redis.go
+++ b/cache-redis.go
@@ -210,6 +210,13 @@ func (b *redisBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 		}
 	}
 
+	// A record that decoded without error but holds no message (such as a
+	// literal "null" JSON value) is treated as a cache-miss.
+	if a == nil || a.Msg == nil {
+		Log.Error("empty cache record from redis")
+		return nil, false, false
+	}
+
 	answer := a.Msg
 	prefetchEligible := a.PrefetchEligible
 	answer.Id = q.Id

--- a/fastest.go
+++ b/fastest.go
@@ -11,7 +11,7 @@ type Fastest struct {
 	resolvers []Resolver
 }
 
-var _ Resolver = &FailRotate{}
+var _ Resolver = &Fastest{}
 
 // NewFastest returns a new instance of a resolver group that returns the fastest
 // response from all its resolvers.

--- a/net-resolver.go
+++ b/net-resolver.go
@@ -82,6 +82,11 @@ func (c *packetConn) Write(p []byte) (n int, err error) {
 	if err != nil {
 		return len(p), err
 	}
+	// A nil response means "drop". Fail the lookup rather than queueing
+	// a nil message that would panic the reader when packing it.
+	if a == nil {
+		return len(p), errors.New("query dropped by resolver")
+	}
 	c.ch <- a
 	return len(p), nil
 }

--- a/prefetch.go
+++ b/prefetch.go
@@ -20,7 +20,7 @@ type Prefetch struct {
 	queryCache *expirationcache.ExpirationLRUCache[dns.Msg]
 }
 
-var _ Resolver = &RoundRobin{}
+var _ Resolver = &Prefetch{}
 
 type PrefetchOptions struct {
 	PrefetchWindow    time.Duration

--- a/replace.go
+++ b/replace.go
@@ -77,8 +77,12 @@ func (r *Replace) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		return nil, err
 	}
 
-	// Set the question back to the original name
-	a.Question[0].Name = oldName
+	// Set the question back to the original name. A response from a
+	// misbehaving upstream may have an empty question section, do not
+	// trust it blindly.
+	if len(a.Question) > 0 {
+		a.Question[0].Name = oldName
+	}
 
 	// Now put the original name in all answer records that have the
 	// new name


### PR DESCRIPTION
A few small hardening fixes for edge cases found during a review, none of which are reachable with a well-behaved configuration and upstreams:

- replace: a response from a misbehaving upstream can carry an empty question section (QDCOUNT=0). The stream-based clients reject these in the pipeline, but DoH/DoQ responses are passed through, so guard the question rewrite instead of indexing unconditionally.
- net-resolver: when the wrapped resolver drops the query (nil response, nil error), the nil message was queued for the reader which would panic packing it. Fail the lookup with an error instead.
- redis cache backend: a value that decodes without error but contains no message (for example a literal "null" JSON value) caused a nil dereference. Treat it as a cache-miss.
- prefetch/fastest: the compile-time interface assertions referenced other types (RoundRobin, FailRotate), copy-paste leftovers that would hide a missing Resolver implementation on the actual types.