### PR TITLE
Fix double-completion race in the pipeline writer

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -112,9 +112,15 @@ func (c *Pipeline) start() {
 					log.With("qname", qName(query)).Debug("sending query")
 					c.metrics.query.Add(1)
 					if err := conn.WriteMsg(query); err != nil {
-						req.markDone(nil, err) // fail the request
-						c.inFlight.get(query)  // clean up the in-flight queue so it doesn't keep growing
-						conn.Close()           // throw away this connection, should wake up the reader as well
+						// Take the request back out of the in-flight queue before
+						// completing it. The reader matches responses by ID and
+						// completes whatever request it finds there; completing a
+						// request twice would panic on the double close of its
+						// done channel. Whoever removes it from the queue owns it.
+						if c.inFlight.get(query) != nil {
+							req.markDone(nil, err) // fail the request
+						}
+						conn.Close() // throw away this connection, should wake up the reader as well
 						wg.Done()
 						c.metrics.err.Add("send_query", 1)
 						log.With("qname", qName(query)).Debug("failed sending query",


### PR DESCRIPTION
## Problem

In the pipeline's writer goroutine, a failed `WriteMsg` completed the request with `markDone` before removing it from the in-flight queue:

```go
req.markDone(nil, err) // fail the request
c.inFlight.get(query)  // clean up the in-flight queue
```

The reader goroutine is still running at that point and matches responses by transaction ID against the same queue. If a response with that ID arrives in the window between the two calls (an upstream spraying IDs, or a late duplicate on a connection where the write failed for a non-fatal reason), the reader takes the request out of the queue and calls `markDone` too. The second `close(r.done)` panics and crashes the process.

## Fix

Remove the request from the in-flight queue first and only complete it if it was still there. Ownership of a request's completion now follows removal from the queue, so writer and reader can never both finish the same request. If the query timeout already removed it, no completion is needed since the caller is gone.

Pipeline tests pass with `-race`.