### PR TITLE
Mark first-failure EMA seeds as inflated for fast recovery

### DIFF
--- a/loadbalance.go
+++ b/loadbalance.go
@@ -259,14 +259,10 @@ func (r *LoadBalance) updateOnFailure(idx int, elapsed time.Duration) bool {
 	if s.count == 0 {
 		// Seed with at least the baseline RTT so a fast first failure doesn't
 		// give this resolver a large weight advantage over unprobed resolvers.
-		baseline := float64(defaultLoadBalanceInitialRTT.Microseconds())
-		s.rttEMA = max(us, baseline)
-		// If the baseline floored the seed above the measured sample, the EMA is
-		// inflated relative to the resolver's real speed. Mark it so the next
-		// success re-seeds instead of slowly blending down from the baseline.
-		if us < baseline {
-			s.emaInflated = true
-		}
+		s.rttEMA = max(us, float64(defaultLoadBalanceInitialRTT.Microseconds()))
+		// The seed is derived from a failure, not a real measurement; mark it
+		// inflated so the first success re-seeds to the measured RTT.
+		s.emaInflated = true
 	} else {
 		newEMA := defaultLoadBalanceEMAAlpha*us + (1-defaultLoadBalanceEMAAlpha)*s.rttEMA
 		if penalize || newEMA > s.rttEMA {

--- a/loadbalance_test.go
+++ b/loadbalance_test.go
@@ -113,6 +113,31 @@ func TestLoadBalanceFirstFailureRecovery(t *testing.T) {
 		"a success after an inflated first-failure seed should re-seed to the measured RTT")
 }
 
+// TestLoadBalanceSlowFirstFailureRecovery verifies that when a resolver's
+// first-ever event is a slow failure — e.g. a timeout above the baseline, so
+// the EMA is seeded to the timeout value itself — the next success re-seeds to
+// the measured RTT instead of slowly blending down from the failure-derived
+// seed.
+func TestLoadBalanceSlowFirstFailureRecovery(t *testing.T) {
+	r := &namedTestResolver{name: "slowfirstfail"}
+	g := NewLoadBalance("test-lb-slow-first-fail", LoadBalanceOptions{}, r) // no penalty
+
+	// First-ever event: a slow failure (e.g. a 2s timeout). The seed is the
+	// timeout value, which says nothing about the resolver's real speed.
+	timeout := 2 * time.Second
+	g.updateOnFailure(0, timeout)
+	require.Equal(t, float64(timeout.Microseconds()), g.stats[0].rttEMA,
+		"a slow first failure should seed the EMA to the measured elapsed time")
+	require.True(t, g.stats[0].emaInflated,
+		"a failure-derived first seed should be marked inflated")
+
+	// A genuine fast success must re-seed to the measured RTT, not blend down
+	// from the timeout (which would take ~20+ successes to decay).
+	g.updateOnSuccess(0, 3*time.Millisecond)
+	require.Equal(t, float64((3 * time.Millisecond).Microseconds()), g.stats[0].rttEMA,
+		"a success after a slow first failure should re-seed to the measured RTT")
+}
+
 // TestLoadBalanceNoReseedWithoutInflation verifies that a failure streak alone
 // (with no failure penalty configured, so updateOnFailure never inflated the
 // EMA) does not wipe an established average on the next success — it blends


### PR DESCRIPTION
## Motivation

The load-balance group's fast-recovery mechanism (#581) marks a failure-inflated EMA with `emaInflated` so the next success re-seeds it to the measured RTT instead of slowly alpha-blending down. In `updateOnFailure`, the first-event branch (`count == 0`) only set the flag when the baseline floored the seed above the measured sample (`us < baseline`).

That left a gap: when a resolver's first-ever event is a slow failure, such as a 2s timeout on its very first query (typical for an upstream that is down at startup), the EMA is seeded to the full timeout value with `emaInflated == false`. The next success then alpha-blends at 0.1 and takes 20+ successes to decay, which is exactly the slow-recovery starvation the flag was introduced to eliminate.

## Changes

- The `count == 0` seed in `updateOnFailure` is always derived from a failure, never a real measurement of the resolver's speed, so it is now marked inflated unconditionally. This also collapses the branch back to the single `max()` expression.
- New `TestLoadBalanceSlowFirstFailureRecovery` covering the slow-first-failure path: a 2s first failure seeds the EMA to 2s and marks it inflated, and the next 3ms success re-seeds to exactly 3ms.

There is no behavior change for the fast-first-failure case (the flag was already set there, and `TestLoadBalanceFirstFailureRecovery` still passes) and no interaction with the failure penalty (the penalty requires 2 consecutive failures, so it can never apply on the first event).

`go test -race ./...` passes, `gofmt` and `go vet` clean.
