### PR TITLE
Fix per-query and startup panics from configuration edge cases

### DIFF
--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -668,6 +668,9 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 		}
 		resolvers[id] = rdns.NewSyslog(id, gr[0], opt)
 	case "cache":
+		if len(gr) != 1 {
+			return fmt.Errorf("type cache only supports one resolver in '%s'", id)
+		}
 		var shuffleFunc rdns.AnswerShuffleFunc
 		switch g.CacheAnswerShuffle {
 		case "": // default

--- a/syslog.go
+++ b/syslog.go
@@ -57,6 +57,11 @@ func NewSyslog(id string, resolver Resolver, opt SyslogOptions) *Syslog {
 
 // Resolve passes a DNS query through unmodified. Query details are sent via syslog.
 func (r *Syslog) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+	// The writer is nil if the syslog connection failed at startup. Pass
+	// queries through rather than crash on the first logged query.
+	if r.writer == nil {
+		return r.resolver.Resolve(q, ci)
+	}
 	var msg string
 	if r.opt.LogRequest {
 		msg = fmt.Sprintf("id=%s qid=%d type=query client=%s qtype=%s qname=%s", r.id, q.Id, ci.SourceIP.String(), qType(q), qName(q))

--- a/syslog_test.go
+++ b/syslog_test.go
@@ -1,0 +1,26 @@
+package rdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// When the syslog connection fails at startup, queries must still be
+// passed through rather than panic on the nil writer.
+func TestSyslogUnreachableServer(t *testing.T) {
+	opt := SyslogOptions{
+		Network:     "tcp",
+		Address:     "127.0.0.1:1", // nothing listens here, Dial fails
+		LogRequest:  true,
+		LogResponse: true,
+	}
+	r := NewSyslog("test-syslog", &TestResolver{}, opt)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	a, err := r.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, a)
+}

--- a/ttl-modifier.go
+++ b/ttl-modifier.go
@@ -188,7 +188,11 @@ func TTLSelectLast(r *TTLModifier, a *dns.Msg) bool {
 // TTLSelectRandom is a function for the TTL Modifier that sets the TTL
 // to a random value between ttl-min and ttl-max.
 func TTLSelectRandom(r *TTLModifier, a *dns.Msg) bool {
-	value := r.MinTTL + uint32(rand.Intn(int(r.MaxTTL-r.MinTTL)))
+	// Guard against ttl-max <= ttl-min, rand.Intn panics on values < 1
+	value := r.MinTTL
+	if r.MaxTTL > r.MinTTL {
+		value = r.MinTTL + uint32(rand.Intn(int(r.MaxTTL-r.MinTTL)))
+	}
 	iterateOverAnswerRRHeader(a, func(h *dns.RR_Header) {
 		h.Ttl = value
 	})

--- a/ttl-modifier_test.go
+++ b/ttl-modifier_test.go
@@ -90,3 +90,42 @@ func TestTTLSelectHighest(t *testing.T) {
 
 	require.Equal(t, []uint32{600, 600, 600}, answerTTLs(a))
 }
+
+func TestTTLSelectRandom(t *testing.T) {
+	r := NewTTLModifier("test-ttl", ttlTestResolver(300, 60, 600), TTLModifierOptions{
+		SelectFunc: TTLSelectRandom,
+		MinTTL:     100,
+		MaxTTL:     200,
+	})
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	a, err := r.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+
+	// All records must use the same TTL within [min, max)
+	ttls := answerTTLs(a)
+	require.Equal(t, ttls[0], ttls[1])
+	require.Equal(t, ttls[0], ttls[2])
+	require.GreaterOrEqual(t, ttls[0], uint32(100))
+	require.Less(t, ttls[0], uint32(200))
+}
+
+// ttl-max == ttl-min as well as ttl-max < ttl-min must not panic and
+// fall back to ttl-min.
+func TestTTLSelectRandomDegenerateRange(t *testing.T) {
+	for _, opt := range []TTLModifierOptions{
+		{SelectFunc: TTLSelectRandom, MinTTL: 100, MaxTTL: 100},
+		{SelectFunc: TTLSelectRandom, MinTTL: 100, MaxTTL: 50},
+	} {
+		r := NewTTLModifier("test-ttl", ttlTestResolver(300, 60, 600), opt)
+
+		q := new(dns.Msg)
+		q.SetQuestion("example.com.", dns.TypeA)
+		a, err := r.Resolve(q, ClientInfo{})
+		require.NoError(t, err)
+		// MaxTTL caps the values after the select function ran
+		expected := min(opt.MinTTL, opt.MaxTTL)
+		require.Equal(t, []uint32{expected, expected, expected}, answerTTLs(a))
+	}
+}


### PR DESCRIPTION
Three panics reachable through plausible configurations:

- syslog: NewSyslog deliberately does not fail startup when the syslog server is unreachable, but it kept a nil writer. With log-request or log-response enabled, the first query then panicked in writer.Write. Queries are now passed through unlogged when there is no writer, matching the existing "log but don't block" intent.
- ttl-modifier: ttl-select "random" computes rand.Intn(ttl-max - ttl-min), which panics when ttl-max equals ttl-min, and wraps around the uint32 subtraction when ttl-max is below ttl-min. Degenerate ranges now fall back to ttl-min.
- cache group: the cache case was the only single-resolver group missing the resolver count check, so a cache group with an empty resolvers list crashed with an index out-of-range panic at startup instead of returning a config error.

Includes tests for the syslog passthrough and the degenerate TTL ranges.