### PR TITLE
Validate the response question in the DoQ, DoH and ODoH clients

### DIFF
--- a/dohclient.go
+++ b/dohclient.go
@@ -191,7 +191,7 @@ func (d *DoHClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	defer resp.Body.Close()
 
 	// Extract the DNS response from the HTTP response
-	return d.responseFromHTTP(resp)
+	return d.responseFromHTTP(q, resp)
 }
 
 func (d *DoHClient) buildRequest(ctx context.Context, msg []byte) (*http.Request, error) {
@@ -262,7 +262,7 @@ func (d *DoHClient) String() string {
 }
 
 // Check the HTTP response status code and parse out the response DNS message.
-func (d *DoHClient) responseFromHTTP(resp *http.Response) (*dns.Msg, error) {
+func (d *DoHClient) responseFromHTTP(q *dns.Msg, resp *http.Response) (*dns.Msg, error) {
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		d.metrics.err.Add(fmt.Sprintf("http%d", resp.StatusCode), 1)
 		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
@@ -277,13 +277,16 @@ func (d *DoHClient) responseFromHTTP(resp *http.Response) (*dns.Msg, error) {
 		return nil, err
 	}
 	a := new(dns.Msg)
-	err = a.Unpack(rb)
-	if err != nil {
+	if err := a.Unpack(rb); err != nil {
 		d.metrics.err.Add("unpack", 1)
-	} else {
-		d.metrics.response.Add(rCode(a), 1)
+		return nil, err
 	}
-	return a, err
+	if err := validateResponseQuestion(q, a); err != nil {
+		d.metrics.err.Add("question", 1)
+		return nil, err
+	}
+	d.metrics.response.Add(rCode(a), 1)
+	return a, nil
 }
 
 func dohTcpTransport(opt DoHClientOptions) (http.RoundTripper, error) {

--- a/doqclient.go
+++ b/doqclient.go
@@ -234,8 +234,18 @@ func (d *DoQClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 
 	// Decode the response and restore the ID
 	a := new(dns.Msg)
-	err = a.Unpack(b)
+	if err := a.Unpack(b); err != nil {
+		d.metrics.err.Add("unpack", 1)
+		return nil, err
+	}
 	a.Id = q.Id
+
+	// The QUIC stream proves which stream carried the response, not that the DNS
+	// message in it answers the question that was asked.
+	if err := validateResponseQuestion(q, a); err != nil {
+		d.metrics.err.Add("question", 1)
+		return nil, err
+	}
 
 	// Receiving a edns-tcp-keepalive EDNS(0) option is a fatal error according to the RFC
 	edns0 = a.IsEdns0()
@@ -250,7 +260,7 @@ func (d *DoQClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	}
 	d.metrics.response.Add(rCode(a), 1)
 
-	return a, err
+	return a, nil
 }
 
 func (d *DoQClient) String() string {

--- a/doqclient_test.go
+++ b/doqclient_test.go
@@ -2,6 +2,7 @@ package rdns
 
 import (
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
@@ -28,4 +29,56 @@ func TestDOQError(t *testing.T) {
 	_, err = d.Resolve(q, ClientInfo{})
 	require.Error(t, err)
 	require.Equal(t, id, q.Id) // Shouldn't touch the ID in the query
+}
+
+// A DoQ upstream that answers with a question other than the one that was
+// asked must be rejected, and nothing may be stored in a cache placed in front
+// of it. The QUIC stream identifies which stream carried the response, not that
+// the DNS message in it answers the question. See issue #595.
+func TestDOQWrongQuestionResponse(t *testing.T) {
+	// Upstream that always answers for attacker.example., regardless of the query
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			a := new(dns.Msg)
+			a.SetQuestion("attacker.example.", dns.TypeA)
+			a.Response = true
+			a.Id = q.Id
+			rr, err := dns.NewRR("attacker.example. 3600 IN A 6.6.6.6")
+			if err != nil {
+				return nil, err
+			}
+			a.Answer = []dns.RR{rr}
+			return a, nil
+		},
+	}
+
+	addr, err := getUDPLnAddress()
+	require.NoError(t, err)
+	tlsServerConfig, err := TLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+	require.NoError(t, err)
+
+	ln := NewQUICListener("test-doq", addr, DoQListenerOptions{TLSConfig: tlsServerConfig}, upstream)
+	go func() { _ = ln.Start() }()
+	defer ln.Stop()
+	time.Sleep(500 * time.Millisecond)
+
+	tlsClientConfig, err := TLSClientConfig("testdata/ca.crt", "", "", "")
+	require.NoError(t, err)
+	client, err := NewDoQClient("test-doq-client", addr, DoQClientOptions{TLSConfig: tlsClientConfig})
+	require.NoError(t, err)
+
+	cache := NewCache("test-cache", client, CacheOptions{})
+
+	q := new(dns.Msg)
+	q.SetQuestion("victim.example.", dns.TypeA)
+
+	// The mismatched response must not be passed on to the caller
+	_, err = cache.Resolve(q.Copy(), ClientInfo{})
+	require.Error(t, err)
+
+	// Nothing should have been cached under the victim's key, so a second query
+	// hits the upstream again rather than being served a poisoned entry.
+	_, err = cache.Resolve(q.Copy(), ClientInfo{})
+	require.Error(t, err)
+	require.Equal(t, 2, upstream.HitCount())
 }

--- a/message.go
+++ b/message.go
@@ -1,10 +1,40 @@
 package rdns
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/miekg/dns"
 )
+
+// Confirms that a response from an upstream answers the question that was
+// asked. As per https://tools.ietf.org/html/rfc7858#section-3.3 and RFC 5452
+// section 9.1, the response to a query that carried a Question must echo it
+// back. A response with an empty Question section (QDCOUNT=0) is rejected
+// rather than accepted - on datagram transports, skipping the check would
+// leave only the 16-bit transaction ID and source port as anti-spoofing
+// protection. On authenticated transports it guards against a misbehaving
+// upstream, and stops a mismatched answer from being stored in a cache under
+// the key of the question that was actually asked.
+//
+// Queries without a Question section are not validated. The name comparison is
+// case-insensitive; RouteDNS does not use DNS-0x20, so case carries no
+// information that needs preserving here.
+func validateResponseQuestion(q, a *dns.Msg) error {
+	if len(q.Question) == 0 {
+		return nil
+	}
+	question := q.Question[0]
+	if len(a.Question) == 0 {
+		return fmt.Errorf("expected answer for %s, got response with empty question section", question.String())
+	}
+	answer := a.Question[0]
+	if !strings.EqualFold(answer.Name, question.Name) || answer.Qclass != question.Qclass || answer.Qtype != question.Qtype {
+		return fmt.Errorf("expected answer for %s, got %s", question.String(), answer.String())
+	}
+	return nil
+}
 
 // Return the query name from a DNS query.
 func qName(q *dns.Msg) string {

--- a/message_test.go
+++ b/message_test.go
@@ -47,3 +47,73 @@ func TestSetUDPSizeDisabled(t *testing.T) {
 	require.Same(t, q, out)
 	require.Nil(t, out.IsEdns0())
 }
+
+func TestValidateResponseQuestion(t *testing.T) {
+	query := func(name string, qtype uint16) *dns.Msg {
+		q := new(dns.Msg)
+		q.SetQuestion(name, qtype)
+		return q
+	}
+
+	tests := []struct {
+		name    string
+		q, a    *dns.Msg
+		wantErr bool
+	}{
+		{
+			name: "matching question",
+			q:    query("example.com.", dns.TypeA),
+			a:    query("example.com.", dns.TypeA),
+		},
+		{
+			name: "name case does not matter",
+			q:    query("ExAmPlE.CoM.", dns.TypeA),
+			a:    query("example.com.", dns.TypeA),
+		},
+		{
+			name:    "name mismatch",
+			q:       query("victim.example.", dns.TypeA),
+			a:       query("attacker.example.", dns.TypeA),
+			wantErr: true,
+		},
+		{
+			name:    "type mismatch",
+			q:       query("example.com.", dns.TypeA),
+			a:       query("example.com.", dns.TypeAAAA),
+			wantErr: true,
+		},
+		{
+			name: "class mismatch",
+			q:    query("example.com.", dns.TypeA),
+			a: func() *dns.Msg {
+				a := query("example.com.", dns.TypeA)
+				a.Question[0].Qclass = dns.ClassCHAOS
+				return a
+			}(),
+			wantErr: true,
+		},
+		{
+			name:    "empty question in response",
+			q:       query("example.com.", dns.TypeA),
+			a:       new(dns.Msg),
+			wantErr: true,
+		},
+		{
+			// A query without a question can't be validated against.
+			name: "empty question in query",
+			q:    new(dns.Msg),
+			a:    query("example.com.", dns.TypeA),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateResponseQuestion(test.q, test.a)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/odohclient.go
+++ b/odohclient.go
@@ -92,7 +92,7 @@ func (d *ODoHClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	defer resp.Body.Close()
 
 	// Decode and decrypt the response
-	return d.decodeProxyResponse(resp, queryContext)
+	return d.decodeProxyResponse(q, resp, queryContext)
 }
 
 func (d *ODoHClient) String() string {
@@ -100,7 +100,7 @@ func (d *ODoHClient) String() string {
 }
 
 // Check the HTTP response status code, parse out the response DNS message and decrypt it.
-func (d *ODoHClient) decodeProxyResponse(resp *http.Response, queryContext odoh.QueryContext) (*dns.Msg, error) {
+func (d *ODoHClient) decodeProxyResponse(q *dns.Msg, resp *http.Response, queryContext odoh.QueryContext) (*dns.Msg, error) {
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		d.proxy.metrics.err.Add(fmt.Sprintf("http%d", resp.StatusCode), 1)
 		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
@@ -128,13 +128,16 @@ func (d *ODoHClient) decodeProxyResponse(resp *http.Response, queryContext odoh.
 		return nil, err
 	}
 	a := new(dns.Msg)
-	err = a.Unpack(decryptedResponse)
-	if err != nil {
+	if err := a.Unpack(decryptedResponse); err != nil {
 		d.proxy.metrics.err.Add("unpack", 1)
-	} else {
-		d.proxy.metrics.response.Add(rCode(a), 1)
+		return nil, err
 	}
-	return a, err
+	if err := validateResponseQuestion(q, a); err != nil {
+		d.proxy.metrics.err.Add("question", 1)
+		return nil, err
+	}
+	d.proxy.metrics.response.Add(rCode(a), 1)
+	return a, nil
 }
 
 // Modify a DoH request for proxy-use. The URL and headers need to be updated.

--- a/pipeline.go
+++ b/pipeline.go
@@ -2,7 +2,6 @@ package rdns
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"math"
 	"net"
@@ -216,19 +215,9 @@ func newRequest(q *dns.Msg) *request {
 func (r *request) waitFor() (*dns.Msg, error) {
 	<-r.done
 
-	if r.err == nil && len(r.q.Question) > 0 {
-		// As per https://tools.ietf.org/html/rfc7858#section-3.3 and RFC 5452
-		// section 9.1, the response to a query that carried a Question must echo
-		// it back. A response with an empty Question section (QDCOUNT=0) must be
-		// rejected rather than accepted - skipping the check would leave only the
-		// 16-bit transaction ID and source port as anti-spoofing protection.
-		q := r.q.Question[0]
-		if len(r.a.Question) == 0 {
-			return nil, fmt.Errorf("expected answer for %s, got response with empty question section", q.String())
-		}
-		a := r.a.Question[0]
-		if a.Name != q.Name || a.Qclass != q.Qclass || a.Qtype != q.Qtype {
-			return nil, fmt.Errorf("expected answer for %s, got %s", q.String(), a.String())
+	if r.err == nil {
+		if err := validateResponseQuestion(r.q, r.a); err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Fixes #595.

## Problem

`Pipeline` validates that an upstream response echoes the question that was asked (`pipeline.go`, per RFC 5452 section 9.1). Plain DNS, DoT and DTLS go through it. DoQ, DoH and ODoH each have their own response path, and none of them did that check.

So a DoQ upstream could answer a query for `victim.example. A` with a response whose Question and Answer are both for `attacker.example. A`, and the client would accept it. With a cache group in front, the response got stored under the original query key. On the way back out the cache restores the original question (`cache-memory.go`), producing a message whose question section says `victim.example.` while the answer records are still owned by `attacker.example.`. I reproduced this locally and it behaves exactly as the issue describes.

The issue only names DoQ, but `dohclient.go` and `odohclient.go` had the same gap.

## Scope

Worth being clear about what this is and is not, since the issue is written up as a cache-poisoning vulnerability.

The responses on these transports arrive over an authenticated TLS or QUIC channel from the upstream the operator configured, with certificate validation on by default. There is no off-path attacker. The party that has to send the mismatched response is the configured upstream itself, and such an upstream can already answer `victim.example.` with any address it likes, which is strictly more effective than returning records owned by a name that downstream stubs will discard. The cache is keyed on the request question, so a bad answer can only land under the key that upstream was asked about. There is no cross-key pollution.

What makes it worth fixing:

* The transports behave inconsistently. Someone reading the RFC 5452 comment in `pipeline.go` would reasonably assume the check applies everywhere.
* The cache rewrites the question, so the mismatch stops being visible to anything downstream. Several groups match answer records on `Rrtype` alone without checking the owner name (`resolver.go`, `fastest-tcp.go`, `syslog.go`), so a wrong-owner record would be consumed rather than dropped.
* A buggy upstream or middlebox that mixes up responses now surfaces an error instead of being silently accepted.

On the plain UDP path the same check is doing real anti-spoofing work, which is a different situation and unchanged here.

## Change

Move the check out of `request.waitFor` into `validateResponseQuestion` in `message.go` and call it from all four paths, so there is a single definition.

Two deliberate decisions:

* **The name comparison is now case-insensitive.** `pipeline.go` compared names byte for byte. Extending an exact comparison to DoH means more exposure to servers that normalise the case of the echoed question. RouteDNS does not implement DNS-0x20 anywhere, so case in the response carries no signal that needs preserving. This is a relaxation for the paths that already had the check, so it cannot break anything that worked before.
* **Responses with `QDCOUNT=0` are rejected**, including FORMERR responses that carry no question. That is already how the check behaves on DoT and plain DNS today, so this makes DoQ, DoH and ODoH consistent with it rather than introducing new behaviour.

I did not add the cache-level guard the issue suggests. Once every network-facing client validates, the only thing that can hand the cache a mismatched question is RouteDNS's own group code, which is trusted, and a check there risks breaking groups that legitimately rewrite the question such as `replace` and `dns64`. Happy to add it if you would rather have the belt and braces.

Also fixed while in `doqclient.go`: it called `a.Unpack(b)` and then used `a` before checking the returned error, reading `a.IsEdns0()` and recording a response metric on a partially populated message. It also never incremented an `unpack` error metric, which DoH and ODoH both do.

## Tests

`TestValidateResponseQuestion` covers the helper directly: matching, case-insensitive names, name/type/class mismatches, an empty question in the response, and a query with no question.

`TestDOQWrongQuestionResponse` is the regression test the issue asks for. It stands up a local DoQ listener backed by a resolver that always answers `attacker.example.`, puts a cache in front of a `DoQClient` pointed at it, and asserts the mismatched response is rejected and that nothing is cached under the victim key. I confirmed it fails without the client-side change.

`go test -race ./...` passes. That includes `TestDOQSimple` and the DoH client tests, which query real upstreams, so the new check does not reject what production servers actually send back.