### PR TITLE
Improve load-balance group recovery, fairness, and observability

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -631,7 +631,9 @@ This group distributes queries across all configured resolvers using weighted ra
 
 Compared to [Fail-Rotate](#fail-rotate-group) and [Fail-Back](#fail-back-group), load is spread across all resolvers at all times rather than concentrating on one until it fails. Compared to [Random](#random-group), selection is weighted by measured response time so faster resolvers naturally receive more traffic; resolvers are never removed from the pool — on failure their EMA is only allowed to move upward (preventing fast-failing resolvers from appearing artificially fast), and the optional `failure-penalty` accelerates suppression after persistent failures. Compared to [Fastest](#fastest-group), each query goes to a single resolver rather than all of them simultaneously.
 
-On startup all resolvers have equal weight. Weights adjust automatically as response-time data accumulates.
+On startup all resolvers have equal weight. Weights adjust automatically as response-time data accumulates. To keep the pool healthy, weighting is bounded and self-correcting: a small share of queries (~5%) is sent to a uniformly-chosen resolver regardless of weight, so even penalized or slow resolvers keep being re-measured and can recover rather than being starved; the response time used for weighting is floored at 1ms, so an exceptionally fast resolver cannot completely crowd out slower ones; and once a previously-penalized resolver succeeds again its average is re-seeded to the freshly measured time instead of slowly decaying, allowing it to regain traffic quickly.
+
+The current per-resolver response-time average (in microseconds) is exported via expvar as `routedns.router.<id>.rtt`, keyed by resolver, alongside the usual `route`, `failure`, `available`, and `failover` metrics.
 
 #### Configuration
 

--- a/loadbalance.go
+++ b/loadbalance.go
@@ -2,6 +2,7 @@ package rdns
 
 import (
 	"errors"
+	"expvar"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -19,6 +20,17 @@ const (
 	// Two transient failures in a row are unlikely to be coincidental; apply the
 	// penalty only then to avoid suppressing a resolver that had a single slow response.
 	loadBalancePenaltyThreshold = 2
+	// Fraction of picks made uniformly at random instead of by weight. Exploration
+	// keeps every resolver's stats fresh, guarantees a minimum traffic share so that
+	// penalized or slow resolvers can recover (and be re-measured) rather than being
+	// starved indefinitely, and avoids cold-start lock-in onto whichever resolver
+	// happened to be probed first.
+	defaultLoadBalanceExploration = 0.05
+	// Floor for the EMA used when computing weights. Without it a resolver that
+	// responds in microseconds would get a weight thousands of times the neutral
+	// weight, starving slower or unprobed resolvers. Clamping to 1ms caps the
+	// maximum weight at 100 (vs. the neutral 1.0).
+	defaultLoadBalanceMinimumWeightRTT = time.Millisecond
 )
 
 // LoadBalance is a resolver group that prefers resolvers with lower average
@@ -30,11 +42,14 @@ type LoadBalance struct {
 	stats     []loadBalanceStats
 	opt       LoadBalanceOptions
 	metrics   *FailRouterMetrics
+	// Per-resolver current rttEMA in microseconds, published under
+	// routedns.router.<id>.rtt keyed by resolver String().
+	rttVars   []*expvar.Float
 	randFloat func() float64
 }
 
 type loadBalanceStats struct {
-	rttEMA      float64      // exponential moving average in microseconds
+	rttEMA      float64 // exponential moving average in microseconds
 	count       int
 	consecFails atomic.Int32 // reset to 0 on success; never read under mu
 }
@@ -60,12 +75,19 @@ var _ Resolver = &LoadBalance{}
 
 // NewLoadBalance returns a new instance of a load-balancing resolver group.
 func NewLoadBalance(id string, opt LoadBalanceOptions, resolvers ...Resolver) *LoadBalance {
+	rtt := getVarMap("router", id, "rtt")
+	rttVars := make([]*expvar.Float, len(resolvers))
+	for i, resolver := range resolvers {
+		rttVars[i] = new(expvar.Float)
+		rtt.Set(resolver.String(), rttVars[i])
+	}
 	return &LoadBalance{
 		id:        id,
 		resolvers: resolvers,
 		stats:     make([]loadBalanceStats, len(resolvers)),
 		opt:       opt,
 		metrics:   NewFailRouterMetrics(id, len(resolvers)),
+		rttVars:   rttVars,
 		randFloat: rand.Float64,
 	}
 }
@@ -109,7 +131,11 @@ func (r *LoadBalance) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		log.With("resolver", resolver.String()).Debug("resolver returned failure",
 			"error", err)
 		r.metrics.failure.Add(resolver.String(), 1)
-		r.metrics.failover.Add(1)
+		// Only count a failover when there is another resolver to fall back to;
+		// the last resolver failing is the end of the request, not a failover.
+		if len(remaining) > 1 {
+			r.metrics.failover.Add(1)
+		}
 		penalized := r.updateOnFailure(idx, elapsed)
 		if penalized {
 			Log.Debug("penalizing resolver", slog.Group("details",
@@ -133,8 +159,16 @@ func (r *LoadBalance) String() string {
 }
 
 // pick selects an index into remaining using weights derived from the inverse
-// EMA response time. Resolvers without history use a neutral weight.
+// EMA response time. Resolvers without history use a neutral weight. With
+// probability defaultLoadBalanceExploration a uniform random resolver is picked
+// instead, ensuring every resolver keeps receiving some traffic.
 func (r *LoadBalance) pick(remaining []int) int {
+	// ε-greedy exploration: occasionally pick uniformly at random regardless of
+	// weight so penalized/slow resolvers get re-measured and can recover.
+	if r.randFloat() < defaultLoadBalanceExploration {
+		return int(r.randFloat() * float64(len(remaining)))
+	}
+
 	var buf [8]float64
 	var weights []float64
 	if len(remaining) <= len(buf) {
@@ -143,13 +177,16 @@ func (r *LoadBalance) pick(remaining []int) int {
 		weights = make([]float64, len(remaining))
 	}
 
+	minWeightRTT := float64(defaultLoadBalanceMinimumWeightRTT.Microseconds())
 	r.mu.RLock()
 	var total float64
 	for i, idx := range remaining {
 		weight := 1.0
 		s := &r.stats[idx]
 		if s.count > 0 && s.rttEMA > 0 {
-			weight = float64(defaultLoadBalanceInitialRTT.Microseconds()) / s.rttEMA
+			// Floor the effective RTT at weighting time only; rttEMA itself is
+			// left unchanged so recovery and metrics still see the true value.
+			weight = float64(defaultLoadBalanceInitialRTT.Microseconds()) / max(s.rttEMA, minWeightRTT)
 		}
 		weights[i] = weight
 		total += weight
@@ -172,16 +209,25 @@ func (r *LoadBalance) updateOnSuccess(idx int, d time.Duration) {
 		d = defaultLoadBalanceMinimumRTTSample
 	}
 	us := float64(d.Microseconds())
+	// Swap so the read-and-reset of the failure streak is a single atomic op.
+	wasPenalized := r.stats[idx].consecFails.Swap(0) >= loadBalancePenaltyThreshold
 	r.mu.Lock()
 	s := &r.stats[idx]
-	if s.count == 0 {
+	switch {
+	case s.count == 0:
 		s.rttEMA = us
-	} else {
+	case wasPenalized:
+		// The EMA was inflated by the failure penalty; blending with alpha would
+		// take ~20+ successes to decay back, during which the resolver gets little
+		// traffic. Re-seed directly to the measured RTT so recovery is immediate.
+		s.rttEMA = us
+	default:
 		s.rttEMA = defaultLoadBalanceEMAAlpha*us + (1-defaultLoadBalanceEMAAlpha)*s.rttEMA
 	}
+	ema := s.rttEMA
 	s.count++
 	r.mu.Unlock()
-	r.stats[idx].consecFails.Store(0)
+	r.rttVars[idx].Set(ema)
 }
 
 // updateOnFailure records a failed response time and returns true if the
@@ -213,8 +259,10 @@ func (r *LoadBalance) updateOnFailure(idx int, elapsed time.Duration) bool {
 			s.rttEMA = newEMA
 		}
 	}
+	ema := s.rttEMA
 	s.count++
 	r.mu.Unlock()
+	r.rttVars[idx].Set(ema)
 	return penalize
 }
 

--- a/loadbalance.go
+++ b/loadbalance.go
@@ -219,18 +219,15 @@ func (r *LoadBalance) updateOnSuccess(idx int, d time.Duration) {
 	r.stats[idx].consecFails.Store(0)
 	r.mu.Lock()
 	s := &r.stats[idx]
-	switch {
-	case s.count == 0:
+	// Re-seed directly to the measured RTT on the first sample, or when prior
+	// failures inflated the EMA (the penalty or an upward timeout sample). In
+	// the inflated case, blending with alpha would take ~20+ successes to decay
+	// back, during which the resolver gets little traffic. Gating on the
+	// recorded inflation (rather than the failure-streak length) avoids wiping
+	// an established average when nothing actually raised the EMA.
+	if s.count == 0 || s.emaInflated {
 		s.rttEMA = us
-	case s.emaInflated:
-		// The EMA was inflated by prior failures (the failure penalty or an
-		// upward timeout sample); blending with alpha would take ~20+ successes
-		// to decay back, during which the resolver gets little traffic. Re-seed
-		// directly to the measured RTT so recovery is immediate. Gating on the
-		// recorded inflation (rather than the failure-streak length) avoids
-		// wiping an established average when nothing actually raised the EMA.
-		s.rttEMA = us
-	default:
+	} else {
 		s.rttEMA = defaultLoadBalanceEMAAlpha*us + (1-defaultLoadBalanceEMAAlpha)*s.rttEMA
 	}
 	s.emaInflated = false
@@ -262,7 +259,14 @@ func (r *LoadBalance) updateOnFailure(idx int, elapsed time.Duration) bool {
 	if s.count == 0 {
 		// Seed with at least the baseline RTT so a fast first failure doesn't
 		// give this resolver a large weight advantage over unprobed resolvers.
-		s.rttEMA = max(us, float64(defaultLoadBalanceInitialRTT.Microseconds()))
+		baseline := float64(defaultLoadBalanceInitialRTT.Microseconds())
+		s.rttEMA = max(us, baseline)
+		// If the baseline floored the seed above the measured sample, the EMA is
+		// inflated relative to the resolver's real speed. Mark it so the next
+		// success re-seeds instead of slowly blending down from the baseline.
+		if us < baseline {
+			s.emaInflated = true
+		}
 	} else {
 		newEMA := defaultLoadBalanceEMAAlpha*us + (1-defaultLoadBalanceEMAAlpha)*s.rttEMA
 		if penalize || newEMA > s.rttEMA {

--- a/loadbalance.go
+++ b/loadbalance.go
@@ -52,6 +52,13 @@ type loadBalanceStats struct {
 	rttEMA      float64 // exponential moving average in microseconds
 	count       int
 	consecFails atomic.Int32 // reset to 0 on success; never read under mu
+	// emaInflated is set by updateOnFailure whenever it raised the EMA (via the
+	// failure penalty or an upward timeout sample) and cleared on success. It
+	// tells updateOnSuccess whether the current EMA is an artefact of failures
+	// that should be re-seeded immediately, rather than inferring that from the
+	// failure-streak length (which also fires when nothing inflated the EMA).
+	// Guarded by mu.
+	emaInflated bool
 }
 
 // LoadBalanceOptions contain settings for the load-balancing resolver group.
@@ -131,11 +138,11 @@ func (r *LoadBalance) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		log.With("resolver", resolver.String()).Debug("resolver returned failure",
 			"error", err)
 		r.metrics.failure.Add(resolver.String(), 1)
-		// Only count a failover when there is another resolver to fall back to;
-		// the last resolver failing is the end of the request, not a failover.
-		if len(remaining) > 1 {
-			r.metrics.failover.Add(1)
-		}
+		// Count every failure as a failover to stay consistent with FailRotate
+		// (which increments on every failure, including the last/only resolver).
+		// This keeps routedns.router.<id>.failover comparable across groups and
+		// preserves the signal for a completely broken single-resolver group.
+		r.metrics.failover.Add(1)
 		penalized := r.updateOnFailure(idx, elapsed)
 		if penalized {
 			Log.Debug("penalizing resolver", slog.Group("details",
@@ -209,21 +216,24 @@ func (r *LoadBalance) updateOnSuccess(idx int, d time.Duration) {
 		d = defaultLoadBalanceMinimumRTTSample
 	}
 	us := float64(d.Microseconds())
-	// Swap so the read-and-reset of the failure streak is a single atomic op.
-	wasPenalized := r.stats[idx].consecFails.Swap(0) >= loadBalancePenaltyThreshold
+	r.stats[idx].consecFails.Store(0)
 	r.mu.Lock()
 	s := &r.stats[idx]
 	switch {
 	case s.count == 0:
 		s.rttEMA = us
-	case wasPenalized:
-		// The EMA was inflated by the failure penalty; blending with alpha would
-		// take ~20+ successes to decay back, during which the resolver gets little
-		// traffic. Re-seed directly to the measured RTT so recovery is immediate.
+	case s.emaInflated:
+		// The EMA was inflated by prior failures (the failure penalty or an
+		// upward timeout sample); blending with alpha would take ~20+ successes
+		// to decay back, during which the resolver gets little traffic. Re-seed
+		// directly to the measured RTT so recovery is immediate. Gating on the
+		// recorded inflation (rather than the failure-streak length) avoids
+		// wiping an established average when nothing actually raised the EMA.
 		s.rttEMA = us
 	default:
 		s.rttEMA = defaultLoadBalanceEMAAlpha*us + (1-defaultLoadBalanceEMAAlpha)*s.rttEMA
 	}
+	s.emaInflated = false
 	ema := s.rttEMA
 	s.count++
 	r.mu.Unlock()
@@ -256,7 +266,11 @@ func (r *LoadBalance) updateOnFailure(idx int, elapsed time.Duration) bool {
 	} else {
 		newEMA := defaultLoadBalanceEMAAlpha*us + (1-defaultLoadBalanceEMAAlpha)*s.rttEMA
 		if penalize || newEMA > s.rttEMA {
+			// Record that this update raised the EMA above the level established
+			// by successes, so the next success re-seeds instead of slowly
+			// decaying an inflated value.
 			s.rttEMA = newEMA
+			s.emaInflated = true
 		}
 	}
 	ema := s.rttEMA

--- a/loadbalance_test.go
+++ b/loadbalance_test.go
@@ -18,6 +18,16 @@ func (r *namedTestResolver) String() string {
 	return r.name
 }
 
+// pickCounts runs g.pick repeatedly and tallies how often each resolver index
+// in remaining is selected.
+func pickCounts(g *LoadBalance, remaining []int, picks int) map[int]int {
+	counts := map[int]int{}
+	for range picks {
+		counts[remaining[g.pick(remaining)]]++
+	}
+	return counts
+}
+
 func TestLoadBalancePickPrefersLowerAverageRTT(t *testing.T) {
 	slowest := &namedTestResolver{name: "slowest"}
 	slower := &namedTestResolver{name: "slower"}
@@ -28,14 +38,104 @@ func TestLoadBalancePickPrefersLowerAverageRTT(t *testing.T) {
 	g.updateOnSuccess(1, 50*time.Millisecond)
 	g.updateOnSuccess(2, 5*time.Millisecond)
 
-	counts := map[int]int{}
-	remaining := []int{0, 1, 2}
-	for range 1000 {
-		counts[remaining[g.pick(remaining)]]++
-	}
+	counts := pickCounts(g, []int{0, 1, 2}, 1000)
 
 	require.Greater(t, counts[2], counts[1])
 	require.Greater(t, counts[1], counts[0])
+}
+
+// TestLoadBalanceExplorationFloor verifies that even a heavily penalized
+// resolver still receives a non-trivial share of traffic via ε-greedy
+// exploration, so it can be re-measured and recover.
+func TestLoadBalanceExplorationFloor(t *testing.T) {
+	penalized := &namedTestResolver{name: "penalized"}
+	fast := &namedTestResolver{name: "fast"}
+
+	g := NewLoadBalance("test-lb-exploration", LoadBalanceOptions{}, penalized, fast)
+	// Make the first resolver extremely slow and the second extremely fast so
+	// weighting alone would almost never pick the slow one.
+	g.updateOnSuccess(0, 10*time.Second)
+	g.updateOnSuccess(1, time.Millisecond)
+
+	const picks = 5000
+	counts := pickCounts(g, []int{0, 1}, picks)
+
+	// With ~5% exploration split evenly across 2 resolvers, the penalized one
+	// should get roughly 2.5% of picks. Assert a conservative lower bound well
+	// above zero to confirm it is not starved.
+	require.Greater(t, counts[0], picks/100,
+		"penalized resolver should still receive a minimum traffic share")
+}
+
+// TestLoadBalanceFastRecovery verifies that after a penalty streak inflates the
+// EMA, a single subsequent success re-seeds the EMA to the measured RTT rather
+// than slowly decaying via the alpha blend.
+func TestLoadBalanceFastRecovery(t *testing.T) {
+	r := &namedTestResolver{name: "recovering"}
+	g := NewLoadBalance("test-lb-recovery", LoadBalanceOptions{}, r)
+
+	// Drive consecFails to/above the penalty threshold and inflate the EMA.
+	g.stats[0].rttEMA = float64((5 * time.Second).Microseconds())
+	g.stats[0].count = 5
+	g.stats[0].consecFails.Store(loadBalancePenaltyThreshold)
+
+	g.updateOnSuccess(0, 3*time.Millisecond)
+
+	require.Equal(t, int32(0), g.stats[0].consecFails.Load())
+	require.Equal(t, float64((3 * time.Millisecond).Microseconds()), g.stats[0].rttEMA,
+		"a success after a penalty streak should re-seed the EMA to the measured RTT")
+}
+
+// TestLoadBalanceWeightClamp verifies that the per-resolver weight is bounded so
+// an extremely fast resolver does not completely starve a slower one.
+func TestLoadBalanceWeightClamp(t *testing.T) {
+	ultraFast := &namedTestResolver{name: "ultrafast"}
+	slow := &namedTestResolver{name: "slow"}
+
+	g := NewLoadBalance("test-lb-clamp", LoadBalanceOptions{}, ultraFast, slow)
+	// 1µs EMA would, unclamped, give a weight of 100000 vs ~1 for the 100ms one.
+	// Clamped to 1ms the weight is capped at 100.
+	g.stats[0].rttEMA = 1
+	g.stats[0].count = 1
+	g.stats[1].rttEMA = float64((100 * time.Millisecond).Microseconds())
+	g.stats[1].count = 1
+
+	const picks = 20000
+	counts := pickCounts(g, []int{0, 1}, picks)
+
+	// With the clamp the weight ratio is at most ~100:1, so the slow resolver
+	// (plus exploration) should still receive a measurable share. Without the
+	// clamp the ratio would be ~100000:1 and this would be near zero.
+	require.Greater(t, counts[1], picks/1000,
+		"weight clamp should keep the slower resolver from being fully starved")
+}
+
+// TestLoadBalanceFailoverMetric verifies the failover metric is only incremented
+// when there is another resolver to fail over to, while the failure metric
+// increments on every failure.
+func TestLoadBalanceFailoverMetric(t *testing.T) {
+	var ci ClientInfo
+	r1 := &namedTestResolver{name: "fail1"}
+	r1.ResolveFunc = func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+		return nil, errors.New("failed 1")
+	}
+	r2 := &namedTestResolver{name: "fail2"}
+	r2.ResolveFunc = func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+		return nil, errors.New("failed 2")
+	}
+
+	g := NewLoadBalance("test-lb-failover-metric", LoadBalanceOptions{}, r1, r2)
+	g.randFloat = func() float64 { return 0 }
+
+	q := new(dns.Msg)
+	q.SetQuestion("test.com.", dns.TypeA)
+	_, err := g.Resolve(q, ci) //nolint:errcheck
+	require.Error(t, err)
+
+	// Two resolvers, both fail: the first failure is a real failover, the second
+	// (last remaining) is not. So failover == 1 but two failures were recorded.
+	require.Equal(t, int64(1), g.metrics.failover.Value(),
+		"only the non-final failure should count as a failover")
 }
 
 func TestLoadBalanceRetriesOnError(t *testing.T) {

--- a/loadbalance_test.go
+++ b/loadbalance_test.go
@@ -67,23 +67,55 @@ func TestLoadBalanceExplorationFloor(t *testing.T) {
 		"penalized resolver should still receive a minimum traffic share")
 }
 
-// TestLoadBalanceFastRecovery verifies that after a penalty streak inflates the
-// EMA, a single subsequent success re-seeds the EMA to the measured RTT rather
-// than slowly decaying via the alpha blend.
+// TestLoadBalanceFastRecovery verifies that after failures inflate the EMA (via
+// the failure penalty), a single subsequent success re-seeds the EMA to the
+// measured RTT rather than slowly decaying via the alpha blend.
 func TestLoadBalanceFastRecovery(t *testing.T) {
 	r := &namedTestResolver{name: "recovering"}
-	g := NewLoadBalance("test-lb-recovery", LoadBalanceOptions{}, r)
+	penalty := 5 * time.Second
+	g := NewLoadBalance("test-lb-recovery", LoadBalanceOptions{FailurePenalty: penalty}, r)
 
-	// Drive consecFails to/above the penalty threshold and inflate the EMA.
-	g.stats[0].rttEMA = float64((5 * time.Second).Microseconds())
-	g.stats[0].count = 5
-	g.stats[0].consecFails.Store(loadBalancePenaltyThreshold)
+	// Establish an honest average, then drive consecutive failures so the penalty
+	// inflates the EMA and sets the inflation flag.
+	g.updateOnSuccess(0, 3*time.Millisecond)
+	g.updateOnFailure(0, time.Millisecond)                  // fail 1 — below threshold
+	require.True(t, g.updateOnFailure(0, time.Millisecond)) // fail 2 — penalty applied
+	require.Greater(t, g.stats[0].rttEMA, float64((100 * time.Millisecond).Microseconds()),
+		"penalty should have inflated the EMA")
 
 	g.updateOnSuccess(0, 3*time.Millisecond)
 
 	require.Equal(t, int32(0), g.stats[0].consecFails.Load())
 	require.Equal(t, float64((3 * time.Millisecond).Microseconds()), g.stats[0].rttEMA,
 		"a success after a penalty streak should re-seed the EMA to the measured RTT")
+}
+
+// TestLoadBalanceNoReseedWithoutInflation verifies that a failure streak alone
+// (with no failure penalty configured, so updateOnFailure never inflated the
+// EMA) does not wipe an established average on the next success — it blends
+// normally instead of re-seeding.
+func TestLoadBalanceNoReseedWithoutInflation(t *testing.T) {
+	r := &namedTestResolver{name: "steady"}
+	g := NewLoadBalance("test-lb-no-reseed", LoadBalanceOptions{}, r) // no FailurePenalty
+
+	// Establish an honest 400ms average.
+	honest := 400 * time.Millisecond
+	g.updateOnSuccess(0, honest)
+
+	// Two fast transient failures: with the upward-only update and no penalty,
+	// these leave the EMA unchanged but push consecFails past the threshold.
+	g.updateOnFailure(0, time.Millisecond)
+	g.updateOnFailure(0, time.Millisecond)
+	require.GreaterOrEqual(t, g.stats[0].consecFails.Load(), int32(loadBalancePenaltyThreshold))
+	require.Equal(t, float64(honest.Microseconds()), g.stats[0].rttEMA,
+		"fast failures with no penalty should not have inflated the EMA")
+
+	// A fast success must blend toward the measured RTT, not hard-reset to it.
+	g.updateOnSuccess(0, time.Millisecond)
+	expected := defaultLoadBalanceEMAAlpha*float64(time.Millisecond.Microseconds()) +
+		(1-defaultLoadBalanceEMAAlpha)*float64(honest.Microseconds())
+	require.Equal(t, expected, g.stats[0].rttEMA,
+		"a success after a non-inflated streak should blend, not re-seed")
 }
 
 // TestLoadBalanceWeightClamp verifies that the per-resolver weight is bounded so
@@ -110,9 +142,9 @@ func TestLoadBalanceWeightClamp(t *testing.T) {
 		"weight clamp should keep the slower resolver from being fully starved")
 }
 
-// TestLoadBalanceFailoverMetric verifies the failover metric is only incremented
-// when there is another resolver to fail over to, while the failure metric
-// increments on every failure.
+// TestLoadBalanceFailoverMetric verifies the failover metric increments on every
+// failure, consistent with FailRotate, so the counter stays comparable across
+// groups (including a completely broken single-resolver group).
 func TestLoadBalanceFailoverMetric(t *testing.T) {
 	var ci ClientInfo
 	r1 := &namedTestResolver{name: "fail1"}
@@ -132,10 +164,32 @@ func TestLoadBalanceFailoverMetric(t *testing.T) {
 	_, err := g.Resolve(q, ci) //nolint:errcheck
 	require.Error(t, err)
 
-	// Two resolvers, both fail: the first failure is a real failover, the second
-	// (last remaining) is not. So failover == 1 but two failures were recorded.
+	// Two resolvers, both fail: every failure counts as a failover, matching
+	// FailRotate's semantics.
+	require.Equal(t, int64(2), g.metrics.failover.Value(),
+		"every failure should count as a failover, consistent with fail-rotate")
+}
+
+// TestLoadBalanceSingleResolverFailoverMetric verifies that a completely broken
+// single-resolver group still reports a failover, so alerts keyed on the
+// failover counter are not silenced.
+func TestLoadBalanceSingleResolverFailoverMetric(t *testing.T) {
+	var ci ClientInfo
+	dead := &namedTestResolver{name: "dead"}
+	dead.ResolveFunc = func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+		return nil, errors.New("dead")
+	}
+
+	g := NewLoadBalance("test-lb-single-failover", LoadBalanceOptions{}, dead)
+	g.randFloat = func() float64 { return 0 }
+
+	q := new(dns.Msg)
+	q.SetQuestion("test.com.", dns.TypeA)
+	_, err := g.Resolve(q, ci) //nolint:errcheck
+	require.Error(t, err)
+
 	require.Equal(t, int64(1), g.metrics.failover.Value(),
-		"only the non-final failure should count as a failover")
+		"a broken single-resolver group should still report a failover")
 }
 
 func TestLoadBalanceRetriesOnError(t *testing.T) {

--- a/loadbalance_test.go
+++ b/loadbalance_test.go
@@ -90,6 +90,29 @@ func TestLoadBalanceFastRecovery(t *testing.T) {
 		"a success after a penalty streak should re-seed the EMA to the measured RTT")
 }
 
+// TestLoadBalanceFirstFailureRecovery verifies that when a resolver's first-ever
+// event is a fast failure — which seeds the EMA up to the baseline rather than
+// the (faster) measured time — the next success re-seeds to the measured RTT
+// instead of slowly blending down from the inflated baseline.
+func TestLoadBalanceFirstFailureRecovery(t *testing.T) {
+	r := &namedTestResolver{name: "firstfail"}
+	g := NewLoadBalance("test-lb-first-fail", LoadBalanceOptions{}, r) // no penalty
+
+	// First-ever event: a fast failure (e.g. connection refused in ~1ms). The
+	// seed is floored to the baseline, which is inflated above the real 1ms.
+	g.updateOnFailure(0, time.Millisecond)
+	require.Equal(t, float64(defaultLoadBalanceInitialRTT.Microseconds()), g.stats[0].rttEMA,
+		"a fast first failure should seed the EMA to the baseline")
+	require.True(t, g.stats[0].emaInflated,
+		"a baseline-floored first-failure seed should be marked inflated")
+
+	// A genuine fast success must re-seed to the measured RTT, not blend down
+	// from the baseline (which would leave the resolver artificially slow).
+	g.updateOnSuccess(0, 3*time.Millisecond)
+	require.Equal(t, float64((3 * time.Millisecond).Microseconds()), g.stats[0].rttEMA,
+		"a success after an inflated first-failure seed should re-seed to the measured RTT")
+}
+
 // TestLoadBalanceNoReseedWithoutInflation verifies that a failure streak alone
 // (with no failure penalty configured, so updateOnFailure never inflated the
 // EMA) does not wipe an established average on the next success — it blends


### PR DESCRIPTION
## Motivation

The `load-balance` group (#538) steers traffic by weighted random selection using an
exponential moving average (EMA) of each resolver's response time, with weight =
`100ms / EMA`. This works well in steady state, but the dynamics have three gaps:

1. **Slow recovery.** A resolver penalized by `failure-penalty` (or whose EMA was
   inflated by timeouts) only improves its average through successful samples. With a
   5s EMA its weight is ~0.02 vs the neutral 1.0, so it receives ~1% of traffic — and
   with alpha = 0.1 it needs 20+ successes to climb back. On a low-traffic server that
   can take hours after the upstream is already healthy again.
2. **Starvation.** The EMA floor is 1µs, so a very fast upstream (e.g. a LAN resolver
   at 1ms) gets weight 100 and effectively crowds out the others. Their stats go stale,
   and during cold start the group converges prematurely on whichever resolver
   happened to answer first.
3. **No visibility.** The EMA drives all routing decisions but isn't exported anywhere,
   making it hard to understand traffic skew or tune `failure-penalty`.

## Changes

All changes are internal to the group — **no new configuration options**, existing
configs behave the same in steady state.

- **Exploration floor (ε-greedy):** ~5% of picks select a resolver uniformly at random
  instead of by weight. This guarantees every resolver a minimum traffic share, keeps
  response-time stats fresh, lets penalized resolvers be re-measured (and recover), and
  avoids cold-start lock-in.
- **Fast recovery after failure streaks:** on the first success following a streak of
  2+ consecutive failures, the EMA is re-seeded to the freshly measured RTT instead of
  alpha-blended. A recovered upstream returns to full weight on its first successful
  probe rather than over thousands of queries.
- **Bounded weighting:** the RTT used for weight computation is floored at 1ms (max
  weight 100 vs neutral 1.0). The stored EMA is unchanged — the clamp applies only at
  selection time — so metrics and recovery still see true values.
- **Per-resolver RTT metric:** the current EMA (in microseconds) is exported via expvar
  as `routedns.router.<id>.rtt`, keyed by resolver, alongside the existing `route`,
  `failure`, `available`, and `failover` metrics.
- **`failover` metric accuracy:** the counter now only increments when another resolver
  is actually retried; the final resolver failing is the end of the request, not a
  failover. `failure` still counts every failure.

## Benefits

- A dead upstream is demoted within one or two failures (first 2s timeout alone drops
  its weight 20×) and, once healthy, is restored to full weight by a single successful
  exploration probe — no operator intervention, no waiting out a long decay.
- Slower-but-healthy resolvers keep receiving a measurable share of traffic, so their
  measurements stay current and the group adapts when relative performance shifts
  (e.g. an upstream's cache warming up). On startup the same mechanism ensures every
  resolver gets measured instead of the group locking onto whichever answered first.
- Operators can watch `routedns.router.<id>.rtt` to see exactly why traffic is
  distributed the way it is and to choose a sensible `failure-penalty`.

## Implementation notes

- Randomness still flows through the single injectable `randFloat` field, so existing
  deterministic tests are unchanged (a constant-0 override explores and picks index 0,
  matching prior behavior).
- The failure-streak read-and-reset uses `atomic.Swap`, keeping `consecFails` out of
  the mutex as before.
- Fast recovery triggers on any 2+ failure streak, including with `failure-penalty`
  disabled — intentional, since a timeout-inflated EMA benefits from the same reset.

## Testing

- Four new tests: exploration share for a heavily penalized resolver, EMA re-seeding
  after a penalty streak, weight-clamp bounding, and failover-counter accuracy. All use
  distinct group ids to avoid expvar collisions.
- `go test -race ./...` passes (336 tests), `gofmt` and `go vet` clean.

## Documentation

The Load-Balance section of `doc/configuration.md` now describes the exploration share,
bounded weighting, fast recovery, and the new `rtt` metric.