### PR TITLE
Lower the query name once per regexp blocklist match, not once per rule

### DIFF
--- a/blocklistdb-regexp.go
+++ b/blocklistdb-regexp.go
@@ -45,8 +45,9 @@ func (m *RegexpDB) Reload() (BlocklistDB, error) {
 
 func (m *RegexpDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
 	q := msg.Question[0]
+	name := strings.ToLower(q.Name)
 	for _, rule := range m.rules {
-		if rule.MatchString(strings.ToLower(q.Name)) {
+		if rule.MatchString(name) {
 			return nil, nil, &BlocklistMatch{List: m.name, Rule: rule.String()}, true
 		}
 	}

--- a/blocklistdb-regexp_test.go
+++ b/blocklistdb-regexp_test.go
@@ -1,0 +1,83 @@
+package rdns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func regexpDBRules(n int) []string {
+	rules := make([]string, 0, n)
+	for i := range n {
+		rules = append(rules, fmt.Sprintf(`(^|\.)ads%d\.example\.org`, i))
+	}
+	return rules
+}
+
+func newRegexpDBForTest(tb testing.TB, n int) *RegexpDB {
+	tb.Helper()
+	db, err := NewRegexpDB("test", NewStaticLoader(regexpDBRules(n)))
+	require.NoError(tb, err)
+	return db
+}
+
+func regexpQuery(name string) *dns.Msg {
+	q := new(dns.Msg)
+	q.SetQuestion(name, dns.TypeA)
+	return q
+}
+
+// Matching cost must not scale in allocations with the number of rules. A
+// query carrying upper case is what makes this visible: lowering it copies,
+// and doing that inside the rule loop copies once per rule.
+func TestRegexpDBMatchDoesNotAllocatePerRule(t *testing.T) {
+	const rules = 200
+	db := newRegexpDBForTest(t, rules)
+	q := regexpQuery("WWW.ExAmPlE.CoM.")
+
+	allocs := testing.AllocsPerRun(50, func() {
+		_, _, _, _ = db.Match(q)
+	})
+
+	// Lowering the name per rule puts this in the hundreds. The bound is
+	// generous rather than exact because the race detector allocates on its
+	// own account, which is enough to break an equality check.
+	require.Less(t, allocs, float64(rules)/10, "allocations scale with the rule count")
+}
+
+// The rules are compiled from lower-case patterns, so matching has to be
+// case-insensitive in the query name however many rules are searched.
+func TestRegexpDBMatchIsCaseInsensitive(t *testing.T) {
+	db, err := NewRegexpDB("test", NewStaticLoader([]string{
+		`(^|\.)first\.example\.org`,
+		`(^|\.)block\.example\.org`,
+	}))
+	require.NoError(t, err)
+
+	// Matches the second rule, so the search passes over the first one.
+	_, _, match, ok := db.Match(regexpQuery("X.BlOcK.ExAmPlE.OrG."))
+	require.True(t, ok)
+	require.Equal(t, "test", match.List)
+	require.Equal(t, `(^|\.)block\.example\.org`, match.Rule)
+
+	_, _, match, ok = db.Match(regexpQuery("WWW.ExAmPlE.CoM."))
+	require.False(t, ok)
+	require.Nil(t, match, "a miss must not build a match")
+}
+
+func BenchmarkRegexpDBMatchMiss(b *testing.B) {
+	for _, n := range []int{50, 200} {
+		for _, name := range []string{"www.example.com.", "WWW.ExAmPlE.CoM."} {
+			b.Run(fmt.Sprintf("rules=%d/name=%s", n, name), func(b *testing.B) {
+				db := newRegexpDBForTest(b, n)
+				q := regexpQuery(name)
+				b.ReportAllocs()
+				for b.Loop() {
+					_, _, _, _ = db.Match(q)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`RegexpDB.Match` lowered the query name inside the loop over rules:

```go
for _, rule := range m.rules {
    if rule.MatchString(strings.ToLower(q.Name)) {
```

So a list of N expressions scanned the name N times, and allocated a copy of it
N times for any query carrying upper case. The rules are compiled from
lower-case patterns and the name does not change during the search, so it is
now lowered once before the loop.

Same path used by both the query-side `blocklist` component and the
response-side `response-blocklist-name`, since the latter matches through the
same `BlocklistDB`.

## Benchmarks

Best-of-4 on an i7-7600U, a query that matches nothing so the whole list is
searched. Allocation counts are exact.

| rules | query | before | after |
|---|---|---|---|
| 50 | mixed case | 17919 ns / 50 allocs | 12491 ns / 1 alloc |
| 200 | mixed case | 40402 ns / 200 allocs | **13371 ns / 1 alloc** |
| 50 | lower case | 12352 ns / 0 allocs | 12260 ns / 0 allocs |
| 200 | lower case | 14205 ns / 0 allocs | 13986 ns / 0 allocs |

The allocation is one per rule, so the win scales with list size: 2.9x on a
200-rule list.

An all-lower-case query is unchanged in allocations, because `strings.ToLower`
returns the original string when there is nothing to fold. There the fix only
saves the repeated scan, which is small next to the regexp evaluation, so those
two rows are flat. Worth being explicit about, since the headline number only
applies to queries that actually carry upper case.

## Tests

`blocklistdb-regexp.go` had no test file. The new one covers it directly rather
than only through the `blocklist` component:

- `TestRegexpDBMatchIsCaseInsensitive` pins the behaviour the lowering exists
  for, using a name that matches the *second* rule so the search passes over
  the first, and checks a miss returns no match at all.
- `TestRegexpDBMatchDoesNotAllocatePerRule` is the regression guard for the fix
  itself: matching a 200-rule list must allocate a constant amount, not one per
  rule. Moving the call back inside the loop fails it.

The bound in that second test is generous rather than an equality check,
because the race detector allocates on its own account. Verified it still fails
the mutation under both `go test` and `go test -race`; a regression measures in
the hundreds, so the loose bound costs nothing in sensitivity.

`TestBlocklistRegexp` already covered mixed-case matching through the component
and would have caught a hoist that dropped the lowering.

Full suite passes, including under `-race`.

## Context

This is finding 6 from a profiling pass over the query path, following #604.
The remaining items in that pass, roughly in order of payoff: blocklist
databases building a match on the miss path, `DomainDB.Match` splitting the
query name into a heap slice per query, routes evaluating regular expressions
that were never configured, and the memory cache copying answers while holding
its mutex.
