### PR TITLE
Remove redundant copy on cache hits and clean up route helpers

### DIFF
--- a/cache-memory.go
+++ b/cache-memory.go
@@ -61,6 +61,8 @@ func (b *memoryBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 	var expiry time.Time
 	b.mu.Lock()
 	if a := b.lru.get(q); a != nil {
+		// Copy the message so later elements can modify the response
+		// without affecting the cached original.
 		answer = a.Msg.Copy()
 		timestamp = a.Timestamp
 		prefetchEligible = a.PrefetchEligible
@@ -79,9 +81,6 @@ func (b *memoryBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 		return nil, false, false
 	}
 
-	// Make a copy of the response before returning it. Some later
-	// elements might make changes.
-	answer = answer.Copy()
 	answer.Id = q.Id
 	answer.Question = q.Question // restore the case used in the question
 

--- a/route.go
+++ b/route.go
@@ -247,7 +247,7 @@ loop:
 				continue loop
 			}
 		}
-		return nil, fmt.Errorf("unknown type '%s'", s)
+		return nil, fmt.Errorf("unknown type '%s'", typ)
 	}
 	return types, nil
 }
@@ -330,11 +330,17 @@ func parseTimeOfDay(t string) (*TimeOfDay, error) {
 	if err != nil {
 		return nil, err
 	}
+	if hour < 0 || hour > 23 {
+		return nil, fmt.Errorf("invalid time of day %q: hour must be between 0 and 23", t)
+	}
 	var min int
 	if len(f) > 1 {
 		min, err = strconv.Atoi(f[1])
 		if err != nil {
 			return nil, err
+		}
+		if min < 0 || min > 59 {
+			return nil, fmt.Errorf("invalid time of day %q: minute must be between 0 and 59", t)
 		}
 	}
 	return &TimeOfDay{
@@ -352,5 +358,5 @@ func (t *TimeOfDay) isAfter(hour, minute int) bool {
 }
 
 func (t *TimeOfDay) String() string {
-	return fmt.Sprintf("%2d:%2d", t.hour, t.minute)
+	return fmt.Sprintf("%02d:%02d", t.hour, t.minute)
 }


### PR DESCRIPTION
Small cleanups, no behavior change for valid configs:

- The memory cache backend copied the cached message twice on every hit: once under the lock and again just before returning. The locked copy is the one that matters (the cached message is shared), so drop the second one and save an allocation on the hottest cache path.
- `TimeOfDay.String` used `%2d:%2d` and printed ` 9: 5` instead of `09:05` in router listings.
- `stringToType` reported the whole type list in its error message instead of the single type that failed to parse.
- `parseTimeOfDay` accepted out-of-range values like `25:70`, silently producing routes that can never (or always) match. Reject them with an error at config load instead.