### PR TITLE
Encode cache records once when saving to file

### DIFF
--- a/lru-cache-serialize_test.go
+++ b/lru-cache-serialize_test.go
@@ -1,0 +1,93 @@
+package rdns
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// A cache file written before this change must still load, so an upgrade
+// doesn't silently discard the cache. This record was produced by the previous
+// encoder, which built its output through cacheAnswer.MarshalJSON.
+const legacyCacheRecord = `{"Key":{"Question":{"Name":"host.example.com.","Qtype":1,"Qclass":1},"Net":"192.0.2.0","Do":true,"CD":true,"ECSMask":24},"Answer":{"Timestamp":"2026-08-08T12:00:00.123456789Z","Expiry":"2126-08-08T13:00:00.123456789Z","PrefetchEligible":true,"Msg":"khIBAAABAAEAAAAABGhvc3QHZXhhbXBsZQNjb20AAAEAAQRob3N0B2V4YW1wbGUDY29tAAABAAEAAAEsAATAAAIB"}}
+`
+
+func TestLRUDeserializeLegacyFormat(t *testing.T) {
+	c := newLRUCache(0)
+	require.NoError(t, c.deserialize(strings.NewReader(legacyCacheRecord)))
+	require.Equal(t, 1, c.size())
+
+	key := lruKey{
+		Question: dns.Question{Name: "host.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+		Net:      "192.0.2.0",
+		Do:       true,
+		CD:       true,
+		ECSMask:  24,
+	}
+	item := c.items[key]
+	require.NotNil(t, item, "the record's key must survive unchanged")
+	require.Equal(t, "host.example.com.", item.Answer.Msg.Question[0].Name)
+	require.True(t, item.Answer.PrefetchEligible)
+}
+
+// Pins the exact bytes written for a fully-populated record. The cache file
+// has to stay readable by older builds, so any change to field names, order or
+// encoding has to be deliberate rather than a side effect of touching the
+// structs this is built from.
+func TestLRUSerializeFormatStable(t *testing.T) {
+	ts, err := time.Parse(time.RFC3339Nano, "2026-08-08T12:00:00.123456789Z")
+	require.NoError(t, err)
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("host.example.com.", dns.TypeA)
+	msg.Id = 4242 // SetQuestion randomises this
+	msg.Answer = []dns.RR{
+		&dns.A{
+			Hdr: dns.RR_Header{Name: "host.example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+			A:   net.IP{192, 0, 2, 1},
+		},
+	}
+
+	c := newLRUCache(0)
+	c.addKey(lruKey{
+		Question: dns.Question{Name: "host.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+		Net:      "192.0.2.0",
+		Do:       true,
+		CD:       true,
+		ECSMask:  24,
+	}, &cacheAnswer{
+		Timestamp:        ts,
+		Expiry:           ts.Add(time.Hour),
+		PrefetchEligible: true,
+		Msg:              msg,
+	})
+
+	var buf bytes.Buffer
+	require.NoError(t, c.serialize(&buf))
+
+	// Field names and order must match what encoding/json produced for the
+	// old cacheItem/cacheAnswer pair.
+	require.Equal(t,
+		`{"Key":{"Question":{"Name":"host.example.com.","Qtype":1,"Qclass":1},"Net":"192.0.2.0","Do":true,"CD":true,"ECSMask":24},`+
+			`"Answer":{"Timestamp":"2026-08-08T12:00:00.123456789Z","Expiry":"2026-08-08T13:00:00.123456789Z","PrefetchEligible":true,`+
+			`"Msg":"EJIBAAABAAEAAAAABGhvc3QHZXhhbXBsZQNjb20AAAEAAQRob3N0B2V4YW1wbGUDY29tAAABAAEAAAEsAATAAAIB"}}`+"\n",
+		buf.String())
+}
+
+// A truncated or corrupt record is skipped rather than taking the whole cache
+// file down with it.
+func TestLRUDeserializeSkipsBadRecords(t *testing.T) {
+	good := `{"Key":{"Question":{"Name":"good.example.com.","Qtype":1,"Qclass":1}},"Answer":{"Timestamp":"2026-08-08T12:00:00Z","Expiry":"2126-08-08T13:00:00Z","Msg":"khIBAAABAAEAAAAABGhvc3QHZXhhbXBsZQNjb20AAAEAAQRob3N0B2V4YW1wbGUDY29tAAABAAEAAAEsAATAAAIB"}}`
+	// No name, and an entry whose message isn't valid wire format.
+	noName := `{"Key":{"Question":{"Name":"","Qtype":1,"Qclass":1}},"Answer":{"Msg":"AAEC"}}`
+	badMsg := `{"Key":{"Question":{"Name":"bad.example.com.","Qtype":1,"Qclass":1}},"Answer":{"Msg":"AAEC"}}`
+
+	c := newLRUCache(0)
+	require.NoError(t, c.deserialize(strings.NewReader(noName+"\n"+badMsg+"\n"+good+"\n")))
+	require.Equal(t, 1, c.size(), "only the good record should load")
+}

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -2,6 +2,7 @@ package rdns
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"time"
@@ -36,38 +37,62 @@ type cacheAnswer struct {
 	Msg              *dns.Msg
 }
 
-// The custom JSON marshaling is used by the memory backend to persist the
-// cache to a file (MemoryBackendOptions.Filename), packing the message to
-// wire format.
-func (c cacheAnswer) MarshalJSON() ([]byte, error) {
-	msg, err := c.Msg.Pack()
-	if err != nil {
-		return nil, err
-	}
-	type alias cacheAnswer
-	record := struct {
-		alias
-		Msg []byte
-	}{
-		alias: alias(c),
-		Msg:   msg,
-	}
-	return json.Marshal(record)
+// How a cacheItem is written to, and read from, the cache file
+// (MemoryBackendOptions.Filename). It mirrors cacheItem/cacheAnswer with the
+// message in wire format, which is what makes the record marshalable.
+//
+// The cache types deliberately don't carry a MarshalJSON method of their own.
+// One would have to build its output with json.Marshal, which the encoder then
+// re-parses to compact it, encoding every record twice.
+type cacheItemJSON struct {
+	Key    lruKey
+	Answer cacheAnswerJSON
 }
 
-func (c *cacheAnswer) UnmarshalJSON(data []byte) error {
-	type alias cacheAnswer
-	aux := struct {
-		*alias
-		Msg []byte
-	}{
-		alias: (*alias)(c),
+type cacheAnswerJSON struct {
+	Timestamp        time.Time
+	Expiry           time.Time
+	PrefetchEligible bool
+	Msg              []byte
+}
+
+// Builds the on-disk form of an item, packing its message to wire format.
+func newCacheItemJSON(item *cacheItem) (cacheItemJSON, error) {
+	if item.Answer == nil || item.Answer.Msg == nil {
+		return cacheItemJSON{}, errors.New("cache item has no message")
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
+	msg, err := item.Answer.Msg.Pack()
+	if err != nil {
+		return cacheItemJSON{}, err
 	}
-	c.Msg = new(dns.Msg)
-	return c.Msg.Unpack(aux.Msg)
+	return cacheItemJSON{
+		Key: item.Key,
+		Answer: cacheAnswerJSON{
+			Timestamp:        item.Answer.Timestamp,
+			Expiry:           item.Answer.Expiry,
+			PrefetchEligible: item.Answer.PrefetchEligible,
+			Msg:              msg,
+		},
+	}, nil
+}
+
+// Rebuilds a cache item from its on-disk form, unpacking the wire-format
+// message. Returns false for a record that can't be used, which includes ones
+// written by a version that stored different fields.
+func (r cacheItemJSON) toCacheItem() (lruKey, *cacheAnswer, bool) {
+	if r.Key.Question.Name == "" || len(r.Answer.Msg) == 0 {
+		return lruKey{}, nil, false
+	}
+	msg := new(dns.Msg)
+	if err := msg.Unpack(r.Answer.Msg); err != nil {
+		return lruKey{}, nil, false
+	}
+	return r.Key, &cacheAnswer{
+		Timestamp:        r.Answer.Timestamp,
+		Expiry:           r.Answer.Expiry,
+		PrefetchEligible: r.Answer.PrefetchEligible,
+		Msg:              msg,
+	}, true
 }
 
 func newLRUCache(capacity int) *lruCache {
@@ -193,7 +218,11 @@ func (c *lruCache) size() int {
 func (c *lruCache) serialize(w io.Writer) error {
 	enc := json.NewEncoder(w)
 	for item := c.tail.prev; item != c.head; item = item.prev {
-		if err := enc.Encode(item); err != nil {
+		record, err := newCacheItemJSON(item)
+		if err != nil {
+			return err
+		}
+		if err := enc.Encode(record); err != nil {
 			return err
 		}
 	}
@@ -203,15 +232,16 @@ func (c *lruCache) serialize(w io.Writer) error {
 func (c *lruCache) deserialize(r io.Reader) error {
 	dec := json.NewDecoder(r)
 	for dec.More() {
-		item := new(cacheItem)
-		if err := dec.Decode(item); err != nil {
+		var record cacheItemJSON
+		if err := dec.Decode(&record); err != nil {
 			return err
 		}
 		// Skip bad (or incompatible) records
-		if item.Key.Question.Name == "" || item.Answer == nil {
+		key, answer, ok := record.toCacheItem()
+		if !ok {
 			continue
 		}
-		c.addKey(item.Key, item.Answer)
+		c.addKey(key, answer)
 	}
 	return nil
 }


### PR DESCRIPTION
Follow-up to the PR https://github.com/folbricht/routedns/pull/603, covering part 2a of the split: the JSON encoding
itself, without changing the file format.

## The problem

`cacheAnswer.MarshalJSON` builds its result with `json.Marshal`:

```go
func (c cacheAnswer) MarshalJSON() ([]byte, error) {
        msg, err := c.Msg.Pack()
        ...
        return json.Marshal(record)
}
```

The encoder writing the cache file then has to **re-parse that output to compact
it**, because a `MarshalJSON` implementation is allowed to return arbitrary
whitespace. So every record is encoded twice: once inside the method, once again
as the encoder scans and re-emits the bytes it returned.

`UnmarshalJSON` has the same shape on the way back in — it runs a second
`json.Unmarshal` into an aux struct, from inside a decode the caller has already
started.

## The change

Replace both methods with an explicit pair of structs describing the on-disk
record, holding the message in wire format:

```go
type cacheItemJSON struct {
        Key    lruKey
        Answer cacheAnswerJSON
}
```

`serialize` builds one and hands it to the encoder; `deserialize` decodes into
one and converts back. Nothing marshals JSON that then has to be parsed again.

Beyond the speed, this moves the on-disk shape into a type of its own rather
than leaving it implied by a method on the cache types. Adding a field to
`cacheAnswer` no longer changes the file format as a side effect.

## Numbers

1000 records, medians of 7 runs:

| | before | after | |
|---|---|---|---|
| serialize | 4.94 ms | **2.93 ms** | 1.68× |
| serialize allocs | 5019 | 4015 | −20% |
| deserialize | 12.66 ms | **7.42 ms** | 1.71× |
| deserialize allocs | 19038 | 13038 | −32% |

The read side improving was not the goal — it falls out of removing the same
double-parse from `UnmarshalJSON`. That matters more than the write side for the
devices this is aimed at, since loading happens synchronously at startup while
holding the cache lock.

## Format compatibility

The file format is unchanged, and that is the property the tests are built
around:

- `TestLRUSerializeFormatStable` pins the exact bytes written for a
  fully-populated record — every key field, ECS, the DNSSEC and CD bits,
  sub-second timestamps. Any change to field names, order or encoding has to be
  deliberate rather than a side effect of editing the structs.
- `TestLRUDeserializeLegacyFormat` loads a record written by the old encoder, so
  an upgrade doesn't discard an existing cache.

Those two look redundant but cover opposite directions and catch different
regressions: renaming a field on the write side is invisible to the read test,
and dropping one on the read side is invisible to the write test. I checked this
by mutation rather than assuming it — applying seven format-breaking changes,
each was caught by one test or the other, never both.

Worth noting a round-trip test does **not** establish this. It uses the same
encoder on both ends, so any self-consistent format break passes it. I wrote one
first; it survived five of the seven mutations, including a whole-field rename,
and is not in this PR.

There is no serialize/deserialize coverage on master today, so these are new
rather than adapted.

## One behaviour change

A record whose message can't be unpacked is now skipped. Previously the error
came back out of `deserialize` and `loadFromFile` abandoned the whole file, so a
single corrupt record discarded the entire warm cache — including every record
after it. A truncated cache file from an unclean shutdown now costs one entry.

`TestLRUDeserializeSkipsBadRecords` covers this. It fails against master, which
is what confirms the behaviour is genuinely new rather than a re-test.