### PR TITLE
Fix races on blocklist refresh and shared queries in fastest group

### DIFF
--- a/client-blocklist.go
+++ b/client-blocklist.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"net"
 	"sync"
 	"time"
 
@@ -78,7 +79,7 @@ func (r *ClientBlocklist) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		return r.resolver.Resolve(q, ci)
 	}
 
-	if match, ok := r.BlocklistDB.Match(ip); ok {
+	if match, ok := r.match(ip); ok {
 		log := Log.With(
 			slog.String("id", r.id),
 			slog.String("qname", qName(q)),
@@ -105,6 +106,15 @@ func (r *ClientBlocklist) String() string {
 	return r.id
 }
 
+// Match the IP against the blocklist while holding the lock. The refresh
+// loop closes the old database after swapping in a new one, so the match
+// must complete under the lock to never use a closed database.
+func (r *ClientBlocklist) match(ip net.IP) (*BlocklistMatch, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.BlocklistDB.Match(ip)
+}
+
 func (r *ClientBlocklist) refreshLoopBlocklist(refresh time.Duration) {
 	for {
 		time.Sleep(refresh)
@@ -118,9 +128,13 @@ func (r *ClientBlocklist) refreshLoopBlocklist(refresh time.Duration) {
 				"error", err)
 			continue
 		}
+		// Swap the database before closing the old one. Queries match
+		// under a read-lock, so no query can still be using the old
+		// database once the write-lock was acquired here.
 		r.mu.Lock()
-		r.BlocklistDB.Close()
+		old := r.BlocklistDB
 		r.BlocklistDB = db
 		r.mu.Unlock()
+		old.Close()
 	}
 }

--- a/client-blocklist_test.go
+++ b/client-blocklist_test.go
@@ -2,7 +2,9 @@ package rdns
 
 import (
 	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
@@ -62,4 +64,37 @@ func TestClientBlocklistMatch(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, a)
 	require.Equal(t, 1, r.HitCount())
+}
+
+// Concurrent queries while the refresh loop swaps and closes the
+// database. Run with -race to verify the matching is synchronized
+// with the swap.
+func TestClientBlocklistConcurrentRefresh(t *testing.T) {
+	loader := NewStaticLoader([]string{"192.168.0.0/16"})
+	db, err := NewCidrDB("testlist", loader)
+	require.NoError(t, err)
+
+	b, err := NewClientBlocklist("test-cb", &TestResolver{}, ClientBlocklistOptions{
+		BlocklistDB:      db,
+		BlocklistRefresh: time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 200 {
+				_, err := b.Resolve(q, ClientInfo{SourceIP: net.ParseIP("192.168.1.1")})
+				require.NoError(t, err)
+				_, err = b.Resolve(q, ClientInfo{SourceIP: net.ParseIP("10.0.0.1")})
+				require.NoError(t, err)
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/fastest.go
+++ b/fastest.go
@@ -35,10 +35,12 @@ func (r *Fastest) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 
 	responseCh := make(chan response, len(r.resolvers))
 
-	// Send the query to all resolvers. The responses are collected in a buffered channel
+	// Send the query to all resolvers. The responses are collected in a buffered channel.
+	// Give each resolver its own copy of the query since modifiers down the chain
+	// modify the message in place, which would race between the branches.
 	for _, resolver := range r.resolvers {
 		go func() {
-			a, err := resolver.Resolve(q, ci)
+			a, err := resolver.Resolve(q.Copy(), ci)
 			responseCh <- response{resolver, a, err}
 		}()
 	}

--- a/fastest_test.go
+++ b/fastest_test.go
@@ -135,3 +135,29 @@ func TestFastestFailAll(t *testing.T) {
 		require.Equal(t, dns.RcodeServerFailure, a.Rcode)
 	})
 }
+
+// Each resolver branch must receive its own copy of the query. Modifiers
+// in the branches change the message in place, which races between the
+// concurrent branches if the message is shared. Run with -race.
+func TestFastestQueryNotShared(t *testing.T) {
+	mutator := func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+		// Mutate the query like ecs-modifier or edns0-modifier would
+		q.SetEdns0(4096, false)
+		a := new(dns.Msg)
+		a.SetReply(q)
+		return a, nil
+	}
+	r1 := &TestResolver{ResolveFunc: mutator}
+	r2 := &TestResolver{ResolveFunc: mutator}
+
+	g := NewFastest("fastest", r1, r2)
+	for range 100 {
+		q := new(dns.Msg)
+		q.SetQuestion("test.com.", dns.TypeA)
+		a, err := g.Resolve(q, ClientInfo{})
+		require.NoError(t, err)
+		require.NotNil(t, a)
+		// The caller's query must not have been modified by the branches
+		require.Nil(t, q.IsEdns0())
+	}
+}

--- a/response-blocklist-ip.go
+++ b/response-blocklist-ip.go
@@ -82,6 +82,15 @@ func (r *ResponseBlocklistIP) String() string {
 	return r.id
 }
 
+// Match the IP against the blocklist while holding the lock. The refresh
+// loop closes the old database after swapping in a new one, so the match
+// must complete under the lock to never use a closed database.
+func (r *ResponseBlocklistIP) match(ip net.IP) (*BlocklistMatch, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.BlocklistDB.Match(ip)
+}
+
 func (r *ResponseBlocklistIP) refreshLoopBlocklist(refresh time.Duration) {
 	for {
 		time.Sleep(refresh)
@@ -93,10 +102,14 @@ func (r *ResponseBlocklistIP) refreshLoopBlocklist(refresh time.Duration) {
 				"error", err)
 			continue
 		}
+		// Swap the database before closing the old one. Queries match
+		// under a read-lock, so no query can still be using the old
+		// database once the write-lock was acquired here.
 		r.mu.Lock()
-		r.BlocklistDB.Close()
+		old := r.BlocklistDB
 		r.BlocklistDB = db
 		r.mu.Unlock()
+		old.Close()
 	}
 }
 
@@ -112,7 +125,7 @@ func (r *ResponseBlocklistIP) blockIfMatch(query, answer *dns.Msg, ci ClientInfo
 			default:
 				continue
 			}
-			if match, ok := r.BlocklistDB.Match(ip); ok != r.Inverted {
+			if match, ok := r.match(ip); ok != r.Inverted {
 				log := logger(r.id, query, ci).With(
 					slog.String("list", match.GetList()),
 					slog.String("rule", match.GetRule()),
@@ -164,7 +177,7 @@ func (r *ResponseBlocklistIP) filterRR(query *dns.Msg, ci ClientInfo, rrs []dns.
 			newRRs = append(newRRs, rr)
 			continue
 		}
-		if match, ok := r.BlocklistDB.Match(ip); ok != r.Inverted {
+		if match, ok := r.match(ip); ok != r.Inverted {
 			log := logger(r.id, query, ci).With(
 				slog.String("list", match.GetList()),
 				slog.String("rule", match.GetRule()),

--- a/response-blocklist-name.go
+++ b/response-blocklist-name.go
@@ -61,6 +61,15 @@ func (r *ResponseBlocklistName) String() string {
 	return r.id
 }
 
+// Match the name against the blocklist while holding the lock to
+// synchronize with the refresh loop swapping the database.
+func (r *ResponseBlocklistName) match(msg *dns.Msg) (*BlocklistMatch, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, _, match, ok := r.BlocklistDB.Match(msg)
+	return match, ok
+}
+
 func (r *ResponseBlocklistName) refreshLoopBlocklist(refresh time.Duration) {
 	for {
 		time.Sleep(refresh)
@@ -105,7 +114,7 @@ func (r *ResponseBlocklistName) blockIfMatch(query, answer *dns.Msg, ci ClientIn
 			}
 			msg := new(dns.Msg)
 			msg.SetQuestion(name, 0)
-			if _, _, rule, ok := r.BlocklistDB.Match(msg); ok != r.Inverted {
+			if rule, ok := r.match(msg); ok != r.Inverted {
 				log := logger(r.id, query, ci).With("rule", rule.GetRule())
 				if r.BlocklistResolver != nil {
 					log.Debug("blocklist match, forwarding to blocklist-resolver", "resolver", r.BlocklistResolver)


### PR DESCRIPTION
Two groups of data races found with a review and confirmed with the race detector:

Blocklist refresh: client-blocklist and response-blocklist-ip read the blocklist database field without holding the mutex while their refresh loops replace it under lock. They also closed the old database before swapping in the new one, so an in-flight match could operate on a closed database. For the mmap-backed GeoIP/ASN readers that means touching unmapped memory. Matching now happens under a read-lock via a small helper, and the refresh loop swaps first and closes the old database after releasing the lock, at which point no reader can still hold it. response-blocklist-name had the same unsynchronized read (without the close) and gets the same treatment. The blocklist group already did this correctly and is unchanged.

Fastest group: the same dns.Msg was passed to all resolver branches concurrently. Query-mutating modifiers in a branch (ecs-modifier, edns0-modifier) then race against the other branches. Each branch now resolves a copy of the query, matching what load-balance already does.

Both new tests fail under -race without the corresponding fix; the full test suite passes with -race after it.