### PR TITLE
Merge DS trust anchors for the same owner instead of replacing

### DIFF
--- a/dnssec/keystore.go
+++ b/dnssec/keystore.go
@@ -20,12 +20,6 @@ type keystoreEntry struct {
 	mu   sync.RWMutex
 }
 
-func (item *keystoreEntry) setDS(ds *dsSet) {
-	item.mu.Lock()
-	defer item.mu.Unlock()
-	item.ds = ds
-}
-
 func (item *keystoreEntry) setDNSKEY(keys *dnskeySet) {
 	item.mu.Lock()
 	defer item.mu.Unlock()
@@ -51,18 +45,31 @@ func newKeystore(now func() time.Time) *keystore {
 }
 
 func (s *keystore) addDS(name string, dss ...*dns.DS) {
+	item := s.getItem(name)
+	item.mu.Lock()
+	defer item.mu.Unlock()
+
+	// Merge with any existing DS records rather than replacing them, so that
+	// multiple trust anchors for the same owner (e.g. the root KSK-2017 and
+	// KSK-2024) all remain usable. Replacing would leave only the last anchor,
+	// and validation would fail whenever a zone's DNSKEY RRset is signed by a
+	// key matching one of the dropped anchors.
+	records := make([]*dns.DS, 0, len(dss))
+	if item.ds != nil {
+		records = append(records, item.ds.records...)
+	}
+	records = append(records, dss...)
+
 	var ttl uint32 = math.MaxUint32
-	for _, ds := range dss {
+	for _, ds := range records {
 		if ds.Hdr.Ttl < ttl {
 			ttl = ds.Hdr.Ttl
 		}
 	}
-	set := &dsSet{
+	item.ds = &dsSet{
 		expiresAt: s.now().Add(time.Duration(ttl) * time.Second),
-		records:   dss,
+		records:   records,
 	}
-	item := s.getItem(name)
-	item.setDS(set)
 }
 
 func (s *keystore) addDNSKEY(name string, keys []*dns.DNSKEY) {

--- a/dnssec/validator_test.go
+++ b/dnssec/validator_test.go
@@ -1,6 +1,7 @@
 package dnssec
 
 import (
+	"math"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -170,6 +171,39 @@ func TestKeystoreDSExpiry(t *testing.T) {
 	// Should be expired
 	result = ks.getDS("example.com.")
 	require.Nil(t, result)
+}
+
+// TestKeystoreDSMerge verifies that adding multiple DS records for the same
+// owner accumulates them rather than replacing, so that multiple trust anchors
+// (e.g. the root KSK-2017 and KSK-2024) all remain usable.
+func TestKeystoreDSMerge(t *testing.T) {
+	now := time.Now()
+	currentTime := now
+	ks := newKeystore(func() time.Time { return currentTime })
+
+	newDS := func(tag uint16, ttl uint32) *dns.DS {
+		return &dns.DS{
+			Hdr:        dns.RR_Header{Name: ".", Rrtype: dns.TypeDS, Class: dns.ClassINET, Ttl: ttl},
+			KeyTag:     tag,
+			Algorithm:  dns.RSASHA256,
+			DigestType: dns.SHA256,
+			Digest:     "ABCD",
+		}
+	}
+
+	ks.addDS(".", newDS(20326, math.MaxUint32))
+	ks.addDS(".", newDS(38696, 3600))
+
+	result := ks.getDS(".")
+	require.Len(t, result, 2)
+
+	tags := []uint16{result[0].KeyTag, result[1].KeyTag}
+	require.Contains(t, tags, uint16(20326))
+	require.Contains(t, tags, uint16(38696))
+
+	// Expiry must reflect the lowest TTL across the merged set (3600s).
+	currentTime = now.Add(3601 * time.Second)
+	require.Nil(t, ks.getDS("."))
 }
 
 func TestBuildChainOfTrustCaching(t *testing.T) {


### PR DESCRIPTION
When DNSSEC validation uses more than one trust anchor for the same owner, only the last one was retained, which breaks validation under the built-in defaults.

## Problem

`keystore.addDS` replaced the existing DS set for an owner on every call. `SetAnchor` calls it once per trust anchor, and the built-in `defaultTrustAnchors` ship two root anchors (KSK-2017 tag 20326 and KSK-2024 tag 38696). The second call overwrote the first, leaving only the KSK-2024 DS in the keystore.

When building the chain of trust for the root, `filterKeysByDS` narrows the trusted KSKs to only those matching a stored DS. The live root currently signs its DNSKEY RRset with KSK-2017 (tag 20326), so the key that actually produced the signature was filtered out and every signed lookup failed with `DNSKEY self-signature verification failed for .`.

The effect is that any deployment using the built-in defaults (or any owner configured with more than one anchor, including the multi-entry IANA `root-anchors.xml` consumed via `dnssec-trust-anchor-url`) returned SERVFAIL for all signed responses.

## Fix

`addDS` now merges new DS records with any already stored for the owner instead of replacing them, and recomputes the expiry from the lowest TTL across the merged set, all under the item lock. The now-unused `setDS` helper is removed.

Verified against the live root that both default anchors validate real signed domains (example.com, cloudflare.com) after the change, where they failed before. Added `TestKeystoreDSMerge` covering accumulation and the merged-TTL expiry; `go test -race ./dnssec/` passes.