### PR TITLE
Publish a Homebrew cask to folbricht/homebrew-tap on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
   docker:
     name: Docker Images

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -100,6 +100,33 @@ nfpms:
         dst: /etc/routedns/config.toml
         type: config|noreplace
 
+# Publishes a cask to the folbricht/homebrew-tap repo on each release:
+#   brew install folbricht/tap/routedns
+# Casks are macOS-only; Linux users have the native packages above.
+homebrew_casks:
+  - name: routedns
+    repository:
+      owner: folbricht
+      name: homebrew-tap
+      token: '{{ .Env.HOMEBREW_TAP_TOKEN }}'
+    homepage: https://github.com/folbricht/routedns
+    description: DNS stub resolver, proxy and router with support for DoT, DoH, DoQ and more
+    license: BSD-3-Clause
+    binaries:
+      - routedns
+    # The release binaries are not signed/notarized, so clear the
+    # quarantine attribute Homebrew sets on download or Gatekeeper
+    # refuses to run them. The staged file keeps its download name
+    # (routedns-darwin-arm64, ...), hence the glob.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            Dir.glob("#{staged_path}/routedns*").each do |f|
+              system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", f], must_succeed: false
+            end
+          end
+
 checksum:
   name_template: 'checksums.txt'
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ sudo rpm -i routedns_<version>_linux_amd64.rpm    # Fedora/RHEL
 sudo systemctl enable --now routedns
 ```
 
+### Homebrew (macOS)
+
+```text
+brew install folbricht/tap/routedns
+```
+
 ### Docker
 
 Multi-arch images (amd64, arm64, armv7) are published on every release to [Docker Hub](https://hub.docker.com/r/folbricht/routedns) and [GitHub Container Registry](https://github.com/folbricht/routedns/pkgs/container/routedns), tagged `latest` and with the release version:


### PR DESCRIPTION
## Summary

Makes `brew install folbricht/tap/routedns` work on macOS. On every release, GoReleaser now pushes a generated `Casks/routedns.rb` to [folbricht/homebrew-tap](https://github.com/folbricht/homebrew-tap), pointing at the raw darwin binaries from the release with per-arch checksums.

Details:

- Uses `homebrew_casks` since the older `brews` formula mechanism is deprecated in GoReleaser v2. Casks are macOS-only; Linux users have the deb/rpm/apk packages.
- The release binaries are unsigned, so the cask includes a postflight hook that clears the quarantine attribute Homebrew sets on download, otherwise Gatekeeper refuses to run the binary. The hook globs for `routedns*` in the staged path because binary-format archives are staged under their download name (`routedns-darwin-arm64`), not the target name, and the naive `staged_path/routedns` from the documentation example would fail the install.
- The release workflow passes `HOMEBREW_TAP_TOKEN` through to GoReleaser. The secret (fine-grained PAT with contents read/write on the tap repo) is set on this repository.
- README gains a Homebrew section.

## Verification

Validated with `goreleaser check` and a full snapshot build; the generated cask (per-arch url/sha256/binary stanzas targeting `routedns`, quarantine postflight) was inspected in `dist/homebrew/Casks/routedns.rb`. The actual tap push happens on the first release after merge.