### PR TITLE
Release with GoReleaser: Raspberry Pi and OpenWrt binaries plus Linux packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,68 +17,23 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: linux
-            goarch: arm
-            goarm: "7"
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-          - goos: windows
-            goarch: amd64
-          - goos: freebsd
-            goarch: amd64
-
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
-      - name: Build binary
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
         env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          GOARM: ${{ matrix.goarm }}
-        run: |
-          EXT=""
-          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
-          SUFFIX="${GOOS}-${GOARCH}"
-          if [ -n "$GOARM" ]; then SUFFIX="${SUFFIX}v${GOARM}"; fi
-          go build -trimpath -o "routedns-${SUFFIX}${EXT}" ./cmd/routedns
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: routedns-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goarm && format('v{0}', matrix.goarm) || '' }}
-          path: routedns-*
-
-  publish:
-    name: Publish Release
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
-          generate_release_notes: true
-          files: artifacts/*
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,72 +1,112 @@
 # goreleaser config for routedns
-# mostly uses defaults
+# Run by .github/workflows/release.yaml on every release tag. Validate
+# changes locally with:
+#   goreleaser check
+#   goreleaser release --snapshot --clean
+#
 # Make sure to check the documentation at https://goreleaser.com
 
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
 
 project_name: routedns
+
 builds:
-  - binary: routedns
+  # Targets that are also packaged as deb/rpm/apk/archlinux below.
+  - id: packaged
+    binary: routedns
     main: ./cmd/routedns/
     env:
       - CGO_ENABLED=0
-
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
     goos:
-      - windows
-      - darwin
       - linux
-
+      - darwin
+      - windows
+      - freebsd
     goarch:
       - amd64
-      - 386
+      - arm64
+      - arm
+    goarm:
+      - "7"
+    ignore:
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: arm64
+
+  # Binary-only targets for small/embedded devices: armv6 covers older
+  # Raspberry Pis (1/Zero), mips/mipsle cover common OpenWrt routers.
+  # Softfloat since most router SoCs have no FPU. These are excluded
+  # from the nfpm packages, whose distro arch names don't map cleanly.
+  - id: embedded
+    binary: routedns
+    main: ./cmd/routedns/
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+    goarch:
+      - arm
+      - mips
+      - mipsle
+    goarm:
+      - "6"
+    gomips:
+      - softfloat
+
+# Upload plain binaries named like the previous handcrafted releases
+# (routedns-linux-amd64, routedns-linux-armv7, ...) so existing download
+# links keep working.
+archives:
+  - formats: [binary]
+    name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}'
 
 nfpms:
   - package_name: routedns
-    file_name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    ids:
+      - packaged
+    file_name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}'
     vendor: Frank Olbricht
     homepage: https://github.com/folbricht/routedns
     maintainer: Frank Olbricht <frank.olbricht@gmail.com>
-    description: RouteDNS acts as a stub resolver and proxy that offers flexible configuration options
-    license: BSD-3-Clause license
+    description: DNS stub resolver, proxy and router with support for DoT, DoH, DoQ and more
+    license: BSD-3-Clause
     formats:
       - deb
       - rpm
-    bindir: /usr/sbin
+      - apk
+      - archlinux
+    bindir: /usr/bin
+    contents:
+      - src: packaging/routedns.service
+        dst: /usr/lib/systemd/system/routedns.service
+      - src: cmd/routedns/example-config/simple-dot-proxy.toml
+        dst: /etc/routedns/config.toml
+        type: config|noreplace
 
 checksum:
   name_template: 'checksums.txt'
+
+changelog:
+  use: github-native
 
 release:
   github:
     owner: folbricht
     name: routedns
-
-  # If set to true, will not auto-publish the release.
-  # Default is false.
-  draft: true
-
-  # If set to true, will mark the release as not ready for production.
-  # Default is false.
-  prerelease: true
-
-  # You can change the name of the GitHub release.
-  # This is parsed with the Go template engine and the following variables
-  # are available:
-  # - ProjectName
-  # - Tag
-  # - Version (Git tag without `v` prefix)
-  # Default is ``
-  name_template: "{{ .ProjectName }}-{{ .Tag }}"
-
-snapshot:
-  name_template: "{{ .Version }}~dev1"
-
-changelog:
-  sort: asc
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'

--- a/README.md
+++ b/README.md
@@ -87,7 +87,17 @@ git clone https://github.com/folbricht/routedns.git
 cd routedns/cmd/routedns && go install
 ```
 
-Pre-built binaries for Linux (amd64, arm64, armv7), macOS (amd64, arm64), FreeBSD, and Windows are available on the [GitHub Releases](https://github.com/folbricht/routedns/releases) page.
+Pre-built binaries for Linux (amd64, arm64, armv6/armv7 for Raspberry Pi, mips/mipsle softfloat for OpenWrt routers), macOS (amd64, arm64), FreeBSD, and Windows are available on the [GitHub Releases](https://github.com/folbricht/routedns/releases) page.
+
+### Linux packages
+
+Releases include deb, rpm, apk, and Arch Linux packages for amd64, arm64, and armv7. They install the binary to `/usr/bin/routedns`, a default configuration to `/etc/routedns/config.toml`, and a systemd service:
+
+```text
+sudo dpkg -i routedns_<version>_linux_amd64.deb   # Debian/Ubuntu/Raspberry Pi OS
+sudo rpm -i routedns_<version>_linux_amd64.rpm    # Fedora/RHEL
+sudo systemctl enable --now routedns
+```
 
 ### Docker
 

--- a/packaging/routedns.service
+++ b/packaging/routedns.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=RouteDNS - DNS stub resolver and router
+After=network.target
+
+[Service]
+Type=simple
+DynamicUser=true
+NoNewPrivileges=true
+# Add capabilities below as needed by the configuration. Append them to the
+# AmbientCapabilities line, separated by spaces.
+#   CAP_NET_BIND_SERVICE - bind to ports < 1024 (already set)
+#   CAP_SYS_ADMIN        - required by the `netns` option on listeners/
+#                          resolvers; setns(CLONE_NEWNET) needs it to enter
+#                          a Linux network namespace.
+#   CAP_NET_ADMIN        - required by the `fwmark` option (SO_MARK) on
+#                          listeners/resolvers.
+#   CAP_NET_RAW          - required by the `bind-if` option (SO_BINDTODEVICE)
+#                          on listeners/resolvers when running on Linux
+#                          kernels older than 5.7. Since 5.7 it is not
+#                          needed for the initial bind to an interface.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/routedns /etc/routedns/config.toml
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Replaces the handcrafted cross-compile matrix in `release.yaml` with GoReleaser and expands what each release ships.

**New binary targets**
- `linux/armv6` for Raspberry Pi 1 and Zero (the existing armv7 binary does not run on those)
- `linux/mips` and `linux/mipsle` with softfloat for OpenWrt routers, which mostly lack an FPU

All binaries are now built with `-trimpath` and stripped with `-s -w`, reducing size by roughly a third. That matters on flash-constrained router hardware. The existing seven asset names (`routedns-linux-amd64`, `routedns-darwin-arm64`, ...) are unchanged so download links keep working, and a `checksums.txt` is now included.

**Linux packages**
Releases now include deb, rpm, apk and Arch Linux packages for amd64, arm64 and armv7. Each installs:
- `/usr/bin/routedns`
- `/etc/routedns/config.toml` (the simple DoT proxy example, marked as a config file so upgrades never overwrite local edits)
- a systemd unit (`packaging/routedns.service`, a copy of the existing unit adapted to package paths)

Installing as a service becomes `dpkg -i` + `systemctl enable --now routedns`.

**Workflow changes**
`release.yaml` keeps the `workflow_call` + tag input pattern (required because tags pushed with `GITHUB_TOKEN` do not trigger tag workflows) and now runs a single GoReleaser job instead of the seven-way matrix. Release notes switch from GitHub's `generate_release_notes` to GoReleaser's `github-native` changelog, which produces the same output.

## Verification

Validated locally with `goreleaser check` and a full `goreleaser release --snapshot` run: all 10 binaries and 12 packages build, asset names match the previous release exactly, the amd64 binary runs and reports the correct version, `file` confirms mips (32-bit MSB) and armv6 (EABI5) outputs, and `dpkg-deb` shows the expected contents with `/etc/routedns/config.toml` registered in conffiles.