### PR TITLE
Build per-query log context only when it is actually logged

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -159,7 +159,10 @@ func (r *Cache) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 			if min, ok := minTTL(a); ok && min < r.CacheOptions.PrefetchTrigger {
 				prefetchQ := q.Copy()
 				go func() {
-					log.Debug("prefetching record")
+					// Built here rather than captured: capturing the
+					// caller's logger would move it to the heap on every
+					// query, prefetching or not.
+					logger(r.id, prefetchQ, ci).Debug("prefetching record")
 
 					// Send the same query upstream
 					prefetchA, err := r.resolver.Resolve(prefetchQ, ci)

--- a/dnslistener.go
+++ b/dnslistener.go
@@ -104,7 +104,7 @@ func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNe
 			ci.SourceIP = addr.IP
 		}
 
-		log := Log.With(
+		log := deferredLog(Log).With(
 			"id", id,
 			"client", ci.SourceIP,
 			"qname", qName(req),

--- a/dnslistener.go
+++ b/dnslistener.go
@@ -87,7 +87,9 @@ func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNe
 		var err error
 
 		ci := ClientInfo{
-			Listener: id,
+			Listener:     id,
+			Protocol:     protocol,
+			ListenerAddr: addr,
 		}
 
 		if r, ok := w.(interface{ ConnectionState() *tls.ConnectionState }); ok {
@@ -104,13 +106,7 @@ func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNe
 			ci.SourceIP = addr.IP
 		}
 
-		log := deferredLog(Log).With(
-			"id", id,
-			"client", ci.SourceIP,
-			"qname", qName(req),
-			"protocol", protocol,
-			"addr", addr,
-		)
+		log := logger(id, req, ci)
 		if len(req.Question) == 0 {
 			metrics.err.Add("noquestion", 1)
 			log.Warn("dropping query with no Question section")

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -353,7 +353,7 @@ func (s *DoHListener) parseAndRespond(b []byte, w http.ResponseWriter, r *http.R
 		TLSServerName: tlsServerName,
 		Listener:      s.id,
 	}
-	log := Log.With(
+	log := deferredLog(Log).With(
 		"id", s.id,
 		"client", ci.SourceIP,
 		"qtype", qType(q),

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -352,16 +352,10 @@ func (s *DoHListener) parseAndRespond(b []byte, w http.ResponseWriter, r *http.R
 		DoHPath:       r.URL.Path,
 		TLSServerName: tlsServerName,
 		Listener:      s.id,
+		Protocol:      "doh",
+		ListenerAddr:  s.addr,
 	}
-	log := deferredLog(Log).With(
-		"id", s.id,
-		"client", ci.SourceIP,
-		"qtype", qType(q),
-		"qname", qName(q),
-		"protocol", "doh",
-		"addr", s.addr,
-		"path", r.URL.Path,
-	)
+	log := logger(s.id, q, ci)
 	log.Debug("received query")
 
 	var err error

--- a/doqlistener.go
+++ b/doqlistener.go
@@ -155,7 +155,7 @@ func (s *DoQListener) handleConnection(connection *quic.Conn) {
 	case *net.UDPAddr:
 		ci.SourceIP = addr.IP
 	}
-	log := s.log.With("client", connection.RemoteAddr())
+	log := deferredLog(s.log).With("client", connection.RemoteAddr())
 
 	if !isAllowed(s.opt.AllowedNet, ci.SourceIP) {
 		log.Debug("rejecting incoming connection")
@@ -178,7 +178,7 @@ func (s *DoQListener) handleConnection(connection *quic.Conn) {
 	}
 }
 
-func (s *DoQListener) handleStream(stream *quic.Stream, connection *quic.Conn, log *slog.Logger, ci ClientInfo) {
+func (s *DoQListener) handleStream(stream *quic.Stream, connection *quic.Conn, log deferredLogger, ci ClientInfo) {
 	// DNS over QUIC uses one stream per query/response.
 	defer stream.Close()
 	s.metrics.stream.Add(1)

--- a/doqlistener.go
+++ b/doqlistener.go
@@ -148,6 +148,8 @@ func (s *DoQListener) handleConnection(connection *quic.Conn) {
 	ci := ClientInfo{
 		Listener:      s.id,
 		TLSServerName: tlsServerName,
+		Protocol:      "doq",
+		ListenerAddr:  s.addr,
 	}
 	switch addr := connection.RemoteAddr().(type) {
 	case *net.TCPAddr:
@@ -155,7 +157,8 @@ func (s *DoQListener) handleConnection(connection *quic.Conn) {
 	case *net.UDPAddr:
 		ci.SourceIP = addr.IP
 	}
-	log := deferredLog(s.log).With("client", connection.RemoteAddr())
+	// No query yet, so this logger carries only the connection context.
+	log := logger(s.id, nil, ci)
 
 	if !isAllowed(s.opt.AllowedNet, ci.SourceIP) {
 		log.Debug("rejecting incoming connection")
@@ -170,17 +173,22 @@ func (s *DoQListener) handleConnection(connection *quic.Conn) {
 		if err != nil {
 			break
 		}
-		log.With("stream", stream.StreamID()).Debug("opening stream")
+		log.Debug("opening stream", "stream", stream.StreamID())
 		go func() {
-			s.handleStream(stream, connection, log, ci)
-			log.With("stream", stream.StreamID()).Debug("closing stream")
+			s.handleStream(stream, connection, ci)
+			log.Debug("closing stream", "stream", stream.StreamID())
 		}()
 	}
 }
 
-func (s *DoQListener) handleStream(stream *quic.Stream, connection *quic.Conn, log deferredLogger, ci ClientInfo) {
+func (s *DoQListener) handleStream(stream *quic.Stream, connection *quic.Conn, ci ClientInfo) {
 	// DNS over QUIC uses one stream per query/response.
 	defer stream.Close()
+
+	// Until the query has been decoded there is nothing to name it by, so
+	// the read and decode failures below are reported with the connection
+	// context alone.
+	log := logger(s.id, nil, ci)
 	s.metrics.stream.Add(1)
 
 	// The deadline covers the whole query read, including the length prefix.
@@ -211,6 +219,7 @@ func (s *DoQListener) handleStream(stream *quic.Stream, connection *quic.Conn, l
 		log.Warn("failed to decode query", "error", err)
 		return
 	}
+	log = logger(s.id, q, ci)
 	// A DNS message with QDCOUNT=0 unpacks cleanly but downstream resolvers
 	// (logger, cache, blocklists) all index `q.Question[0]` unconditionally
 	// and panic on an empty Question slice. Reject these at the listener.
@@ -219,7 +228,6 @@ func (s *DoQListener) handleStream(stream *quic.Stream, connection *quic.Conn, l
 		log.Warn("dropping query with no Question section")
 		return
 	}
-	log = log.With("qname", qName(q))
 	log.Debug("received query")
 	s.metrics.query.Add(1)
 

--- a/fastest-tcp.go
+++ b/fastest-tcp.go
@@ -3,7 +3,6 @@ package rdns
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"net"
 	"strconv"
 	"time"
@@ -140,7 +139,7 @@ func (r *FastestTCP) String() string {
 // Probes all IPs and returns only the RR with the fastest responding IP.
 // Waits for the first one that comes back. Returns an error if the fastest response
 // is an error.
-func (r *FastestTCP) probeFastest(log *slog.Logger, rrs []dns.RR) ([]dns.RR, error) {
+func (r *FastestTCP) probeFastest(log queryLogger, rrs []dns.RR) ([]dns.RR, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	resultCh := r.probe(ctx, log, rrs)
@@ -163,7 +162,7 @@ func (r *FastestTCP) probeFastest(log *slog.Logger, rrs []dns.RR) ([]dns.RR, err
 
 // Probes all IPs and returns them in the order of response time, fastest first. Returns
 // an error if any of the probes fail or if the probe times out.
-func (r *FastestTCP) probeAll(log *slog.Logger, rrs []dns.RR) ([]dns.RR, error) {
+func (r *FastestTCP) probeAll(log queryLogger, rrs []dns.RR) ([]dns.RR, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	resultCh := r.probe(ctx, log, rrs)
@@ -192,7 +191,7 @@ type tcpProbeResult struct {
 // even when the caller stops reading early (e.g. probeFastest after the first result,
 // or probeAll on error/timeout). This guarantees every goroutine runs to completion
 // and closes its socket.
-func (r *FastestTCP) probe(ctx context.Context, log *slog.Logger, rrs []dns.RR) <-chan tcpProbeResult {
+func (r *FastestTCP) probe(ctx context.Context, log queryLogger, rrs []dns.RR) <-chan tcpProbeResult {
 	resultCh := make(chan tcpProbeResult, len(rrs))
 	for _, rr := range rrs {
 		var d net.Dialer

--- a/listener.go
+++ b/listener.go
@@ -28,6 +28,13 @@ type ClientInfo struct {
 	// Listener ID of the listener that first received the request. Can be
 	// used to route queries.
 	Listener string
+
+	// Transport the query arrived on, such as "udp", "tcp", "dot", "doh",
+	// "doq", "dtls" or "odoh". Empty for queries not produced by a listener.
+	Protocol string
+
+	// Address the receiving listener is bound to.
+	ListenerAddr string
 }
 
 // Metrics that are available from listeners and clients.

--- a/logger.go
+++ b/logger.go
@@ -1,7 +1,11 @@
 package rdns
 
 import (
+	"context"
 	"log/slog"
+	"runtime"
+	"slices"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -10,11 +14,137 @@ import (
 // changed directly on this instance or the instance replaced.
 var Log = slog.Default()
 
-func logger(id string, q *dns.Msg, ci ClientInfo) *slog.Logger {
-	return Log.With(
-		slog.String("id", id),
-		slog.Any("client", ci.SourceIP),
-		slog.String("qtype", dns.Type(q.Question[0].Qtype).String()),
-		slog.String("qname", qName(q)),
+// queryLogger holds the per-query log context (resolver id, client, question)
+// and renders it only once a level check has passed. Attributes are stored
+// rather than formatted, so a call that ends up being suppressed costs nothing
+// beyond the level check. Every record carries the full query context
+// regardless of level, so Warn and Error identify the query they refer to even
+// when debug logging is off.
+type queryLogger struct {
+	// Destination, resolved when the logger is created so that a record and
+	// the level check that admitted it always go to the same logger. Falls
+	// back to Log when unset.
+	dst *slog.Logger
+
+	id string
+	q  *dns.Msg
+	ci ClientInfo
+
+	// Additional attributes from With, in slog's alternating key/value form
+	// (slog.Attr values are also accepted, as by slog.Logger.With).
+	extra []any
+}
+
+func logger(id string, q *dns.Msg, ci ClientInfo) queryLogger {
+	return queryLogger{dst: Log, id: id, q: q, ci: ci}
+}
+
+// With returns a copy of the logger with additional attributes appended.
+func (l queryLogger) With(args ...any) queryLogger {
+	if len(args) == 0 {
+		return l
+	}
+	// Clip so the append allocates rather than writing into an array shared
+	// with the receiver. Callers keep logging through the value they called
+	// With on, which must not see the attributes added to the copy.
+	l.extra = append(slices.Clip(l.extra), args...)
+	return l
+}
+
+func (l queryLogger) Debug(msg string, args ...any) { l.log(slog.LevelDebug, msg, args...) }
+func (l queryLogger) Info(msg string, args ...any)  { l.log(slog.LevelInfo, msg, args...) }
+func (l queryLogger) Warn(msg string, args ...any)  { l.log(slog.LevelWarn, msg, args...) }
+func (l queryLogger) Error(msg string, args ...any) { l.log(slog.LevelError, msg, args...) }
+
+func (l queryLogger) log(level slog.Level, msg string, args ...any) {
+	dst := l.dst
+	if dst == nil {
+		dst = Log
+	}
+	ctx := context.Background()
+	if !dst.Enabled(ctx, level) {
+		return
+	}
+
+	r := newRecord(level, msg)
+	r.Add(
+		slog.String("id", l.id),
+		slog.Any("client", l.ci.SourceIP),
+		slog.String("qtype", qTypeName(l.q)),
+		slog.String("qname", qName(l.q)),
 	)
+	r.Add(l.extra...)
+	r.Add(args...)
+	_ = dst.Handler().Handle(ctx, r)
+}
+
+// deferredLogger holds an arbitrary set of attributes and applies them only
+// once a level check has passed. It serves the listeners, whose attributes vary
+// by protocol and so can't be typed fields the way queryLogger's are; a call
+// that is suppressed costs the level check and nothing else, and one that is
+// emitted costs the same as slog.Logger.With would have.
+//
+// Prefer queryLogger for the resolver chain: its fixed attribute set is held in
+// typed fields, so it does not allocate at all.
+type deferredLogger struct {
+	dst *slog.Logger
+
+	// Attributes in slog's alternating key/value form (slog.Attr values are
+	// also accepted, as by slog.Logger.With).
+	attrs []any
+}
+
+func deferredLog(dst *slog.Logger) deferredLogger {
+	return deferredLogger{dst: dst}
+}
+
+// With returns a copy of the logger with additional attributes appended.
+func (l deferredLogger) With(args ...any) deferredLogger {
+	if len(args) == 0 {
+		return l
+	}
+	// Clip so the append allocates rather than writing into an array shared
+	// with the receiver. Callers keep logging through the value they called
+	// With on, which must not see the attributes added to the copy.
+	l.attrs = append(slices.Clip(l.attrs), args...)
+	return l
+}
+
+func (l deferredLogger) Debug(msg string, args ...any) { l.log(slog.LevelDebug, msg, args...) }
+func (l deferredLogger) Info(msg string, args ...any)  { l.log(slog.LevelInfo, msg, args...) }
+func (l deferredLogger) Warn(msg string, args ...any)  { l.log(slog.LevelWarn, msg, args...) }
+func (l deferredLogger) Error(msg string, args ...any) { l.log(slog.LevelError, msg, args...) }
+
+func (l deferredLogger) log(level slog.Level, msg string, args ...any) {
+	dst := l.dst
+	if dst == nil {
+		dst = Log
+	}
+	ctx := context.Background()
+	if !dst.Enabled(ctx, level) {
+		return
+	}
+
+	r := newRecord(level, msg)
+	r.Add(l.attrs...)
+	r.Add(args...)
+	_ = dst.Handler().Handle(ctx, r)
+}
+
+// Builds a record carrying the PC of the code that called the Debug/Info/Warn/
+// Error method, for handlers configured with AddSource. Skips runtime.Callers,
+// this function, the log method, and that wrapper.
+func newRecord(level slog.Level, msg string) slog.Record {
+	var pcs [1]uintptr
+	runtime.Callers(4, pcs[:])
+	return slog.NewRecord(time.Now(), level, msg, pcs[0])
+}
+
+// Returns the string representation of the query type, rendering types with no
+// registered name as "TYPE<n>". qType returns an empty string for those.
+func qTypeName(q *dns.Msg) string {
+	if len(q.Question) == 0 {
+		return ""
+	}
+	return dns.Type(q.Question[0].Qtype).String()
 }

--- a/logger.go
+++ b/logger.go
@@ -14,12 +14,21 @@ import (
 // changed directly on this instance or the instance replaced.
 var Log = slog.Default()
 
-// queryLogger holds the per-query log context (resolver id, client, question)
-// and renders it only once a level check has passed. Attributes are stored
-// rather than formatted, so a call that ends up being suppressed costs nothing
-// beyond the level check. Every record carries the full query context
-// regardless of level, so Warn and Error identify the query they refer to even
-// when debug logging is off.
+// queryLogger holds the per-query log context and renders it only once a level
+// check has passed. Attributes are stored rather than formatted, so a call that
+// ends up being suppressed costs nothing beyond the level check. Every record
+// carries the full query context regardless of level, so Warn and Error
+// identify the query they refer to even when debug logging is off.
+//
+// The context is whatever the component already has in hand: its own id, the
+// query, and the ClientInfo threaded through every Resolve. The listener half
+// of it (protocol, listener address, DoH path) comes from ClientInfo, so a
+// listener logs through this type exactly as a resolver does.
+//
+// Attributes with no value are omitted: a nil query drops qtype and qname,
+// which is what connection-scoped records logged before a query is read look
+// like, and the three listener attributes are absent for queries that no
+// listener produced.
 type queryLogger struct {
 	// Destination, resolved when the logger is created so that a record and
 	// the level check that admitted it always go to the same logger. Falls
@@ -67,66 +76,20 @@ func (l queryLogger) log(level slog.Level, msg string, args ...any) {
 	}
 
 	r := newRecord(level, msg)
-	r.Add(
-		slog.String("id", l.id),
-		slog.Any("client", l.ci.SourceIP),
-		slog.String("qtype", qTypeName(l.q)),
-		slog.String("qname", qName(l.q)),
-	)
+	r.Add(slog.String("id", l.id), slog.Any("client", l.ci.SourceIP))
+	if l.q != nil {
+		r.Add(slog.String("qtype", qTypeName(l.q)), slog.String("qname", qName(l.q)))
+	}
+	if l.ci.Protocol != "" {
+		r.Add(slog.String("protocol", l.ci.Protocol))
+	}
+	if l.ci.ListenerAddr != "" {
+		r.Add(slog.String("addr", l.ci.ListenerAddr))
+	}
+	if l.ci.DoHPath != "" {
+		r.Add(slog.String("path", l.ci.DoHPath))
+	}
 	r.Add(l.extra...)
-	r.Add(args...)
-	_ = dst.Handler().Handle(ctx, r)
-}
-
-// deferredLogger holds an arbitrary set of attributes and applies them only
-// once a level check has passed. It serves the listeners, whose attributes vary
-// by protocol and so can't be typed fields the way queryLogger's are; a call
-// that is suppressed costs the level check and nothing else, and one that is
-// emitted costs the same as slog.Logger.With would have.
-//
-// Prefer queryLogger for the resolver chain: its fixed attribute set is held in
-// typed fields, so it does not allocate at all.
-type deferredLogger struct {
-	dst *slog.Logger
-
-	// Attributes in slog's alternating key/value form (slog.Attr values are
-	// also accepted, as by slog.Logger.With).
-	attrs []any
-}
-
-func deferredLog(dst *slog.Logger) deferredLogger {
-	return deferredLogger{dst: dst}
-}
-
-// With returns a copy of the logger with additional attributes appended.
-func (l deferredLogger) With(args ...any) deferredLogger {
-	if len(args) == 0 {
-		return l
-	}
-	// Clip so the append allocates rather than writing into an array shared
-	// with the receiver. Callers keep logging through the value they called
-	// With on, which must not see the attributes added to the copy.
-	l.attrs = append(slices.Clip(l.attrs), args...)
-	return l
-}
-
-func (l deferredLogger) Debug(msg string, args ...any) { l.log(slog.LevelDebug, msg, args...) }
-func (l deferredLogger) Info(msg string, args ...any)  { l.log(slog.LevelInfo, msg, args...) }
-func (l deferredLogger) Warn(msg string, args ...any)  { l.log(slog.LevelWarn, msg, args...) }
-func (l deferredLogger) Error(msg string, args ...any) { l.log(slog.LevelError, msg, args...) }
-
-func (l deferredLogger) log(level slog.Level, msg string, args ...any) {
-	dst := l.dst
-	if dst == nil {
-		dst = Log
-	}
-	ctx := context.Background()
-	if !dst.Enabled(ctx, level) {
-		return
-	}
-
-	r := newRecord(level, msg)
-	r.Add(l.attrs...)
 	r.Add(args...)
 	_ = dst.Handler().Handle(ctx, r)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,329 @@
+package rdns
+
+import (
+	"bytes"
+	"log/slog"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func testQuery() *dns.Msg {
+	q := new(dns.Msg)
+	q.SetQuestion("www.example.com.", dns.TypeA)
+	return q
+}
+
+// Returns a logger writing to a buffer, dropping the timestamp so records can
+// be compared directly. The package-global Log is deliberately left alone:
+// background refresh goroutines started by other tests read it without
+// synchronisation (client-blocklist.go), so writing it here would race.
+func captureLog(t *testing.T, level slog.Level, opts ...func(*slog.HandlerOptions)) (*slog.Logger, *bytes.Buffer) {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	o := &slog.HandlerOptions{
+		Level: level,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if len(groups) == 0 && a.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}
+	for _, f := range opts {
+		f(o)
+	}
+	return slog.New(slog.NewTextHandler(buf, o)), buf
+}
+
+// A queryLogger as logger() builds it, but pointed at the test's logger.
+func testQueryLogger(dst *slog.Logger, id string, q *dns.Msg, ci ClientInfo) queryLogger {
+	l := logger(id, q, ci)
+	l.dst = dst
+	return l
+}
+
+// Records must be identical to what slog.Logger.With produces for the same
+// query context, covering the attribute set, their values and their order.
+// slog is the definition of the output format here, so it is used as the
+// oracle rather than a golden string: an attribute added to or reordered in
+// queryLogger.log fails this.
+func TestQueryLoggerMatchesSlogWith(t *testing.T) {
+	q := testQuery()
+	ci := ClientInfo{SourceIP: []byte{192, 168, 1, 5}, Listener: "listener1"}
+
+	tests := []struct {
+		name   string
+		emit   func(l queryLogger)
+		oracle func(l *slog.Logger)
+	}{
+		{
+			name:   "plain message",
+			emit:   func(l queryLogger) { l.Debug("cache-hit") },
+			oracle: func(l *slog.Logger) { l.Debug("cache-hit") },
+		},
+		{
+			name:   "key/value args",
+			emit:   func(l queryLogger) { l.Debug("forwarding", "resolver", "upstream") },
+			oracle: func(l *slog.Logger) { l.Debug("forwarding", "resolver", "upstream") },
+		},
+		{
+			name:   "slog.Attr args",
+			emit:   func(l queryLogger) { l.Warn("failed", slog.String("error", "boom")) },
+			oracle: func(l *slog.Logger) { l.Warn("failed", slog.String("error", "boom")) },
+		},
+		{
+			name:   "With then log",
+			emit:   func(l queryLogger) { l.With("resolver", "upstream").Debug("forwarding") },
+			oracle: func(l *slog.Logger) { l.With("resolver", "upstream").Debug("forwarding") },
+		},
+		{
+			name: "chained With",
+			emit: func(l queryLogger) {
+				l.With(slog.String("list", "l1")).With(slog.String("rule", "r1")).Debug("blocking")
+			},
+			oracle: func(l *slog.Logger) {
+				l.With(slog.String("list", "l1")).With(slog.String("rule", "r1")).Debug("blocking")
+			},
+		},
+		{
+			name:   "With plus call args",
+			emit:   func(l queryLogger) { l.With("list", "l1").Debug("blocking", "rule", "r1") },
+			oracle: func(l *slog.Logger) { l.With("list", "l1").Debug("blocking", "rule", "r1") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst, buf := captureLog(t, slog.LevelDebug)
+			tt.emit(testQueryLogger(dst, "resolver1", q, ci))
+			got := buf.String()
+
+			buf.Reset()
+			tt.oracle(dst.With(
+				slog.String("id", "resolver1"),
+				slog.Any("client", ci.SourceIP),
+				slog.String("qtype", dns.Type(q.Question[0].Qtype).String()),
+				slog.String("qname", qName(q)),
+			))
+			require.Equal(t, buf.String(), got)
+		})
+	}
+}
+
+// Suppressing debug records must not cost the query context on the records
+// that do get emitted: a Warn at info level still identifies its query.
+func TestQueryLoggerKeepsContextWhenDebugDisabled(t *testing.T) {
+	dst, buf := captureLog(t, slog.LevelInfo)
+	q := testQuery()
+	ci := ClientInfo{SourceIP: []byte{10, 0, 0, 1}}
+
+	log := testQueryLogger(dst, "resolver1", q, ci)
+	log.Debug("suppressed")
+	require.Empty(t, buf.String(), "debug record must not be emitted at info level")
+
+	log.Warn("failed to resolve", "error", "boom")
+	out := buf.String()
+	require.Contains(t, out, "id=resolver1")
+	require.Contains(t, out, "client=10.0.0.1")
+	require.Contains(t, out, "qtype=A")
+	require.Contains(t, out, "qname=www.example.com.")
+	require.Contains(t, out, "error=boom")
+}
+
+// With returns an independent value; attributes added to the copy must not
+// appear on records emitted through the logger it was derived from.
+func TestQueryLoggerWithDoesNotMutateReceiver(t *testing.T) {
+	dst, buf := captureLog(t, slog.LevelDebug)
+	base := testQueryLogger(dst, "resolver1", testQuery(), ClientInfo{})
+
+	withList := base.With("list", "l1")
+	branchA := withList.With("rule", "a")
+	branchB := withList.With("rule", "b")
+
+	branchA.Debug("first")
+	branchB.Debug("second")
+	base.Debug("third")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 3)
+	require.Contains(t, lines[0], "list=l1")
+	require.Contains(t, lines[0], "rule=a")
+	require.Contains(t, lines[1], "list=l1")
+	require.Contains(t, lines[1], "rule=b")
+	require.NotContains(t, lines[1], "rule=a")
+	require.NotContains(t, lines[2], "list=l1")
+	require.NotContains(t, lines[2], "rule=")
+}
+
+// Two loggers derived from the same value must not share the array their
+// attributes live in. append only reuses spare capacity, which the sizes the
+// natural call sites produce happen not to have, so the condition is set up
+// explicitly here.
+func TestQueryLoggerWithDoesNotShareSpareCapacity(t *testing.T) {
+	dst, buf := captureLog(t, slog.LevelDebug)
+
+	base := testQueryLogger(dst, "resolver1", testQuery(), ClientInfo{})
+	base.extra = append(make([]any, 0, 8), "list", "l1")
+	require.Greater(t, cap(base.extra), len(base.extra), "test needs spare capacity to be meaningful")
+
+	branchA := base.With("rule", "a")
+	branchB := base.With("rule", "b")
+
+	// Emitted after both derivations, so a shared array shows up as branchB
+	// having overwritten branchA's attribute.
+	branchA.Debug("first")
+	branchB.Debug("second")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	require.Contains(t, lines[0], "rule=a")
+	require.Contains(t, lines[1], "rule=b")
+}
+
+// A handler with AddSource must report the caller, not this package's logger.
+func TestQueryLoggerReportsCallerSource(t *testing.T) {
+	dst, buf := captureLog(t, slog.LevelDebug, func(o *slog.HandlerOptions) { o.AddSource = true })
+	testQueryLogger(dst, "resolver1", testQuery(), ClientInfo{}).Debug("here")
+
+	out := buf.String()
+	require.Contains(t, out, "logger_test.go", "source should point at the call site")
+	require.NotContains(t, out, "logger.go:", "source must not point at the logging helper")
+}
+
+// The question section is read when a record is emitted, so a query without
+// one must not panic there.
+func TestQueryLoggerEmptyQuestion(t *testing.T) {
+	dst, buf := captureLog(t, slog.LevelDebug)
+	require.NotPanics(t, func() {
+		testQueryLogger(dst, "resolver1", new(dns.Msg), ClientInfo{}).Debug("no question")
+	})
+	require.Contains(t, buf.String(), "qname=")
+}
+
+// The listener attribute sets, which vary by protocol, must render exactly as
+// slog.Logger.With renders them. The attribute order is part of the output, so
+// this pins it for each listener.
+func TestDeferredLoggerMatchesSlogWith(t *testing.T) {
+	clientIP := net.IP{192, 168, 1, 5}
+
+	tests := []struct {
+		name string
+		args []any
+		emit func(l deferredLogger)
+		orcl func(l *slog.Logger)
+	}{
+		{
+			name: "dns listener",
+			args: []any{
+				"id", "listener1", "client", clientIP, "qname", "www.example.com.",
+				"protocol", "udp", "addr", ":53",
+			},
+			emit: func(l deferredLogger) { l.Debug("received query") },
+			orcl: func(l *slog.Logger) { l.Debug("received query") },
+		},
+		{
+			name: "dns listener forwarding",
+			args: []any{
+				"id", "listener1", "client", clientIP, "qname", "www.example.com.",
+				"protocol", "udp", "addr", ":53",
+			},
+			emit: func(l deferredLogger) { l.With("resolver", "cache1").Debug("forwarding query to resolver") },
+			orcl: func(l *slog.Logger) { l.With("resolver", "cache1").Debug("forwarding query to resolver") },
+		},
+		{
+			name: "doh listener",
+			args: []any{
+				"id", "doh1", "client", clientIP, "qtype", "A", "qname", "www.example.com.",
+				"protocol", "doh", "addr", ":443", "path", "/dns-query",
+			},
+			emit: func(l deferredLogger) { l.Warn("failed to resolve", "error", "boom") },
+			orcl: func(l *slog.Logger) { l.Warn("failed to resolve", "error", "boom") },
+		},
+		{
+			name: "doq listener stream",
+			args: []any{"id", "doq1", "protocol", "doq", "addr", ":853", "client", clientIP},
+			emit: func(l deferredLogger) { l.With("stream", int64(7)).Debug("opening stream") },
+			orcl: func(l *slog.Logger) { l.With("stream", int64(7)).Debug("opening stream") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst, buf := captureLog(t, slog.LevelDebug)
+			tt.emit(deferredLog(dst).With(tt.args...))
+			got := buf.String()
+
+			buf.Reset()
+			tt.orcl(dst.With(tt.args...))
+			require.Equal(t, buf.String(), got)
+		})
+	}
+}
+
+// As for queryLogger, derived loggers must not share the array their
+// attributes live in.
+func TestDeferredLoggerWithDoesNotShareSpareCapacity(t *testing.T) {
+	dst, buf := captureLog(t, slog.LevelDebug)
+
+	base := deferredLog(dst)
+	base.attrs = append(make([]any, 0, 8), "id", "listener1")
+	require.Greater(t, cap(base.attrs), len(base.attrs), "test needs spare capacity to be meaningful")
+
+	branchA := base.With("stream", int64(1))
+	branchB := base.With("stream", int64(2))
+
+	branchA.Debug("first")
+	branchB.Debug("second")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	require.Contains(t, lines[0], "stream=1")
+	require.Contains(t, lines[1], "stream=2")
+}
+
+func TestDeferredLoggerReportsCallerSource(t *testing.T) {
+	dst, buf := captureLog(t, slog.LevelDebug, func(o *slog.HandlerOptions) { o.AddSource = true })
+	deferredLog(dst).With("id", "listener1").Debug("here")
+
+	out := buf.String()
+	require.Contains(t, out, "logger_test.go", "source should point at the call site")
+	require.NotContains(t, out, "logger.go:", "source must not point at the logging helper")
+}
+
+// Emitting nothing must cost only the level check. The attributes are held
+// as given, so the sole allocation is the one the caller's variadic slice
+// already required.
+func TestDeferredLoggerSuppressedCallIsCheap(t *testing.T) {
+	dst, _ := captureLog(t, slog.LevelInfo)
+	clientIP := net.IP{192, 168, 1, 5}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		log := deferredLog(dst).With(
+			"id", "listener1", "client", clientIP, "qname", "www.example.com.",
+			"protocol", "udp", "addr", ":53",
+		)
+		log.Debug("received query")
+		log.With("resolver", "cache1").Debug("forwarding query to resolver")
+	})
+	// One slice for each of the two With calls, plus the boxing of the only
+	// value that is not a constant string.
+	require.LessOrEqual(t, allocs, float64(3))
+}
+
+// A call whose level is not enabled must do no work beyond the level check.
+func TestQueryLoggerSuppressedCallDoesNotAllocate(t *testing.T) {
+	dst, _ := captureLog(t, slog.LevelInfo)
+	q := testQuery()
+	ci := ClientInfo{SourceIP: []byte{10, 0, 0, 1}}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		log := testQueryLogger(dst, "resolver1", q, ci)
+		log.Debug("cache-hit")
+		log.Debug("forwarding", "resolver", "upstream")
+	})
+	require.Zero(t, allocs)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -204,114 +204,113 @@ func TestQueryLoggerEmptyQuestion(t *testing.T) {
 	require.Contains(t, buf.String(), "qname=")
 }
 
-// The listener attribute sets, which vary by protocol, must render exactly as
-// slog.Logger.With renders them. The attribute order is part of the output, so
-// this pins it for each listener.
-func TestDeferredLoggerMatchesSlogWith(t *testing.T) {
+// A listener logs through the same type, with its protocol, bind address and
+// DoH path coming from ClientInfo. The attribute order is part of the output,
+// so this pins it for each listener shape.
+func TestQueryLoggerListenerContext(t *testing.T) {
+	q := testQuery()
 	clientIP := net.IP{192, 168, 1, 5}
 
 	tests := []struct {
 		name string
-		args []any
-		emit func(l deferredLogger)
-		orcl func(l *slog.Logger)
+		ci   ClientInfo
+		want []any
 	}{
 		{
-			name: "dns listener",
-			args: []any{
-				"id", "listener1", "client", clientIP, "qname", "www.example.com.",
-				"protocol", "udp", "addr", ":53",
+			name: "plain dns listener",
+			ci: ClientInfo{
+				SourceIP: clientIP, Listener: "listener1",
+				Protocol: "udp", ListenerAddr: ":53",
 			},
-			emit: func(l deferredLogger) { l.Debug("received query") },
-			orcl: func(l *slog.Logger) { l.Debug("received query") },
+			want: []any{
+				slog.String("id", "listener1"), slog.Any("client", clientIP),
+				slog.String("qtype", "A"), slog.String("qname", "www.example.com."),
+				slog.String("protocol", "udp"), slog.String("addr", ":53"),
+			},
 		},
 		{
-			name: "dns listener forwarding",
-			args: []any{
-				"id", "listener1", "client", clientIP, "qname", "www.example.com.",
-				"protocol", "udp", "addr", ":53",
+			name: "doh listener carries the path",
+			ci: ClientInfo{
+				SourceIP: clientIP, Listener: "doh1", DoHPath: "/dns-query",
+				Protocol: "doh", ListenerAddr: ":443",
 			},
-			emit: func(l deferredLogger) { l.With("resolver", "cache1").Debug("forwarding query to resolver") },
-			orcl: func(l *slog.Logger) { l.With("resolver", "cache1").Debug("forwarding query to resolver") },
+			want: []any{
+				slog.String("id", "doh1"), slog.Any("client", clientIP),
+				slog.String("qtype", "A"), slog.String("qname", "www.example.com."),
+				slog.String("protocol", "doh"), slog.String("addr", ":443"),
+				slog.String("path", "/dns-query"),
+			},
 		},
 		{
-			name: "doh listener",
-			args: []any{
-				"id", "doh1", "client", clientIP, "qtype", "A", "qname", "www.example.com.",
-				"protocol", "doh", "addr", ":443", "path", "/dns-query",
+			name: "resolver has no listener context",
+			ci:   ClientInfo{SourceIP: clientIP},
+			want: []any{
+				slog.String("id", "resolver1"), slog.Any("client", clientIP),
+				slog.String("qtype", "A"), slog.String("qname", "www.example.com."),
 			},
-			emit: func(l deferredLogger) { l.Warn("failed to resolve", "error", "boom") },
-			orcl: func(l *slog.Logger) { l.Warn("failed to resolve", "error", "boom") },
-		},
-		{
-			name: "doq listener stream",
-			args: []any{"id", "doq1", "protocol", "doq", "addr", ":853", "client", clientIP},
-			emit: func(l deferredLogger) { l.With("stream", int64(7)).Debug("opening stream") },
-			orcl: func(l *slog.Logger) { l.With("stream", int64(7)).Debug("opening stream") },
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			id := tt.want[0].(slog.Attr).Value.String()
 			dst, buf := captureLog(t, slog.LevelDebug)
-			tt.emit(deferredLog(dst).With(tt.args...))
+			testQueryLogger(dst, id, q, tt.ci).Debug("received query")
 			got := buf.String()
 
 			buf.Reset()
-			tt.orcl(dst.With(tt.args...))
+			dst.With(tt.want...).Debug("received query")
 			require.Equal(t, buf.String(), got)
 		})
 	}
 }
 
-// As for queryLogger, derived loggers must not share the array their
-// attributes live in.
-func TestDeferredLoggerWithDoesNotShareSpareCapacity(t *testing.T) {
+// Connection-scoped records, logged before a query has been read, carry the
+// listener context without empty qtype and qname attributes.
+func TestQueryLoggerNilQueryOmitsQuestion(t *testing.T) {
+	ci := ClientInfo{
+		SourceIP: net.IP{192, 168, 1, 5}, Listener: "doq1",
+		Protocol: "doq", ListenerAddr: ":853",
+	}
 	dst, buf := captureLog(t, slog.LevelDebug)
-
-	base := deferredLog(dst)
-	base.attrs = append(make([]any, 0, 8), "id", "listener1")
-	require.Greater(t, cap(base.attrs), len(base.attrs), "test needs spare capacity to be meaningful")
-
-	branchA := base.With("stream", int64(1))
-	branchB := base.With("stream", int64(2))
-
-	branchA.Debug("first")
-	branchB.Debug("second")
-
-	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
-	require.Len(t, lines, 2)
-	require.Contains(t, lines[0], "stream=1")
-	require.Contains(t, lines[1], "stream=2")
-}
-
-func TestDeferredLoggerReportsCallerSource(t *testing.T) {
-	dst, buf := captureLog(t, slog.LevelDebug, func(o *slog.HandlerOptions) { o.AddSource = true })
-	deferredLog(dst).With("id", "listener1").Debug("here")
+	testQueryLogger(dst, "doq1", nil, ci).Debug("accepting incoming connection")
 
 	out := buf.String()
-	require.Contains(t, out, "logger_test.go", "source should point at the call site")
-	require.NotContains(t, out, "logger.go:", "source must not point at the logging helper")
+	require.Contains(t, out, "id=doq1")
+	require.Contains(t, out, "protocol=doq")
+	require.Contains(t, out, "addr=:853")
+	require.NotContains(t, out, "qtype=")
+	require.NotContains(t, out, "qname=")
 }
 
-// Emitting nothing must cost only the level check. The attributes are held
-// as given, so the sole allocation is the one the caller's variadic slice
-// already required.
-func TestDeferredLoggerSuppressedCallIsCheap(t *testing.T) {
+// A query that unpacked but carries no question keeps the attributes, empty,
+// so the record still shows a query was involved.
+func TestQueryLoggerEmptyQuestionKeepsAttributes(t *testing.T) {
+	dst, buf := captureLog(t, slog.LevelDebug)
+	testQueryLogger(dst, "listener1", new(dns.Msg), ClientInfo{Protocol: "udp"}).
+		Warn("dropping query with no Question section")
+
+	out := buf.String()
+	require.Contains(t, out, "qtype=")
+	require.Contains(t, out, "qname=")
+	require.Contains(t, out, "protocol=udp")
+}
+
+// The listener path must stay allocation-free too, which is what folding the
+// listener attributes into ClientInfo buys over holding them as a slice.
+func TestQueryLoggerListenerSuppressedCallDoesNotAllocate(t *testing.T) {
 	dst, _ := captureLog(t, slog.LevelInfo)
-	clientIP := net.IP{192, 168, 1, 5}
+	q := testQuery()
+	ci := ClientInfo{
+		SourceIP: net.IP{192, 168, 1, 5}, Listener: "doh1", DoHPath: "/dns-query",
+		Protocol: "doh", ListenerAddr: ":443",
+	}
 
 	allocs := testing.AllocsPerRun(100, func() {
-		log := deferredLog(dst).With(
-			"id", "listener1", "client", clientIP, "qname", "www.example.com.",
-			"protocol", "udp", "addr", ":53",
-		)
+		log := testQueryLogger(dst, "doh1", q, ci)
 		log.Debug("received query")
-		log.With("resolver", "cache1").Debug("forwarding query to resolver")
 	})
-	// One slice for each of the two With calls, plus the boxing of the only
-	// value that is not a constant string.
-	require.LessOrEqual(t, allocs, float64(3))
+	require.Zero(t, allocs)
 }
 
 // A call whose level is not enabled must do no work beyond the level check.

--- a/odohlistener.go
+++ b/odohlistener.go
@@ -231,7 +231,12 @@ func (s *ODoHListener) ODoHqueryHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	a, err := s.r.Resolve(q, ClientInfo{Listener: s.id, TLSServerName: r.TLS.ServerName})
+	a, err := s.r.Resolve(q, ClientInfo{
+		Listener:      s.id,
+		TLSServerName: r.TLS.ServerName,
+		Protocol:      "odoh",
+		ListenerAddr:  s.addr,
+	})
 	if err != nil {
 		Log.Warn("failed to resolve", "error", err)
 		a = new(dns.Msg)


### PR DESCRIPTION
## Summary

`slog.Logger.With` does not consult the level. The handler pre-formats every
attribute the moment `With` is called, so at the default `info` level the
per-query log context was built in full and then thrown away by the `Debug`
call on the next line.

This happened once per resolver in the chain (`logger()`, ~40 call sites) and
again in each listener handler. On a query that traverses a router, a blocklist
and a cache, building loggers that never logged anything accounted for roughly
three quarters of the work.

Attributes are now held until a level check has passed, and the whole thing
runs through one logger type whose context comes from what every component
already has in hand.

This is aimed at the same low-powered OpenWRT devices as #603.

## Benchmarks

Best-of-6 on an i7-7600U at log level `info`. A Cortex-A53 is considerably
slower in absolute terms, but the ratios should hold. Allocation counts are
exact.

| | master | this PR | |
|---|---|---|---|
| `logger()` | 1957 ns / 16 allocs | 29 ns / 0 allocs | |
| listener handler alone | 3647 ns / 33 allocs | 1080 ns / 11 allocs | 3.4x |
| listener through router, blocklist, cache hit | 10485 ns / 85 allocs | 2598 ns / 15 allocs | **4.0x, -82% allocs** |

The last row is the end-to-end figure: `listenHandler` for UDP, through a
router and a blocklist to a cache hit, with the upstream resolver stubbed out.

## How it works

`logger()` returns a `queryLogger`, a value holding the log context in typed
fields rather than a pre-formatted `*slog.Logger`. The attributes become a
`slog.Record` only once `Enabled` has passed, so a suppressed call allocates
nothing at all. Tests assert that with `testing.AllocsPerRun`, for both the
resolver and the listener shape.

The context is whatever the component already has: its own id, the query, and
the `ClientInfo` threaded through every `Resolve`. Nothing has to be stored or
looked up, which is what keeps it allocation-free.

The listeners were the awkward case, because their attribute set varies by
protocol and so could not be typed fields. Two of the attributes they needed,
the transport and the listener's bind address, are query-scoped listener
identity that `ClientInfo` was simply missing; it already carried `Listener`,
`DoHPath` and `TLSServerName`. Adding `Protocol` and `ListenerAddr` there lets
a listener log through `queryLogger` exactly as a resolver does, and removes
the need for a second logger type.

Attributes with no value are omitted. A nil query drops `qtype` and `qname`,
which is what a DoQ record logged before the query has been read off the stream
looks like, and the three listener attributes are absent for queries no
listener produced.

Note the tempting one-line version of all this, returning a bare `Log` when
debug is disabled, is **not** equivalent. `Warn` and `Error` still emit at the
default level, and that version silently strips `id`, `client` and `qname` from
exactly the lines an operator is most likely to be reading. Every record keeps
its full context here, and `TestQueryLoggerKeepsContextWhenDebugDisabled` pins
it.

## Log format changes

Records are otherwise identical, including attribute order, but the
consolidation does change some lines:

- Resolver records now carry `protocol`, `addr`, and `path` for DoH, since
  `ClientInfo` now supplies them.
- Plain DNS listener records gain `qtype`.
- DoQ records gain `qtype`, use the shared attribute order, and log the client
  address without its port, which is what every other listener already did.
- DoH listener records are unchanged.

`ClientInfo` gaining two fields is source-compatible. The new fields are not
exposed to Lua scripts or usable as route matchers; both would be feature
additions with their own documentation, and are left out here.

## A trap worth knowing about

`Cache.Resolve` used to capture its logger in the prefetch goroutine's closure.
Growing `ClientInfo` by two strings pushed the captured value past the point
where Go keeps it on the stack, and it started heap-allocating on **every**
query, prefetch or not. That is a 160 byte allocation per query hidden behind a
branch that is usually not taken.

The fix is to build the logger inside the goroutine, where the same variables
are captured anyway. Caught by profiling the chain benchmark before and after,
which is also why the resolver-only path in this PR allocates exactly what it
did before rather than one more.

## Tests

New `logger_test.go`:

- `TestQueryLoggerMatchesSlogWith`, output identity against `slog.Logger.With`
  across plain messages, key/value args, `slog.Attr` args, `With` then log,
  chained `With`, and `With` plus call args. Built by running `encoding`'s own
  `slog` at test time rather than against a golden string, so adding or
  reordering an attribute fails it.
- `TestQueryLoggerListenerContext`, each listener shape's full attribute set
  and order, including the DoH path and the resolver case that has no listener
  context.
- `TestQueryLoggerNilQueryOmitsQuestion` and
  `TestQueryLoggerEmptyQuestionKeepsAttributes`, the two ways a record can lack
  a question.
- `TestQueryLoggerKeepsContextWhenDebugDisabled`, a `Warn` at `info` still
  carries `id`, `client`, `qtype` and `qname`.
- `TestQueryLoggerWithDoesNotMutateReceiver` and
  `TestQueryLoggerWithDoesNotShareSpareCapacity`. `append` only reuses spare
  capacity, and the sizes the natural call sites produce happen not to have
  any, so that condition is set up explicitly. Without the `slices.Clip` the
  second fails.
- `TestQueryLoggerReportsCallerSource`, which guards the `runtime.Callers` skip
  depth. Handlers configured with `AddSource` still report the caller, not
  `logger.go`. The PC is captured on the emit path only, so suppressed calls do
  not pay for it.
- `TestQueryLoggerSuppressedCallDoesNotAllocate` and
  `TestQueryLoggerListenerSuppressedCallDoesNotAllocate`. These are the
  regression guard for the performance property itself, which a benchmark would
  not provide since benchmarks do not fail CI.

Checked by mutation: dropping `slices.Clip`, changing the skip depth, dropping
an attribute, emitting a conditional attribute unconditionally, reordering
`protocol` and `addr`, removing the nil-query guard, and skipping the level
check each fail the suite.

Full suite passes, including under `-race`.

## Notes

The tests deliberately do not swap the package-global `Log`. Background refresh
goroutines started by other tests read it without synchronisation
(`client-blocklist.go:121`) and outlive the test that started them, so any test
writing `Log` races with them. This is latent on master, since no test writes
`Log` today, and #603 ran into the same thing independently. Fixing it properly
means synchronising the exported `Log` variable, which is an API change, so it
is left alone here and the tests point a logger at their own destination
instead.

Not addressed, both nearby but out of scope: `dohlistener.go` and
`odohlistener.go` still use `Log.With` on their malformed-query error paths,
which are not per-query; and `response-blocklist-ip.go` builds a logger per
matching resource record, which also wants its `ip.String()` call moved behind
a level check.
