### PR TITLE
Fix lost-write race in keystore.getItem

### DIFF
--- a/dnssec/keystore.go
+++ b/dnssec/keystore.go
@@ -140,9 +140,18 @@ func (s *keystore) getItem(name string) *keystoreEntry {
 	if ok {
 		return item
 	}
-	item = new(keystoreEntry)
+
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Re-check under the write lock: another goroutine may have created the
+	// entry between releasing the read lock above and acquiring the write lock.
+	// Without this, two callers could each insert a fresh entry, the second
+	// overwriting the first, and any DS/DNSKEY written to the orphaned entry
+	// would be silently lost.
+	if item, ok := s.store[mk]; ok {
+		return item
+	}
+	item = new(keystoreEntry)
 	s.store[mk] = item
-	s.mu.Unlock()
 	return item
 }

--- a/dnssec/validator_test.go
+++ b/dnssec/validator_test.go
@@ -2,6 +2,7 @@ package dnssec
 
 import (
 	"math"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -204,6 +205,33 @@ func TestKeystoreDSMerge(t *testing.T) {
 	// Expiry must reflect the lowest TTL across the merged set (3600s).
 	currentTime = now.Add(3601 * time.Second)
 	require.Nil(t, ks.getDS("."))
+}
+
+// TestGetItemConcurrent verifies that concurrent getItem calls for the same
+// name all return the same entry. Before the double-checked lock, two callers
+// could each insert a fresh entry and the second would overwrite the first,
+// leaving one caller with an orphaned entry whose writes are lost.
+func TestGetItemConcurrent(t *testing.T) {
+	ks := newKeystore(time.Now)
+
+	const n = 64
+	items := make([]*keystoreEntry, n)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			items[i] = ks.getItem("example.com.")
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i := 1; i < n; i++ {
+		require.Same(t, items[0], items[i], "all callers must share one entry")
+	}
 }
 
 func TestBuildChainOfTrustCaching(t *testing.T) {


### PR DESCRIPTION
The DNSSEC keystore could lose freshly written DS/DNSKEY records when two goroutines resolved the same zone at the same time.

## Problem

`getItem` looked up an entry under a read lock and, on a miss, created and stored a new entry under a separate write lock:

```go
s.mu.RLock()
item, ok := s.store[mk]
s.mu.RUnlock()
if ok {
    return item
}
item = new(keystoreEntry)
s.mu.Lock()
s.store[mk] = item
s.mu.Unlock()
return item
```

Two goroutines resolving the same zone concurrently can both miss under the read lock and both insert. The second insert overwrites the first, so one goroutine ends up holding a `keystoreEntry` that is no longer in the map. Any DS or DNSKEY later written to that orphaned entry (via `addDS` / `addDNSKEY`) is silently lost, which can cause redundant upstream lookups or drop keys that were just validated.

## Fix

Use double-checked locking: re-check the map under the write lock and only create a new entry if one still does not exist, so all callers for a name share a single entry.

## Test

Added `TestGetItemConcurrent`, which launches many goroutines that call `getItem` for the same name simultaneously and asserts they all receive the same entry. It fails against the previous code (callers receive distinct entries) and passes with this change. `go test -race ./dnssec/` passes.