### PR TITLE
Fix negative drift in the FailBack available metric

### DIFF
--- a/failback.go
+++ b/failback.go
@@ -133,10 +133,14 @@ func (r *FailBack) errorFrom(i int) {
 		r.failCh = r.startResetTimer()
 	}
 	r.active = (r.active + 1) % len(r.resolvers)
+	// Resolvers before the active one failed recently, the rest are presumed
+	// healthy. On wrap-around the group starts over with the full list, so
+	// derive the gauge from the active index rather than decrementing it,
+	// which would drift below zero over repeated rotations.
+	r.metrics.available.Set(int64(len(r.resolvers) - r.active))
 	Log.Info("failing over to resolver", slog.Group("details", slog.String("id", r.id), slog.String("resolver", r.resolvers[r.active].String())))
 	r.mu.Unlock()
 	r.metrics.failover.Add(1)
-	r.metrics.available.Add(-1)
 	r.failCh <- struct{}{} // signal the timer to wait some more before switching back
 }
 
@@ -155,9 +159,11 @@ func (r *FailBack) startResetTimer() chan struct{} {
 			case <-timer.C:
 				r.mu.Lock()
 				r.active = 0
+				// All resolvers are considered available again, regardless of
+				// how far the group had failed over.
+				r.metrics.available.Set(int64(len(r.resolvers)))
 				Log.Debug("failing back to resolver", slog.Group("details", slog.String("resolver", r.resolvers[r.active].String())))
 				r.mu.Unlock()
-				r.metrics.available.Add(1)
 				// we just reset to the first resolver, let's wait for another failure before running again
 				<-failCh
 			}


### PR DESCRIPTION
## Problem

The `available` expvar gauge in the FailBack group was decremented on every failover, including the wrap-around from the last resolver back to index 0, while the reset timer only ever added 1 per reset. With two resolvers, the sequence fail(0->1), fail(1->0), fail(0->1), reset leaves the gauge at -1, and it keeps drifting further negative over time, making it useless for monitoring.

## Fix

Derive the gauge from the group state instead of counting events: resolvers before the active index failed recently, the rest are presumed healthy. On failover the gauge is set to `len(resolvers) - active` (identical to the old decrement for non-wrapping failovers), and the reset timer sets it back to the full resolver count when it fails back to the first resolver, no matter how far the group had rotated. The gauge can no longer go negative.