### PR TITLE
Improve Redis cache performance and fix Flush

### DIFF
--- a/cache-redis.go
+++ b/cache-redis.go
@@ -3,10 +3,10 @@ package rdns
 import (
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -35,12 +35,17 @@ type RedisBackendOptions struct {
 
 var _ CacheBackend = (*redisBackend)(nil)
 
-// Buffer pool for dns.Msg.PackBuffer to minimize allocations.
+// Buffer pool for encoding cache records to minimize allocations.
 var packBufPool = sync.Pool{
 	New: func() any {
 		b := make([]byte, 0, 2048)
 		return &b
 	},
+}
+
+func putPackBuf(bufPtr *[]byte) {
+	*bufPtr = (*bufPtr)[:0]
+	packBufPool.Put(bufPtr)
 }
 
 const (
@@ -54,31 +59,32 @@ const (
 // - byte 1: flags (bit0: prefetchEligible)
 // - bytes 2..9: timestamp (uint64 seconds from Unix epoch, big endian)
 // - bytes 10..N: dns.Msg wire bytes
-func encodeCacheAnswer(item *cacheAnswer) ([]byte, error) {
-	bufPtr := packBufPool.Get().(*[]byte)
-	buf := *bufPtr
-
-	defer func() {
-		*bufPtr = buf[:0]
-		packBufPool.Put(bufPtr)
-	}()
-
-	if cap(buf) == 0 {
-		buf = make([]byte, 0, 2048)
+//
+// The message is packed into buf when it fits, so the returned slice
+// typically aliases buf. The caller owns buf and must not reuse it while
+// the result is in use.
+func encodeCacheAnswer(buf []byte, item *cacheAnswer) ([]byte, error) {
+	if cap(buf) < headerSize {
+		buf = make([]byte, headerSize+2048)
 	}
-
-	// Pack DNS message first into the scratch buffer
 	buf = buf[:cap(buf)]
-	dnsWire, err := item.Msg.PackBuffer(buf)
+
+	// Pack the DNS message directly after the header. PackBuffer packs
+	// in place and only allocates a new buffer if the message doesn't fit.
+	dnsWire, err := item.Msg.PackBuffer(buf[headerSize:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to pack DNS message: %w", err)
 	}
 
-	// Keep the (potentially grown) buffer for cleanup
-	buf = dnsWire
-
-	// Allocate result with header + DNS wire bytes
-	result := make([]byte, headerSize+len(dnsWire))
+	var result []byte
+	if &dnsWire[0] == &buf[headerSize] {
+		// Packed in place, header and wire bytes are contiguous in buf
+		result = buf[:headerSize+len(dnsWire)]
+	} else {
+		// The message didn't fit and PackBuffer allocated a new buffer
+		result = make([]byte, headerSize+len(dnsWire))
+		copy(result[headerSize:], dnsWire)
+	}
 
 	// Write header
 	result[0] = binaryFormatVersion
@@ -89,11 +95,7 @@ func encodeCacheAnswer(item *cacheAnswer) ([]byte, error) {
 	}
 	result[1] = flags
 
-	timestamp := uint64(item.Timestamp.Unix())
-	binary.BigEndian.PutUint64(result[2:10], timestamp)
-
-	// Copy DNS wire bytes after header
-	copy(result[headerSize:], dnsWire)
+	binary.BigEndian.PutUint64(result[2:10], uint64(item.Timestamp.Unix()))
 
 	return result, nil
 }
@@ -148,39 +150,53 @@ func (b *redisBackend) Store(query *dns.Msg, item *cacheAnswer) {
 		return
 	}
 
-	if b.opt.SyncSet {
-		b.storeSync(query, item, ttl)
-	} else {
-		b.storeAsync(query, item, ttl)
-	}
-}
-
-func (b *redisBackend) storeSync(query *dns.Msg, item *cacheAnswer, ttl time.Duration) {
+	// Build the key and encode synchronously. The query and the message
+	// belong to the caller and may be mutated once Store returns, so
+	// they can't be touched from a background goroutine.
 	key := b.keyFromQuery(query)
-	value, err := encodeCacheAnswer(item)
+
+	bufPtr := packBufPool.Get().(*[]byte)
+	value, err := encodeCacheAnswer(*bufPtr, item)
 	if err != nil {
+		putPackBuf(bufPtr)
 		Log.Error("failed to encode cache record", "error", err)
 		return
 	}
+	// If encoding outgrew the pooled buffer, keep the larger one so the
+	// pool adapts to the workload
+	if cap(value) > cap(*bufPtr) {
+		*bufPtr = value
+	}
 
+	if b.opt.SyncSet {
+		b.set(key, value, ttl)
+		putPackBuf(bufPtr)
+		return
+	}
+
+	// Non-blocking semaphore acquire. The value buffer is handed to the
+	// goroutine and returned to the pool once the write completes.
+	select {
+	case b.asyncWriteSem <- struct{}{}:
+		go func() {
+			defer func() {
+				putPackBuf(bufPtr)
+				<-b.asyncWriteSem
+			}()
+			b.set(key, value, ttl)
+		}()
+	default:
+		// Semaphore full, skip async store (best-effort caching)
+		putPackBuf(bufPtr)
+		b.asyncSkipped.Add(1)
+	}
+}
+
+func (b *redisBackend) set(key string, value []byte, ttl time.Duration) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	if err := b.client.Set(ctx, key, value, ttl).Err(); err != nil {
 		Log.Error("failed to write to redis", "error", err)
-	}
-}
-
-func (b *redisBackend) storeAsync(query *dns.Msg, item *cacheAnswer, ttl time.Duration) {
-	// Non-blocking semaphore acquire
-	select {
-	case b.asyncWriteSem <- struct{}{}:
-		go func() {
-			defer func() { <-b.asyncWriteSem }()
-			b.storeSync(query, item, ttl)
-		}()
-	default:
-		// Semaphore full, skip async store (best-effort caching)
-		b.asyncSkipped.Add(1)
 	}
 }
 
@@ -199,21 +215,9 @@ func (b *redisBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 		return nil, false, false
 	}
 
-	// Try binary decode first, with JSON fallback for backward compatibility
-	var a *cacheAnswer
-	a, err = decodeCacheAnswer(valueBytes)
+	a, err := decodeCacheAnswer(valueBytes)
 	if err != nil {
-		// Fallback to JSON for backward compatibility with existing cached entries
-		if jsonErr := json.Unmarshal(valueBytes, &a); jsonErr != nil {
-			Log.Error("failed to decode cache record from redis", "binary_error", err, "json_error", jsonErr)
-			return nil, false, false
-		}
-	}
-
-	// A record that decoded without error but holds no message (such as a
-	// literal "null" JSON value) is treated as a cache-miss.
-	if a == nil || a.Msg == nil {
-		Log.Error("empty cache record from redis")
+		Log.Error("failed to decode cache record from redis", "error", err)
 		return nil, false, false
 	}
 
@@ -246,16 +250,35 @@ func (b *redisBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 }
 
 func (b *redisBackend) Flush() {
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if _, err := b.client.Del(ctx, b.opt.KeyPrefix+"*").Result(); err != nil {
-		Log.Error("failed to delete keys in redis", "error", err)
+	// DEL takes literal key names, not glob patterns, so iterate with
+	// SCAN and delete the matches in batches.
+	var cursor uint64
+	for {
+		keys, next, err := b.client.Scan(ctx, cursor, b.opt.KeyPrefix+"*", 1000).Result()
+		if err != nil {
+			Log.Error("failed to scan keys in redis", "error", err)
+			return
+		}
+		if len(keys) > 0 {
+			if err := b.client.Del(ctx, keys...).Err(); err != nil {
+				Log.Error("failed to delete keys in redis", "error", err)
+				return
+			}
+		}
+		if next == 0 {
+			return
+		}
+		cursor = next
 	}
 }
 
 func (b *redisBackend) Size() int {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
+	// Note: DBSIZE counts all keys in the database, not just those
+	// matching KeyPrefix.
 	size, err := b.client.DBSize(ctx).Result()
 	if err != nil {
 		Log.Error("failed to run dbsize command on redis", "error", err)
@@ -269,13 +292,16 @@ func (b *redisBackend) Close() error {
 
 // Build a key string to be used in redis.
 func (b *redisBackend) keyFromQuery(q *dns.Msg) string {
+	question := q.Question[0]
+
 	var key strings.Builder
+	key.Grow(len(b.opt.KeyPrefix) + len(question.Name) + 32)
 	key.WriteString(b.opt.KeyPrefix)
-	key.WriteString(strings.ToLower(q.Question[0].Name))
+	key.WriteString(strings.ToLower(question.Name))
 	key.WriteByte(':')
-	key.WriteString(dns.Class(q.Question[0].Qclass).String())
+	key.WriteString(dns.Class(question.Qclass).String())
 	key.WriteByte(':')
-	key.WriteString(dns.Type(q.Question[0].Qtype).String())
+	key.WriteString(dns.Type(question.Qtype).String())
 	key.WriteByte(':')
 	// CD=1 responses are unvalidated (RFC 4035 §4.7 / RFC 6840 §5.9) and
 	// must be keyed separately from CD=0 ones.
@@ -286,14 +312,18 @@ func (b *redisBackend) keyFromQuery(q *dns.Msg) string {
 
 	edns0 := q.IsEdns0()
 	if edns0 != nil {
-		key.WriteString(fmt.Sprintf("%t", edns0.Do()))
+		if edns0.Do() {
+			key.WriteString("true")
+		} else {
+			key.WriteString("false")
+		}
 		key.WriteByte(':')
 		// See if we have a subnet option
 		for _, opt := range edns0.Option {
 			if subnet, ok := opt.(*dns.EDNS0_SUBNET); ok {
 				key.WriteString(subnet.Address.String())
 				key.WriteByte('/')
-				key.WriteString(fmt.Sprintf("%d", subnet.SourceNetmask))
+				key.WriteString(strconv.FormatUint(uint64(subnet.SourceNetmask), 10))
 			}
 		}
 	}

--- a/cache-redis_test.go
+++ b/cache-redis_test.go
@@ -37,6 +37,11 @@ func TestRedisKeyFromQuery(t *testing.T) {
 		return q
 	}
 	require.NotEqual(t, b.keyFromQuery(queryECS(24)), b.keyFromQuery(queryECS(16)), "ECS queries with different source-prefix lengths produced the same Redis cache key")
+
+	// The key format must remain stable so existing cache entries stay
+	// valid across upgrades.
+	require.Equal(t, "prefix:example.com.:IN:A::", (&redisBackend{opt: RedisBackendOptions{KeyPrefix: "prefix:"}}).keyFromQuery(queryCD(false)))
+	require.Equal(t, "example.com.:IN:A::false:192.0.2.0/24", b.keyFromQuery(queryECS(24)))
 }
 
 func TestEncodeDecode(t *testing.T) {
@@ -60,7 +65,7 @@ func TestEncodeDecode(t *testing.T) {
 	}
 
 	// Encode
-	encoded, err := encodeCacheAnswer(original)
+	encoded, err := encodeCacheAnswer(nil, original)
 	require.NoError(t, err)
 
 	// Verify format
@@ -101,7 +106,7 @@ func TestEncodeDecodeNoPrefetch(t *testing.T) {
 	}
 
 	// Encode
-	encoded, err := encodeCacheAnswer(original)
+	encoded, err := encodeCacheAnswer(nil, original)
 	require.NoError(t, err)
 
 	// Check flags byte (should be 0)
@@ -132,8 +137,44 @@ func TestDecodeInvalidData(t *testing.T) {
 	}
 }
 
-func TestEncodeDecodePooling(t *testing.T) {
-	// Test that pooling works correctly across multiple encode operations
+func TestEncodeAliasesBuffer(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.SetQuestion("alias.test.", dns.TypeA)
+	msg.Response = true
+
+	item := &cacheAnswer{
+		Timestamp:        time.Unix(1234567890, 0),
+		PrefetchEligible: true,
+		Msg:              msg,
+	}
+
+	// A buffer with enough capacity is used for the result
+	buf := make([]byte, 0, 2048)
+	encoded, err := encodeCacheAnswer(buf, item)
+	require.NoError(t, err)
+	require.Same(t, &buf[:1][0], &encoded[0], "expected result to alias the provided buffer")
+
+	// A buffer that's too small for the message is not used; the result
+	// must still be complete and decode correctly
+	small := make([]byte, 0, headerSize+4)
+	encodedSmall, err := encodeCacheAnswer(small, item)
+	require.NoError(t, err)
+	require.NotSame(t, &small[:1][0], &encodedSmall[0], "expected result not to alias the undersized buffer")
+	require.Equal(t, encoded, encodedSmall)
+
+	decoded, err := decodeCacheAnswer(encodedSmall)
+	require.NoError(t, err)
+	require.Equal(t, "alias.test.", decoded.Msg.Question[0].Name)
+
+	// A nil buffer works too
+	encodedNil, err := encodeCacheAnswer(nil, item)
+	require.NoError(t, err)
+	require.Equal(t, encoded, encodedNil)
+}
+
+func TestEncodeBufferReuse(t *testing.T) {
+	// Encode repeatedly into the same buffer, the way Store does with
+	// pooled buffers, and verify each result round-trips
 	msg := new(dns.Msg)
 	msg.SetQuestion("pool.test.", dns.TypeA)
 	msg.Response = true
@@ -144,9 +185,9 @@ func TestEncodeDecodePooling(t *testing.T) {
 		Msg:              msg,
 	}
 
-	// Encode multiple times to test pool reuse
+	buf := make([]byte, 0, 2048)
 	for i := range 100 {
-		encoded, err := encodeCacheAnswer(item)
+		encoded, err := encodeCacheAnswer(buf, item)
 		require.NoError(t, err, "iteration %d", i)
 
 		// Verify first byte is always version
@@ -160,51 +201,8 @@ func TestEncodeDecodePooling(t *testing.T) {
 	}
 }
 
-func TestEncodeReturnsIndependentSlice(t *testing.T) {
-	// Verify that encoded bytes are independent of the pool and mutations don't affect subsequent encodes
-	msg := new(dns.Msg)
-	msg.SetQuestion("independent.test.", dns.TypeA)
-	msg.Response = true
-
-	item := &cacheAnswer{
-		Timestamp:        time.Unix(1234567890, 0),
-		PrefetchEligible: true,
-		Msg:              msg,
-	}
-
-	// First encode
-	encoded1, err := encodeCacheAnswer(item)
-	require.NoError(t, err)
-
-	// Save a copy of the original encoded data
-	original := make([]byte, len(encoded1))
-	copy(original, encoded1)
-
-	// Mutate the returned slice to verify it's independent of the pool
-	for i := range encoded1 {
-		encoded1[i] = 0xFF
-	}
-
-	// Verify the mutated buffer is now garbage and fails to decode
-	_, err = decodeCacheAnswer(encoded1)
-	require.Error(t, err, "expected decode of mutated buffer to fail")
-
-	// Second encode - should succeed and produce the same result as the first
-	encoded2, err := encodeCacheAnswer(item)
-	require.NoError(t, err)
-
-	// Verify second encode matches the original (not corrupted by mutation)
-	require.Equal(t, original, encoded2, "mutation leaked into pool")
-
-	// Verify we can still decode the second result
-	decoded, err := decodeCacheAnswer(encoded2)
-	require.NoError(t, err)
-
-	require.Equal(t, "independent.test.", decoded.Msg.Question[0].Name)
-}
-
 func TestEncodeConcurrent(t *testing.T) {
-	// Test concurrent encoding to catch pool-related race conditions
+	// Test concurrent encoding, each goroutine reusing its own buffer.
 	// Each goroutine gets its own dns.Msg to avoid racing on shared message internals
 	const numGoroutines = 50
 	const numIterations = 100
@@ -233,8 +231,9 @@ func TestEncodeConcurrent(t *testing.T) {
 				Msg:              msg,
 			}
 
+			buf := make([]byte, 0, 2048)
 			for i := range numIterations {
-				encoded, err := encodeCacheAnswer(item)
+				encoded, err := encodeCacheAnswer(buf, item)
 				if err != nil {
 					errs <- err
 					return
@@ -261,5 +260,42 @@ func TestEncodeConcurrent(t *testing.T) {
 
 	for err := range errs {
 		require.NoError(t, err, "concurrent encode/decode failed")
+	}
+}
+
+func BenchmarkEncodeCacheAnswer(b *testing.B) {
+	msg := new(dns.Msg)
+	msg.SetQuestion("bench.example.com.", dns.TypeA)
+	msg.Response = true
+	for i := range 4 {
+		rr, err := dns.NewRR(fmt.Sprintf("bench.example.com. 300 IN A 192.0.2.%d", i+1))
+		require.NoError(b, err)
+		msg.Answer = append(msg.Answer, rr)
+	}
+
+	item := &cacheAnswer{
+		Timestamp:        time.Now(),
+		PrefetchEligible: true,
+		Msg:              msg,
+	}
+
+	buf := make([]byte, 0, 2048)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := encodeCacheAnswer(buf, item); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkKeyFromQuery(b *testing.B) {
+	backend := &redisBackend{opt: RedisBackendOptions{KeyPrefix: "routedns:"}}
+	q := new(dns.Msg)
+	q.SetQuestion("bench.example.com.", dns.TypeA)
+	q.SetEdns0(4096, true)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = backend.keyFromQuery(q)
 	}
 }

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -36,6 +36,9 @@ type cacheAnswer struct {
 	Msg              *dns.Msg
 }
 
+// The custom JSON marshaling is used by the memory backend to persist the
+// cache to a file (MemoryBackendOptions.Filename), packing the message to
+// wire format.
 func (c cacheAnswer) MarshalJSON() ([]byte, error) {
 	msg, err := c.Msg.Pack()
 	if err != nil {


### PR DESCRIPTION
Performance and correctness improvements for the Redis cache backend.

## Changes

- **Zero-allocation encoding**: `encodeCacheAnswer` now packs the DNS message directly after the binary header in a pooled buffer, instead of packing into a scratch buffer and copying into a fresh allocation for every store. The buffer is held until the Redis `SET` completes and then returned to the pool. If a message outgrows the pooled buffer, the grown buffer is kept so the pool adapts to the workload.
- **Data race fixed**: encoding and key building now happen synchronously in `Store`. Previously the message was packed inside a background goroutine while the listener could still mutate the same `dns.Msg` (truncation, ID). Only the network write runs in the background now.
- **JSON fallback removed**: all cached entries use the binary format by now, so the `json.Unmarshal` fallback in `Lookup` is gone. The JSON methods on `cacheAnswer` remain since the memory backend's cache file persistence uses them; a comment documents that.
- **`Flush` fixed**: it passed a glob pattern to `DEL`, which takes literal key names, so it deleted a key literally named `routedns:*` and flushed nothing. It now iterates with `SCAN MATCH prefix*` and deletes matches in batches of 1000.
- **Key building de-allocated**: replaced the two `fmt.Sprintf` calls with literal writes and `strconv`, and pre-sized the builder. The key format is byte-identical to before (covered by a new test), so existing cache entries stay valid across the upgrade.

## Benchmarks

| | Before | After |
|---|---|---|
| Encode | 899 ns/op, 192 B, 1 alloc | 794 ns/op, 0 B, 0 allocs |
| Key build | 379 ns/op, 116 B, 4 allocs | 191 ns/op, 64 B, 1 alloc |

Both benchmarks are included in `cache-redis_test.go`. Tests updated for the new buffer ownership contract and pass with `-race`.