### PR TITLE
Publish multi-arch Docker images to Docker Hub and GHCR on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,7 @@
 **/.gitignore
 **/*.md
 Dockerfile
+dist
+cmd/routedns/routedns
 doc
 testdata

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -37,3 +38,47 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Docker Images
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push images
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            folbricht/routedns:latest
+            folbricht/routedns:${{ inputs.tag || github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/routedns:latest
+            ghcr.io/${{ github.repository_owner }}/routedns:${{ inputs.tag || github.ref_name }}

--- a/.github/workflows/version-bump-release.yaml
+++ b/.github/workflows/version-bump-release.yaml
@@ -92,5 +92,9 @@ jobs:
     uses: ./.github/workflows/release.yaml
     with:
       tag: ${{ needs.build.outputs.tag }}
+    # Repository secrets (DOCKERHUB_*) are not visible to reusable
+    # workflows unless explicitly inherited.
+    secrets: inherit
     permissions:
       contents: write
+      packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
-FROM golang:alpine as builder
-ARG GOOS
-ARG GOARCH
+# Cross-compiles on the build host (BUILDPLATFORM) so multi-arch images
+# build without emulation. TARGETOS/TARGETARCH/TARGETVARIANT are set
+# automatically by buildx for each requested platform.
+FROM --platform=$BUILDPLATFORM golang:alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-WORKDIR cmd/routedns
-RUN GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build 
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} CGO_ENABLED=0 \
+	go build -trimpath -ldflags="-s -w" -o /routedns ./cmd/routedns
 
 FROM alpine:latest
-COPY --from=builder /build/cmd/routedns/routedns .
-COPY cmd/routedns/example-config/simple-dot-proxy.toml config.toml
+COPY --from=builder /routedns /routedns
+COPY cmd/routedns/example-config/simple-dot-proxy.toml /config.toml
 EXPOSE 53/tcp 53/udp
 ENTRYPOINT ["/routedns"]
 CMD ["config.toml"]

--- a/README.md
+++ b/README.md
@@ -101,10 +101,16 @@ sudo systemctl enable --now routedns
 
 ### Docker
 
-A container is available on [Docker Hub](https://hub.docker.com/r/folbricht/routedns):
+Multi-arch images (amd64, arm64, armv7) are published on every release to [Docker Hub](https://hub.docker.com/r/folbricht/routedns) and [GitHub Container Registry](https://github.com/folbricht/routedns/pkgs/container/routedns), tagged `latest` and with the release version:
 
 ```text
 docker run -d --rm --network host folbricht/routedns
+```
+
+or from GHCR:
+
+```text
+docker run -d --rm --network host ghcr.io/folbricht/routedns
 ```
 
 With a custom config:


### PR DESCRIPTION
## Summary

The Docker Hub image (`folbricht/routedns:latest`) was amd64-only, pushed manually, and last updated in August 2025. This PR makes container images part of every release.

**What changes**

- `Dockerfile` now cross-compiles on the build platform using `BUILDPLATFORM` and `TARGETOS`/`TARGETARCH`/`TARGETVARIANT`, so multi-arch builds need no QEMU emulation for the compile step. Binaries are built with `-trimpath -s -w` matching the release binaries. Image layout is unchanged (`/routedns`, `/config.toml`), so existing `docker run` commands keep working.
- `release.yaml` gains a `docker` job that runs after GoReleaser and pushes images for **amd64, arm64 and armv7** to both **`folbricht/routedns`** and **`ghcr.io/folbricht/routedns`**, tagged `latest` and with the release version (e.g. `v0.1.221`).
- `version-bump-release.yaml` now passes `secrets: inherit` to the reusable release workflow. Without it the `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` repository secrets are not visible to the called workflow. The granted permissions also gain `packages: write` for GHCR.
- `.dockerignore` additionally excludes `dist/` and a locally built `cmd/routedns/routedns` so they cannot bloat the build context or leak into images.
- README documents both registries.

**Requirements already in place**: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets. GHCR uses the built-in `GITHUB_TOKEN`; the package appears at `ghcr.io/folbricht/routedns` on first push.

## Verification

Built locally with podman: the `linux/arm64` build succeeds and `podman inspect` confirms an arm64/linux image; the native amd64 image runs, `routedns -v` reports v0.1.220, and the default entrypoint works. The first real end-to-end push happens on the next release after merge.