### PR TITLE
Handle dropped queries in prefetch and fastest-tcp without panic

### DIFF
--- a/fastest-tcp.go
+++ b/fastest-tcp.go
@@ -65,7 +65,7 @@ func NewFastestTCP(id string, resolver Resolver, opt FastestTCPOptions) *Fastest
 func (r *FastestTCP) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	log := logger(r.id, q, ci)
 	a, err := r.resolver.Resolve(q, ci)
-	if err != nil {
+	if err != nil || a == nil { // a nil response with no error means the query was dropped
 		return a, err
 	}
 	question := q.Question[0]

--- a/fastest-tcp_test.go
+++ b/fastest-tcp_test.go
@@ -140,3 +140,15 @@ func TestFastestTCPProbeCap(t *testing.T) {
 
 	waitForGoroutines(t, before, 2*time.Second)
 }
+
+// A dropped query (nil response, nil error) must be passed through
+// without dereferencing the response.
+func TestFastestTCPDroppedQuery(t *testing.T) {
+	r := NewFastestTCP("test-ftcp", NewDropResolver("test-drop"), FastestTCPOptions{})
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	a, err := r.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Nil(t, a)
+}

--- a/prefetch.go
+++ b/prefetch.go
@@ -67,9 +67,10 @@ func NewPrefetch(id string, resolver Resolver, opt PrefetchOptions) *Prefetch {
 			ci := ClientInfo{Listener: "prefetch"}
 			logger(r.id, q, ci).Debug("prefetching")
 
-			// Send the query again, the response should be cached by the resolver
+			// Send the query again, the response should be cached by the resolver.
+			// A nil response with no error means the query was dropped.
 			answer, err := r.resolver.Resolve(q, ci)
-			if err != nil {
+			if err != nil || answer == nil {
 				return
 			}
 
@@ -92,8 +93,8 @@ func NewPrefetch(id string, resolver Resolver, opt PrefetchOptions) *Prefetch {
 
 func (r *Prefetch) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	answer, err := r.resolver.Resolve(q, ci)
-	if err != nil {
-		return nil, err
+	if err != nil || answer == nil { // a nil response with no error means the query was dropped
+		return answer, err
 	}
 
 	// Check the response can be used for prefetch, return if not

--- a/prefetch_test.go
+++ b/prefetch_test.go
@@ -1,0 +1,30 @@
+package rdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// A dropped query (nil response, nil error) must be passed through
+// without dereferencing the response.
+func TestPrefetchDroppedQuery(t *testing.T) {
+	r := NewPrefetch("test-prefetch", NewDropResolver("test-drop"), PrefetchOptions{})
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	a, err := r.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Nil(t, a)
+}
+
+func TestPrefetchPassthrough(t *testing.T) {
+	r := NewPrefetch("test-prefetch", &TestResolver{}, PrefetchOptions{})
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	a, err := r.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, a)
+}


### PR DESCRIPTION
A nil response with a nil error is the established "drop" signal, returned by the drop resolver and by the rate-limiter when no limit-resolver is configured. The listeners handle it by closing the connection, and most modifiers check for it after calling their inner resolver.

The prefetch and fastest-tcp modifiers only checked the error and then dereferenced the response (answer.Rcode and a.Answer respectively), so placing either of them in front of a chain that can drop queries crashed the process with a nil-pointer panic on the first dropped query. The prefetch refresh callback had the same problem.

Adds the missing nil checks and tests that exercise the drop path through both modifiers.