### PR TITLE
Try every RRSIG covering an RRset, not just the first

### DIFF
--- a/dnssec/denial.go
+++ b/dnssec/denial.go
@@ -26,11 +26,7 @@ func verifyDSDenial(resp *dns.Msg, name string, parentKeys []*dns.DNSKEY, now ti
 		if key.rrtype != dns.TypeNSEC && key.rrtype != dns.TypeNSEC3 {
 			continue
 		}
-		sig, ok := sigs[key]
-		if !ok {
-			continue
-		}
-		if err := verifyRRSIG(sig, parentKeys, rrset, now); err != nil {
+		if !verifyAnyRRSIG(sigs[key], parentKeys, rrset, now) {
 			continue
 		}
 		for _, rr := range rrset {

--- a/dnssec/denial_existence.go
+++ b/dnssec/denial_existence.go
@@ -56,21 +56,7 @@ func (v *Validator) collectVerifiedDenialRecords(ns []dns.RR, qname string) (nse
 		if key.rrtype != dns.TypeNSEC && key.rrtype != dns.TypeNSEC3 {
 			continue
 		}
-		sig, ok := sigs[key]
-		if !ok {
-			continue
-		}
-		// The signer zone must be at or above the queried name; an NSEC/NSEC3
-		// from an unrelated zone proves nothing about qname.
-		signer := dns.CanonicalName(sig.SignerName)
-		if !dns.IsSubDomain(signer, qname) {
-			continue
-		}
-		zsk, _, err := v.buildChainOfTrust(signer)
-		if err != nil {
-			continue
-		}
-		if verifyRRSIG(sig, zsk, rrset, v.now()) != nil {
+		if !v.rrsetSignedFromAncestor(rrset, sigs[key], qname) {
 			continue
 		}
 		for _, rr := range rrset {
@@ -83,6 +69,28 @@ func (v *Validator) collectVerifiedDenialRecords(ns []dns.RR, qname string) (nse
 		}
 	}
 	return nsecs, nsec3s
+}
+
+// rrsetSignedFromAncestor reports whether any of the supplied RRSIGs
+// authenticates rrset under a signer at or above qname that chains to the trust
+// anchor. An NSEC/NSEC3 from an unrelated zone proves nothing about qname, so
+// the signer-bailiwick check is applied per signature; trying every RRSIG
+// tolerates a key rollover where the set carries more than one.
+func (v *Validator) rrsetSignedFromAncestor(rrset []dns.RR, sigs []*dns.RRSIG, qname string) bool {
+	for _, sig := range sigs {
+		signer := dns.CanonicalName(sig.SignerName)
+		if !dns.IsSubDomain(signer, qname) {
+			continue
+		}
+		zsk, _, err := v.buildChainOfTrust(signer)
+		if err != nil {
+			continue
+		}
+		if verifyRRSIG(sig, zsk, rrset, v.now()) == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // nsecProvesDenial reports whether the authenticated NSEC records prove the

--- a/dnssec/validator.go
+++ b/dnssec/validator.go
@@ -92,8 +92,8 @@ func (v *Validator) Validate(answer *dns.Msg) error {
 	rrsets, sigs := groupRRsByTypeAndName(answer.Answer)
 
 	for key, rrset := range rrsets {
-		sig, ok := sigs[key]
-		if !ok {
+		rrsigs := sigs[key]
+		if len(rrsigs) == 0 {
 			// Check if this is an insecure delegation by looking for DS in parent
 			zone := rrset[0].Header().Name
 			if err := v.checkInsecureDelegation(zone); err != nil {
@@ -101,7 +101,7 @@ func (v *Validator) Validate(answer *dns.Msg) error {
 			}
 			return fmt.Errorf("%w: %s/%s", ErrNoSignature, key.name, dns.TypeToString[key.rrtype])
 		}
-		if err := v.validateRRset(rrset, sig); err != nil {
+		if err := v.validateRRset(rrset, rrsigs); err != nil {
 			return err
 		}
 	}
@@ -158,25 +158,38 @@ func (v *Validator) proveNoDS(zone string) (bool, error) {
 	return true, nil
 }
 
-// validateRRset validates a set of RRs against the provided RRSIG by
-// building a chain of trust to the signer's DNSKEY.
-func (v *Validator) validateRRset(rrset []dns.RR, sig *dns.RRSIG) error {
-	// RFC 4035 §5.3.1: the RRSIG Signer's Name MUST be the zone that
-	// contains the RRset, i.e. equal to or an ancestor of the owner name.
-	// miekg/dns Verify() only does a textual strings.HasSuffix check, so a
-	// signer "tim." would be accepted for owner "victim." — enforce a
-	// label-aware comparison here before fetching keys for the signer.
+// validateRRset validates a set of RRs against the provided RRSIGs by building
+// a chain of trust to each signer's DNSKEY. An RRset is accepted as soon as one
+// of its RRSIGs verifies; this tolerates ZSK rollovers, where the set carries
+// signatures from both the outgoing and incoming keys and only one is valid
+// against the currently-published DNSKEY RRset.
+func (v *Validator) validateRRset(rrset []dns.RR, sigs []*dns.RRSIG) error {
 	owner := dns.CanonicalName(rrset[0].Header().Name)
-	signer := dns.CanonicalName(sig.SignerName)
-	// dns.IsSubDomain(parent, child): true when child is at or below parent.
-	if !dns.IsSubDomain(signer, owner) {
-		return fmt.Errorf("%w: %s cannot sign %s", ErrSignerOutOfBailiwick, signer, owner)
+	var lastErr error
+	for _, sig := range sigs {
+		// RFC 4035 §5.3.1: the RRSIG Signer's Name MUST be the zone that
+		// contains the RRset, i.e. equal to or an ancestor of the owner name.
+		// miekg/dns Verify() only does a textual strings.HasSuffix check, so a
+		// signer "tim." would be accepted for owner "victim." — enforce a
+		// label-aware comparison here before fetching keys for the signer.
+		signer := dns.CanonicalName(sig.SignerName)
+		// dns.IsSubDomain(parent, child): true when child is at or below parent.
+		if !dns.IsSubDomain(signer, owner) {
+			lastErr = fmt.Errorf("%w: %s cannot sign %s", ErrSignerOutOfBailiwick, signer, owner)
+			continue
+		}
+		zsk, _, err := v.buildChainOfTrust(signer)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if err := verifyRRSIG(sig, zsk, rrset, v.now()); err != nil {
+			lastErr = err
+			continue
+		}
+		return nil
 	}
-	zsk, _, err := v.buildChainOfTrust(signer)
-	if err != nil {
-		return err
-	}
-	return verifyRRSIG(sig, zsk, rrset, v.now())
+	return lastErr
 }
 
 // buildChainOfTrust recursively builds a DNSSEC chain of trust from
@@ -403,6 +416,19 @@ func verifyRRSIG(sig *dns.RRSIG, keys []*dns.DNSKEY, rrset []dns.RR, now time.Ti
 	return fmt.Errorf("%w: %v", ErrSignatureInvalid, lastErr)
 }
 
+// verifyAnyRRSIG reports whether any of the given RRSIGs verifies against the
+// supplied keys and RRset. It is used where the signer's keys are already known
+// (e.g. NSEC/NSEC3 denial), so the RRset is authenticated as soon as one
+// signature checks out, tolerating multiple RRSIGs from a key rollover.
+func verifyAnyRRSIG(sigs []*dns.RRSIG, keys []*dns.DNSKEY, rrset []dns.RR, now time.Time) bool {
+	for _, sig := range sigs {
+		if verifyRRSIG(sig, keys, rrset, now) == nil {
+			return true
+		}
+	}
+	return false
+}
+
 // filterKeysByDS returns the subset of keys whose computed DS digest matches
 // one of the provided DS records.
 func filterKeysByDS(keys []*dns.DNSKEY, ds []*dns.DS) []*dns.DNSKEY {
@@ -429,10 +455,13 @@ type rrsetKey struct {
 }
 
 // groupRRsByTypeAndName groups the RRs in a section into RRsets keyed by
-// (canonical name, type) and extracts covering RRSIGs.
-func groupRRsByTypeAndName(section []dns.RR) (map[rrsetKey][]dns.RR, map[rrsetKey]*dns.RRSIG) {
+// (canonical name, type) and extracts all covering RRSIGs. An RRset can carry
+// more than one RRSIG (e.g. during a ZSK rollover, where it is signed by both
+// the outgoing and incoming key); all are kept so callers can accept the RRset
+// if any signature verifies.
+func groupRRsByTypeAndName(section []dns.RR) (map[rrsetKey][]dns.RR, map[rrsetKey][]*dns.RRSIG) {
 	rrsets := make(map[rrsetKey][]dns.RR)
-	sigs := make(map[rrsetKey]*dns.RRSIG)
+	sigs := make(map[rrsetKey][]*dns.RRSIG)
 
 	for _, rr := range section {
 		if sig, ok := rr.(*dns.RRSIG); ok {
@@ -440,10 +469,7 @@ func groupRRsByTypeAndName(section []dns.RR) (map[rrsetKey][]dns.RR, map[rrsetKe
 				name:   dns.CanonicalName(sig.Hdr.Name),
 				rrtype: sig.TypeCovered,
 			}
-			// Keep the first RRSIG for each RRset (could be enhanced to try multiple)
-			if _, exists := sigs[key]; !exists {
-				sigs[key] = sig
-			}
+			sigs[key] = append(sigs[key], sig)
 			continue
 		}
 		hdr := rr.Header()

--- a/dnssec/validator_chain_test.go
+++ b/dnssec/validator_chain_test.go
@@ -122,6 +122,65 @@ func TestBuildChainOfTrustAcceptsSignedDS(t *testing.T) {
 	require.NoError(t, v.Validate(answer))
 }
 
+// TestValidateAcceptsRRsetDuringZSKRollover covers a ZSK rollover where the
+// answer RRset carries two RRSIGs: one from a retired ZSK that is no longer in
+// the published DNSKEY set, and one from the current ZSK. The retired
+// signature appears first. The validator must try every RRSIG and accept the
+// RRset on the current one, rather than failing on the first.
+func TestValidateAcceptsRRsetDuringZSKRollover(t *testing.T) {
+	now := time.Now()
+
+	rootKSK, rootKSKpriv := genKey(t, ".", 257)
+	rootZSK, rootZSKpriv := genKey(t, ".", 256)
+	rootDNSKEYSig := signRRset(t, rootKSK, rootKSKpriv, now, []dns.RR{rootZSK, rootKSK})
+
+	childKSK, childKSKpriv := genKey(t, "child.", 257)
+	childZSK, childZSKpriv := genKey(t, "child.", 256)
+	// Retired ZSK: still signs the answer, but is no longer published in the
+	// child's DNSKEY RRset, so its RRSIG cannot be verified.
+	retiredZSK, retiredZSKpriv := genKey(t, "child.", 256)
+	childDNSKEYSig := signRRset(t, childKSK, childKSKpriv, now, []dns.RR{childZSK, childKSK})
+
+	childDS := childKSK.ToDS(dns.SHA256)
+	require.NotNil(t, childDS)
+	childDSSig := signRRset(t, rootZSK, rootZSKpriv, now, []dns.RR{childDS})
+
+	childA, _ := dns.NewRR("child. 300 IN A 1.2.3.4")
+	retiredASig := signRRset(t, retiredZSK, retiredZSKpriv, now, []dns.RR{childA})
+	currentASig := signRRset(t, childZSK, childZSKpriv, now, []dns.RR{childA})
+
+	resolver := func(q *dns.Msg) (*dns.Msg, error) {
+		a := new(dns.Msg)
+		a.SetReply(q)
+		name := dns.CanonicalName(q.Question[0].Name)
+		switch q.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			switch name {
+			case ".":
+				a.Answer = []dns.RR{rootZSK, rootKSK, rootDNSKEYSig}
+			case "child.":
+				a.Answer = []dns.RR{childZSK, childKSK, childDNSKEYSig}
+			}
+		case dns.TypeDS:
+			if name == "child." {
+				a.Answer = []dns.RR{childDS, childDSSig}
+			}
+		}
+		return a, nil
+	}
+
+	v := NewValidator(WithResolver(resolver), WithTime(func() time.Time { return now }))
+	rootAnchor := rootKSK.ToDS(dns.SHA256)
+	v.SetAnchor(".", rootAnchor.KeyTag, rootAnchor.Algorithm, rootAnchor.DigestType, rootAnchor.Digest)
+
+	answer := new(dns.Msg)
+	answer.SetQuestion("child.", dns.TypeA)
+	// Retired signature first to ensure the first-RRSIG-only path would fail.
+	answer.Answer = []dns.RR{childA, retiredASig, currentASig}
+
+	require.NoError(t, v.Validate(answer))
+}
+
 // TestValidateRejectsStrippedRRSIGWithEmptyDS reproduces the downgrade attack
 // where an on-path attacker strips the RRSIG from a signed zone's answer and
 // then replies NODATA to the validator's follow-up DS query. Without an

--- a/dnssec/validator_test.go
+++ b/dnssec/validator_test.go
@@ -39,8 +39,8 @@ func TestGroupRRsByTypeAndName(t *testing.T) {
 
 	require.Len(t, rrsets[aKey], 2)
 	require.Len(t, rrsets[aaaaKey], 1)
-	require.NotNil(t, sigs[aKey])
-	require.Nil(t, sigs[aaaaKey])
+	require.Len(t, sigs[aKey], 1)
+	require.Empty(t, sigs[aaaaKey])
 }
 
 func TestFilterKeysByDS(t *testing.T) {


### PR DESCRIPTION
DNSSEC validation could SERVFAIL a perfectly valid response during a ZSK rollover because only the first RRSIG covering each RRset was ever tried.

## Problem

`groupRRsByTypeAndName` kept only the first RRSIG it saw for a given RRset and discarded the rest. An RRset can legitimately carry more than one RRSIG, most commonly during a ZSK rollover, when the zone double-signs records with both the outgoing and incoming keys. If the retained signature happened to be the one whose key was no longer in the published DNSKEY RRset, `verifyRRSIG` returned `no matching DNSKEY` and the entire response was rejected as bogus, even though a valid signature was present in the message.

## Fix

`groupRRsByTypeAndName` now returns all covering RRSIGs per RRset, and the consumers accept the RRset as soon as one signature verifies:

- `validateRRset` iterates the signatures, applying the signer-bailiwick check per RRSIG and returning the last error only if none verify.
- The NSEC/NSEC3 denial paths (`verifyDSDenial`, `collectVerifiedDenialRecords`) use the new `verifyAnyRRSIG` / `rrsetSignedFromAncestor` helpers.

The per-signature bailiwick and chain-of-trust checks are unchanged, so security properties are preserved: a signature only counts if its signer is in bailiwick and chains to the trust anchor. This change only makes validation succeed in more legitimate cases (multiple valid-shaped signatures), never fewer.

## Test

Added `TestValidateAcceptsRRsetDuringZSKRollover`, which double-signs an answer with a retired (unpublished) ZSK first and the current ZSK second. It fails against the previous first-RRSIG-only behavior (`no matching DNSKEY`) and passes with this change. `go test -race ./dnssec/` passes.