### PR TITLE
Expose protocol and listener_addr to Lua scripts

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1716,7 +1716,7 @@ Scripts have access to the following types and globals:
 - **Question** - DNS question. Create with `Question.new(name, qtype, qclass)`. Fields: `name`, `qtype`, `qclass`.
 - **RR** - Resource record. Create with `RR.new({rtype = TypeA, name = "example.com.", class = ClassIN, ttl = 300, a = "1.2.3.4"})`. Header fields: `name`, `rtype`, `class`, `ttl`, `rdlength`. Data fields are type-specific and use lowercase names (e.g., `a`, `aaaa`, `ns`, `cname`, `mx`, `preference`, `target`, etc.).
 - **OPT** - EDNS0 OPT pseudo-record. Create with `OPT.new(udp_size, do_bit)`. Fields: `udp_size`, `do_bit`, `version`, `extended_rcode`, `option` (array of EDNS0 options), `name`, `rtype`. Also returned by `Message:is_edns0()` and created implicitly by `Message:set_edns0(udp_size, do_bit)`.
-- **ClientInfo** - Client information passed as the second argument (`ci`) to `Resolve(msg, ci)`. Read-only fields: `source_ip` (string or nil), `doh_path` (string), `tls_server_name` (string), `listener` (string).
+- **ClientInfo** - Client information passed as the second argument (`ci`) to `Resolve(msg, ci)`. Read-only fields: `source_ip` (string or nil), `doh_path` (string), `tls_server_name` (string), `listener` (string), `protocol` (string, the transport the query arrived on, one of `udp`, `tcp`, `dot`, `doh`, `doq`, `dtls` or `odoh`), `listener_addr` (string, the address the receiving listener is bound to). The last two are empty for queries that were not produced by a listener, such as those from the `prefetch` component.
 - **Error** - Error value. Create with `Error.new("message")`. Methods: `error()`.
 - **Resolvers** - Table of upstream resolvers. Each resolver has a `:resolve(msg, ci)` method that returns `(response, error)` (e.g. `Resolvers[1]:resolve(msg, ci)`).
 - **DNS constants** - Type constants (`TypeA`, `TypeAAAA`, `TypeMX`, ...), class constants (`ClassIN`, `ClassCH`, ...), rcode constants (`RcodeNOERROR`, `RcodeNXDOMAIN`, ...).
@@ -1805,6 +1805,11 @@ function Resolve(msg, ci)
 
     -- Route based on TLS server name
     if ci.tls_server_name == "private.dns.example.com" then
+        return Resolvers[1]:resolve(msg, ci)
+    end
+
+    -- Treat anything that arrived over an encrypted transport as trusted
+    if ci.protocol == "dot" or ci.protocol == "doh" or ci.protocol == "doq" then
         return Resolvers[1]:resolve(msg, ci)
     end
 

--- a/lua-clientinfo.go
+++ b/lua-clientinfo.go
@@ -33,6 +33,10 @@ func (s *LuaScript) RegisterClientInfoType() {
 				L.Push(lua.LString(ci.TLSServerName))
 			case "listener":
 				L.Push(lua.LString(ci.Listener))
+			case "protocol":
+				L.Push(lua.LString(ci.Protocol))
+			case "listener_addr":
+				L.Push(lua.LString(ci.ListenerAddr))
 			default:
 				L.ArgError(2, fmt.Sprintf("clientinfo does not have field %q", fieldName))
 				return 0

--- a/lua_test.go
+++ b/lua_test.go
@@ -949,6 +949,16 @@ function Resolve(msg, ci)
 		return nil, Error.new("unexpected listener: " .. tostring(ci.listener))
 	end
 
+	-- Verify protocol
+	if ci.protocol ~= "doh" then
+		return nil, Error.new("unexpected protocol: " .. tostring(ci.protocol))
+	end
+
+	-- Verify listener_addr
+	if ci.listener_addr ~= ":443" then
+		return nil, Error.new("unexpected listener_addr: " .. tostring(ci.listener_addr))
+	end
+
 	return nil, nil
 end`,
 	}
@@ -958,6 +968,8 @@ end`,
 		DoHPath:       "/dns-query",
 		TLSServerName: "dns.example.com",
 		Listener:      "my-listener",
+		Protocol:      "doh",
+		ListenerAddr:  ":443",
 	}
 	resolver := new(TestResolver)
 
@@ -969,6 +981,27 @@ end`,
 
 	_, err = r.Resolve(q, ci)
 	require.NoError(t, err)
+}
+
+// Reading a field the type does not have must fail rather than silently
+// yielding nil, so a typo in a script surfaces at the first query.
+func TestLuaClientInfoUnknownField(t *testing.T) {
+	opt := LuaOptions{
+		Script: `
+function Resolve(msg, ci)
+	local _ = ci.protocol_typo
+	return nil, nil
+end`,
+	}
+	r, err := NewLua("test-lua", opt, new(TestResolver))
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	_, err = r.Resolve(q, ClientInfo{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "protocol_typo")
 }
 
 func TestLuaClientInfoNilSourceIP(t *testing.T) {
@@ -983,6 +1016,14 @@ function Resolve(msg, ci)
 	-- Empty string fields should be empty
 	if ci.doh_path ~= "" then
 		return nil, Error.new("expected empty doh_path")
+	end
+
+	-- Queries not produced by a listener carry no transport context
+	if ci.protocol ~= "" then
+		return nil, Error.new("expected empty protocol")
+	end
+	if ci.listener_addr ~= "" then
+		return nil, Error.new("expected empty listener_addr")
 	end
 
 	return nil, nil


### PR DESCRIPTION
## Summary

#604 added `Protocol` and `ListenerAddr` to `ClientInfo` so that a listener
could log through the same helper as the resolvers. They are query-scoped
client information like the four fields already there, but the Lua binding
still only exposed the older ones, so a script could route on the TLS server
name while having no way to ask whether the query arrived encrypted at all.

Both are now readable from Lua as `protocol` and `listener_addr`, following the
snake_case naming the existing fields use.

## Behaviour

`protocol` is the transport the query arrived on: `udp`, `tcp`, `dot`, `doh`,
`doq`, `dtls` or `odoh`. `listener_addr` is the address the receiving listener
is bound to.

Both are empty strings for queries no listener produced, such as those the
`prefetch` component generates, which matches how `doh_path` and
`tls_server_name` already behave for queries that do not carry them. Only
`source_ip` yields nil, and that is unchanged.

Read-only, like the rest of the type. No config surface changes.

## Tests

`TestLuaClientInfoAccess` and `TestLuaClientInfoNilSourceIP` are extended to
cover the two fields set and empty respectively.

`TestLuaClientInfoUnknownField` is new and covers a path that had no test at
all: reading a field the type does not have raises rather than yielding nil, so
a typo in a script surfaces at the first query instead of silently taking the
wrong branch. Worth pinning while the switch it guards is being edited.

Checked by mutation: dropping the `protocol` case, and having `listener_addr`
return the wrong field, each fail the suite.

Full suite passes, including under `-race`.

## Docs

`doc/configuration.md` lists both fields with their possible values and notes
when they are empty. The Lua routing example gains a branch that trusts
encrypted transports, since routing on `protocol` is the obvious reason to want
this.
