### PR TITLE
Switch Docker image to distroless static-debian13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,13 @@ COPY . .
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} CGO_ENABLED=0 \
 	go build -trimpath -ldflags="-s -w" -o /routedns ./cmd/routedns
 
-FROM alpine:latest
+# Distroless static base: no shell, package manager, or userland — only the
+# static binary plus CA certs, tzdata, and /etc/passwd. The :latest tag runs as
+# root (uid 0), so the daemon binds privileged port 53 with no extra runtime
+# flags. Works because the binary is CGO_ENABLED=0 (fully static).
+FROM gcr.io/distroless/static-debian13:latest
 COPY --from=builder /routedns /routedns
 COPY cmd/routedns/example-config/simple-dot-proxy.toml /config.toml
 EXPOSE 53/tcp 53/udp
 ENTRYPOINT ["/routedns"]
-CMD ["config.toml"]
+CMD ["/config.toml"]


### PR DESCRIPTION
## What

Replaces the runtime base of the Docker image from `alpine:latest` with
`gcr.io/distroless/static-debian13:latest`. The build (builder) stage is
unchanged — it still cross-compiles a fully static `CGO_ENABLED=0` binary with
`-trimpath -ldflags="-s -w"`.

## Why

Alpine ships a full busybox userland the DNS daemon never uses: a shell,
`apk`, ~291 executables in `PATH`, and ~16 OS packages. That's needless attack
surface and a larger image. A static Go binary needs none of it.

[Distroless][distroless] `static-debian13` contains only the binary plus CA
certs, tzdata, `/etc/passwd`, and nsswitch — no shell, no package manager, no
userland tools. Distroless is a Google project maintained at
[GoogleContainerTools/distroless][distroless].

[distroless]: https://github.com/GoogleContainerTools/distroless

The **`:latest`** tag (rather than `:nonroot`) is used deliberately: it runs as
**root (uid 0)**, so the daemon binds privileged port 53 with no extra runtime
configuration. The `:nonroot` tag (uid 65532) cannot bind :53 on hosts where
`net.ipv4.ip_unprivileged_port_start` excludes it, and `--cap-add
NET_BIND_SERVICE` alone does not fix that without a file capability on the
binary — so `:latest` keeps deployment as simple as the old alpine image.

## Impact

| | alpine:latest (old) | distroless static:latest (new) |
|---|---|---|
| Image size (uncompressed) | 42.5 MB | 35.9 MB (−16%) |
| Shell / package manager | present | none |
| Executables in `PATH` | ~291 | 0 |
| OS packages | ~16 | ~0 |
| Runs as | root | root |
| Binds :53 out of the box | yes | yes |
| Runtime memory (RSS) | ~2.5 MiB | ~2.5 MiB (unchanged) |

Runtime memory is unchanged, as expected — a static binary's RSS is the binary,
not the base OS layer. The wins are reduced attack surface and a smaller image.

Note: `CMD` was changed from the relative `config.toml` to the absolute
`/config.toml`, because distroless does not default the working directory to `/`
the way the alpine image did.

## Verification

Built and run on linux/amd64 and linux/arm64 via buildx. Confirmed:

- Container starts and listeners bind `:53` (TCP + UDP) with a plain
  `docker run` — no `--sysctl`, `--cap-add`, or port remap.
- Still binds `:53` under a hardened
  `--sysctl net.ipv4.ip_unprivileged_port_start=1024` (root ignores the
  unprivileged-port floor) — the exact case that fails on `:nonroot`.
- DoT resolution works end to end (`dig example.com` returns an A record),
  proving the bundled CA certs are used.
- `--entrypoint /bin/sh` fails (`no such file or directory`) — confirming no
  shell is present.

## Notes for reviewers

- No CA-cert copy is needed; `static-debian13` bundles them and sets
  `SSL_CERT_FILE`.
- Multi-arch build is unaffected — the base is published for
  amd64/arm64/arm/s390x/ppc64le/riscv64.