### PR TITLE
Use expiration-cache sharding for prefetch tracking

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -454,6 +454,8 @@ Example config files: [cache.toml](../cmd/routedns/example-config/cache.toml), [
 
 While [Cache](#cache) has built-in prefetch capabilities, the dedicated `prefetch` group may be more appropriate for some use cases. It tracks the number of queries made within a time window and actively prefetches frequently requested records. While it actively sends queries in order to refresh a cache, it does not cache responses itself and relies on a cache upstream from it.
 
+On multi-core systems the internal tracking caches are automatically sharded (based on `GOMAXPROCS`) to reduce lock contention under concurrent query load. This is an internal optimization only; it does not change behavior or measurably affect end-to-end query latency.
+
 #### Configuration
 
 Prefetch groups are instantiated with `type = "prefetch"` in the groups section of the configuration.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/folbricht/routedns
 go 1.25.0
 
 require (
-	github.com/0xERR0R/expiration-cache v0.1.0
+	github.com/0xERR0R/expiration-cache v0.2.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91
 	github.com/cisco/go-hpke v0.0.0-20230407100446-246075f83609
@@ -32,7 +32,7 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/hashicorp/golang-lru v1.0.2 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xERR0R/expiration-cache v0.1.0 h1:K0G8UmwX4ncKHw5u/Ka5/k46G7/qXPtU9rWPbImk80k=
-github.com/0xERR0R/expiration-cache v0.1.0/go.mod h1:JW3Pj+nzWK0ak630rxv/aIVTlGOshArmP1f1xfF+mAQ=
+github.com/0xERR0R/expiration-cache v0.2.0 h1:x6TGJI3lh+LaRUB1A0xMjaQ9qYRTrQfzuKrIbT04Chg=
+github.com/0xERR0R/expiration-cache v0.2.0/go.mod h1:dMZtuoO/1DZ9tIeN5FBLdd82npkmNxVaGezjjtbxaq8=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91 h1:vX+gnvBc56EbWYrmlhYbFYRaeikAke1GL84N4BEYOFE=
@@ -41,8 +41,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
-github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/heimdalr/dag v1.5.0 h1:hqVtijvY776P5OKP3QbdVBRt3Xxq6BYopz3XgklsGvo=
 github.com/heimdalr/dag v1.5.0/go.mod h1:lthekrHl01dddmzqyBQ1YZbi7XcVGGzjFo0jIky5knc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/prefetch.go
+++ b/prefetch.go
@@ -3,6 +3,7 @@ package rdns
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync/atomic"
 	"time"
 
@@ -30,6 +31,14 @@ type PrefetchOptions struct {
 }
 
 func NewPrefetch(id string, resolver Resolver, opt PrefetchOptions) *Prefetch {
+	return newPrefetchWithShards(id, resolver, opt, 0)
+}
+
+// newPrefetchWithShards builds a Prefetch, allowing the cache shard count to be
+// overridden. A shards value of 0 selects the default (GOMAXPROCS-based) sizing
+// via expirationCacheShards; a non-zero value forces that count, which is used
+// by benchmarks to compare sharded against unsharded caches.
+func newPrefetchWithShards(id string, resolver Resolver, opt PrefetchOptions, shards uint) *Prefetch {
 	if opt.PrefetchWindow == 0 {
 		opt.PrefetchWindow = time.Hour
 	}
@@ -40,6 +49,13 @@ func NewPrefetch(id string, resolver Resolver, opt PrefetchOptions) *Prefetch {
 		opt.PrefetchCacheSize = opt.PrefetchMaxItems * 3
 	}
 
+	nameShards := shards
+	queryShards := shards
+	if shards == 0 {
+		nameShards = expirationCacheShards(opt.PrefetchCacheSize)
+		queryShards = expirationCacheShards(opt.PrefetchMaxItems)
+	}
+
 	r := &Prefetch{
 		id:       id,
 		resolver: resolver,
@@ -47,9 +63,11 @@ func NewPrefetch(id string, resolver Resolver, opt PrefetchOptions) *Prefetch {
 	}
 	r.nameCache = expirationcache.NewCache[atomic.Uint64](context.Background(), expirationcache.Options{
 		MaxSize: uint(opt.PrefetchCacheSize),
+		Shards:  nameShards,
 	})
 	r.queryCache = expirationcache.NewCacheWithOnExpired(context.Background(), expirationcache.Options{
 		MaxSize: uint(opt.PrefetchMaxItems),
+		Shards:  queryShards,
 	},
 		func(ctx context.Context, key string) (val *dns.Msg, ttl time.Duration) {
 			// Check if the query is still eligible for prefetch by looking it up in the nameCache
@@ -89,6 +107,14 @@ func NewPrefetch(id string, resolver Resolver, opt PrefetchOptions) *Prefetch {
 	)
 
 	return r
+}
+
+func expirationCacheShards(maxSize int) uint {
+	gomaxprocs := runtime.GOMAXPROCS(0)
+	if gomaxprocs <= 1 || maxSize == 1 {
+		return 0
+	}
+	return uint(gomaxprocs)
 }
 
 func (r *Prefetch) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {

--- a/prefetch_bench_test.go
+++ b/prefetch_bench_test.go
@@ -1,0 +1,72 @@
+package rdns
+
+import (
+	"fmt"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// answerResolver returns a valid, cacheable response (success, untruncated,
+// TTL >= 2) so that Prefetch.Resolve exercises its cache read/write path
+// rather than bailing out early.
+type answerResolver struct{}
+
+func (answerResolver) Resolve(q *dns.Msg, _ ClientInfo) (*dns.Msg, error) {
+	a := new(dns.Msg)
+	a.SetReply(q)
+	if len(q.Question) > 0 {
+		rr, _ := dns.NewRR(q.Question[0].Name + " 60 IN A 192.0.2.1")
+		a.Answer = append(a.Answer, rr)
+	}
+	return a, nil
+}
+
+func (answerResolver) String() string { return "answerResolver()" }
+
+// benchPrefetch drives Prefetch.Resolve concurrently across a spread of
+// distinct query names. The number of distinct names controls how much the
+// goroutines collide on the same cache keys/shards. shards selects the cache
+// sharding: 1 means a single shard (the pre-change behavior), >1 forces that
+// many shards (the post-change behavior uses GOMAXPROCS).
+func benchPrefetch(b *testing.B, distinctNames int, shards uint) {
+	// Build a Prefetch but override the shard count so we can compare
+	// sharded vs unsharded independently of GOMAXPROCS.
+	r := newPrefetchWithShards("bench", answerResolver{}, PrefetchOptions{
+		PrefetchThreshold: 1, // cache on the first hit so writes happen every call
+		PrefetchMaxItems:  distinctNames * 2,
+		PrefetchCacheSize: distinctNames * 6,
+	}, shards)
+
+	names := make([]string, distinctNames)
+	for i := range names {
+		names[i] = fmt.Sprintf("host%d.example.com.", i)
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		var i uint64
+		q := new(dns.Msg)
+		for pb.Next() {
+			name := names[atomic.AddUint64(&i, 1)%uint64(distinctNames)]
+			q.SetQuestion(name, dns.TypeA)
+			if _, err := r.Resolve(q, ClientInfo{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// Few distinct names => heavy contention on the same shards.
+func BenchmarkPrefetchHotKeysUnsharded(b *testing.B) { benchPrefetch(b, 8, 1) }
+func BenchmarkPrefetchHotKeysSharded(b *testing.B) {
+	benchPrefetch(b, 8, uint(runtime.GOMAXPROCS(0)))
+}
+
+// Many distinct names => writes spread across keys (and shards).
+func BenchmarkPrefetchSpreadUnsharded(b *testing.B) { benchPrefetch(b, 4096, 1) }
+func BenchmarkPrefetchSpreadSharded(b *testing.B) {
+	benchPrefetch(b, 4096, uint(runtime.GOMAXPROCS(0)))
+}

--- a/prefetch_test.go
+++ b/prefetch_test.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -27,4 +28,18 @@ func TestPrefetchPassthrough(t *testing.T) {
 	a, err := r.Resolve(q, ClientInfo{})
 	require.NoError(t, err)
 	require.NotNil(t, a)
+}
+
+func TestExpirationCacheShards(t *testing.T) {
+	old := runtime.GOMAXPROCS(4)
+	t.Cleanup(func() {
+		runtime.GOMAXPROCS(old)
+	})
+
+	require.Equal(t, uint(4), expirationCacheShards(0))
+	require.Equal(t, uint(4), expirationCacheShards(100))
+	require.Equal(t, uint(0), expirationCacheShards(1))
+
+	runtime.GOMAXPROCS(1)
+	require.Equal(t, uint(0), expirationCacheShards(100))
 }


### PR DESCRIPTION
Saw the library got updated, so got Claude to investigate if it is useful and it did see some improvements so raising it as a PR. Please feel free to close if you think otherwise

## Summary

This updates the dedicated `prefetch` resolver to use the sharding support added
in `github.com/0xERR0R/expiration-cache` v0.2.0.

Both internal prefetch tracking caches now set `Options.Shards` automatically
based on `runtime.GOMAXPROCS(0)`. Single-core processes and cache capacities of
one remain unsharded.

## Rationale

`expiration-cache` uses an LRU internally, and `Get` updates recency. That means
prefetch cache reads still take an LRU lock. Under concurrent DNS traffic, the
dedicated `prefetch` group can hit these caches frequently:

- `nameCache.Get` / `nameCache.Put` for successful prefetch-eligible responses
- `queryCache.Put` once a query reaches the configured threshold
- `queryCache.Get` from the expiration callback when refreshing hot entries

v0.2.0 can split the cache across independent LRU shards, reducing lock
contention when different query names are handled concurrently on multi-core
systems.

## Benchmarks

`BenchmarkPrefetch*` drives `Prefetch.Resolve` concurrently (`-cpu=8`) and
compares a single-shard cache (previous behavior) against a GOMAXPROCS-sharded
cache. The benchmark uses an instant in-memory resolver to isolate the prefetch
group's own cache bookkeeping. Median of 5 runs on a 4-core host:

| Scenario | Unsharded | Sharded | In-bookkeeping delta |
|---|---|---|---|
| Hot keys (8 names, high contention) | 4033 ns/op | 3537 ns/op | ~12% lower |
| Spread (4096 names, low contention) | 4076 ns/op | 3045 ns/op | ~25% lower |

Allocations are unchanged (26 allocs/op) — sharding only splits the lock and
adds no per-query overhead.

**Scope of the win:** this is a sub-microsecond reduction in the prefetch
group's in-process bookkeeping, not an end-to-end speedup. Real queries are
dominated by upstream network/TLS latency (milliseconds), so this change is
not observable in user-facing query latency. It only relieves lock contention,
and only matters at high concurrent QPS on multi-core systems. Treat it as a
defensive scalability improvement that comes for free with the v0.2.0 upgrade,
not a latency optimization.

## Tradeoff

With sharding enabled, LRU eviction is per-shard rather than globally exact. For
prefetch tracking this is acceptable because the data is approximate popularity
bookkeeping, not authoritative DNS response storage.

## Changes

- Bump `github.com/0xERR0R/expiration-cache` to v0.2.0 (adds `Options.Shards`).
- Add `expirationCacheShards` helper for selecting a shard count.
- Configure sharding for both prefetch expiration caches.
- Refactor `NewPrefetch` to delegate to an internal `newPrefetchWithShards`
  constructor so the shard count can be forced in benchmarks; `NewPrefetch`
  keeps the existing auto-sizing behavior.
- Add a focused unit test for shard selection and concurrent `Resolve`
  benchmarks comparing sharded vs. unsharded.

## Testing

```sh
go test -run 'TestPrefetch|TestExpirationCacheShards' .
go test -run '^$' -bench 'BenchmarkPrefetch' -benchmem -cpu=8 .
```