### PR TITLE
Copy the query in ECS and EDNS0 modifiers instead of mutating in place

### DIFF
--- a/ecs-modifier.go
+++ b/ecs-modifier.go
@@ -26,8 +26,12 @@ func NewECSModifier(id string, resolver Resolver, f ECSModifierFunc) (*ECSModifi
 
 // Resolve modifies the OPT EDNS0 record and passes it to the next resolver.
 func (r *ECSModifier) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-	// Modify the query
+	// Modify a copy of the query. The original belongs to the caller; the
+	// listener reads it after Resolve returns to decide UDP truncation and
+	// DoT padding, so adding or removing EDNS0 in place would corrupt those
+	// decisions for the client.
 	if r.modifier != nil {
+		q = q.Copy()
 		r.modifier(r.id, q, ci)
 	}
 

--- a/edns0-modifier.go
+++ b/edns0-modifier.go
@@ -24,8 +24,12 @@ func NewEDNS0Modifier(id string, resolver Resolver, f EDNS0ModifierFunc) (*EDNS0
 
 // Resolve modifies the OPT EDNS0 record and passes it to the next resolver.
 func (r *EDNS0Modifier) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-	// Modify the query
+	// Modify a copy of the query. The original belongs to the caller; the
+	// listener reads it after Resolve returns to decide UDP truncation and
+	// DoT padding, so adding or removing EDNS0 in place would corrupt those
+	// decisions for the client.
 	if r.modifier != nil {
+		q = q.Copy()
 		r.modifier(q, ci)
 	}
 


### PR DESCRIPTION
## Problem

`ECSModifierAdd` and `EDNS0ModifierAdd` call `q.SetEdns0(4096, false)` on the caller's message when the client did not send an OPT record (and the delete variants remove options from it). The listener reads that same message again after `Resolve` returns:

- `dnslistener.go` computes the UDP truncation limit from `req.IsEdns0()`. A client that never advertised EDNS0 (512 byte limit) is treated as accepting 4096 bytes and can receive an oversized, non-truncated UDP response that it will drop or misparse.
- `padAnswer(req, a)` on DoT/DTLS is fooled into padding, and adding an OPT record to, responses for clients that never sent EDNS0, which RFC 6891 forbids.

The bug is masked when a cache sits between the listener and the modifier (the cache forwards `q.Copy()`), but triggers in any listener -> router -> ecs-modifier/edns0-modifier -> client chain.

## Fix

Work on a copy of the query in both modifiers, matching what the `Replace` and DNSSEC modifiers already do. The copy is only made when a modifier function is actually configured.