### PR TITLE
Reduce the memory backend's per-entry overhead

### DIFF
--- a/cache-memory.go
+++ b/cache-memory.go
@@ -64,17 +64,17 @@ func (b *memoryBackend) Store(query *dns.Msg, item *cacheAnswer) {
 
 func (b *memoryBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 	var answer *dns.Msg
-	var timestamp time.Time
+	var timestamp int64
 	var prefetchEligible bool
-	var expiry time.Time
+	var expiry int64
 	b.mu.Lock()
-	if a := b.lru.get(q); a != nil {
+	if item := b.lru.get(q); item != nil {
 		// Copy the message so later elements can modify the response
 		// without affecting the cached original.
-		answer = a.Msg.Copy()
-		timestamp = a.Timestamp
-		prefetchEligible = a.PrefetchEligible
-		expiry = a.Expiry
+		answer = item.msg.Copy()
+		timestamp = item.timestamp
+		prefetchEligible = item.prefetchEligible
+		expiry = item.expiry
 	}
 	b.mu.Unlock()
 
@@ -84,7 +84,8 @@ func (b *memoryBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 	}
 
 	// Check if item has expired from the cache
-	if time.Now().After(expiry) {
+	now := time.Now().UnixNano()
+	if now > expiry {
 		b.Evict(q)
 		return nil, false, false
 	}
@@ -93,8 +94,13 @@ func (b *memoryBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 	answer.Question = q.Question // restore the case used in the question
 
 	// Calculate the time the record spent in the cache. We need to
-	// subtract that from the TTL of each answer record.
-	age := uint32(time.Since(timestamp).Seconds())
+	// subtract that from the TTL of each answer record. A record stored
+	// ahead of the current time, which a backwards clock step or a cache
+	// file from another machine can produce, counts as brand new.
+	var age uint32
+	if now > timestamp {
+		age = uint32((now - timestamp) / int64(time.Second))
+	}
 
 	// Go through all the answers, NS, and Extra and adjust the TTL (subtract the time
 	// it's spent in the cache). If the record is too old, evict it from the cache
@@ -138,11 +144,11 @@ func (b *memoryBackend) Flush() {
 func (b *memoryBackend) startGC(period time.Duration) {
 	for {
 		time.Sleep(period)
-		now := time.Now()
+		now := time.Now().UnixNano()
 		var total, removed int
 		b.mu.Lock()
-		b.lru.deleteFunc(func(a *cacheAnswer) bool {
-			if now.After(a.Expiry) {
+		b.lru.deleteFunc(func(item *cacheItem) bool {
+			if now > item.expiry {
 				removed++
 				return true
 			}

--- a/lru-cache-serialize_test.go
+++ b/lru-cache-serialize_test.go
@@ -29,10 +29,10 @@ func TestLRUDeserializeLegacyFormat(t *testing.T) {
 		CD:       true,
 		ECSMask:  24,
 	}
-	item := c.items[key]
+	item := c.find(key)
 	require.NotNil(t, item, "the record's key must survive unchanged")
-	require.Equal(t, "host.example.com.", item.Answer.Msg.Question[0].Name)
-	require.True(t, item.Answer.PrefetchEligible)
+	require.Equal(t, "host.example.com.", item.msg.Question[0].Name)
+	require.True(t, item.prefetchEligible)
 }
 
 // Pins the exact bytes written for a fully-populated record. The cache file

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -3,6 +3,7 @@ package rdns
 import (
 	"encoding/json"
 	"errors"
+	"hash/maphash"
 	"io"
 	"strings"
 	"time"
@@ -10,16 +11,36 @@ import (
 	"github.com/miekg/dns"
 )
 
+// lruCache holds cached DNS responses in a doubly-linked list ordered by
+// recency, indexed by a 64-bit hash of the cache key.
+//
+// Indexing by hash rather than by lruKey directly keeps the 48-byte key out
+// of every map slot, which matters because the item already holds the key.
+// A lookup compares the full key, so a hash collision can only ever cause a
+// cache miss. Two distinct keys colliding on 64 bits is rare enough that the
+// loser is dropped rather than chained; the seed is random per instance, so
+// a client cannot craft names that collide on purpose.
 type lruCache struct {
 	maxItems   int
-	items      map[lruKey]*cacheItem
+	items      map[uint64]*cacheItem
 	head, tail *cacheItem
+	seed       maphash.Seed
+	count      int
 }
 
+// cacheItem holds a cached answer inline rather than pointing at a
+// cacheAnswer, which saves an allocation and a traced pointer per entry.
 type cacheItem struct {
-	Key        lruKey
-	Answer     *cacheAnswer
+	key        lruKey
 	prev, next *cacheItem
+
+	msg *dns.Msg
+	// Unix nanoseconds. A time.Time would carry a location pointer that the
+	// GC has to trace for every entry in the cache, for no more resolution
+	// than an int64 already gives.
+	timestamp        int64 // time the record was cached, used to adjust TTL
+	expiry           int64 // time the record expires and should be removed
+	prefetchEligible bool  // the cache can prefetch this record
 }
 
 type lruKey struct {
@@ -58,22 +79,40 @@ type cacheAnswerJSON struct {
 
 // Builds the on-disk form of an item, packing its message to wire format.
 func newCacheItemJSON(item *cacheItem) (cacheItemJSON, error) {
-	if item.Answer == nil || item.Answer.Msg == nil {
+	if item.msg == nil {
 		return cacheItemJSON{}, errors.New("cache item has no message")
 	}
-	msg, err := item.Answer.Msg.Pack()
+	msg, err := item.msg.Pack()
 	if err != nil {
 		return cacheItemJSON{}, err
 	}
 	return cacheItemJSON{
-		Key: item.Key,
+		Key: item.key,
 		Answer: cacheAnswerJSON{
-			Timestamp:        item.Answer.Timestamp,
-			Expiry:           item.Answer.Expiry,
-			PrefetchEligible: item.Answer.PrefetchEligible,
+			Timestamp:        nanoTime(item.timestamp),
+			Expiry:           nanoTime(item.expiry),
+			PrefetchEligible: item.prefetchEligible,
 			Msg:              msg,
 		},
 	}, nil
+}
+
+// Conversions between the time.Time a cacheAnswer carries and the unix
+// nanoseconds an item holds. The zero time maps to zero, which UnixNano
+// cannot represent, and back again; times are written out in UTC so a cache
+// file doesn't depend on the timezone of the host that wrote it.
+func unixNano(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
+}
+
+func nanoTime(n int64) time.Time {
+	if n == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, n).UTC()
 }
 
 // Rebuilds a cache item from its on-disk form, unpacking the wire-format
@@ -103,9 +142,10 @@ func newLRUCache(capacity int) *lruCache {
 
 	return &lruCache{
 		maxItems: capacity,
-		items:    make(map[lruKey]*cacheItem),
+		items:    make(map[uint64]*cacheItem),
 		head:     head,
 		tail:     tail,
+		seed:     maphash.MakeSeed(),
 	}
 }
 
@@ -119,25 +159,63 @@ func (c *lruCache) addKey(key lruKey, answer *cacheAnswer) {
 	if item != nil {
 		// Update the item, it's already at the top of the list
 		// so we can just change the value
-		item.Answer = answer
+		item.setAnswer(answer)
 		return
 	}
-	// Add new item to the top of the linked list
-	item = &cacheItem{
-		Key:    key,
-		Answer: answer,
-		next:   c.head.next,
-		prev:   c.head,
+	item = &cacheItem{key: key}
+	item.setAnswer(answer)
+	c.insert(item)
+}
+
+// Copies an answer into the item. The cacheAnswer itself is not retained.
+func (i *cacheItem) setAnswer(a *cacheAnswer) {
+	i.msg = a.Msg
+	i.timestamp = unixNano(a.Timestamp)
+	i.expiry = unixNano(a.Expiry)
+	i.prefetchEligible = a.PrefetchEligible
+}
+
+// Link a new item into the index and the top of the linked list.
+func (c *lruCache) insert(item *cacheItem) {
+	h := c.hash(item.key)
+	if existing := c.items[h]; existing != nil {
+		c.unlink(existing)
 	}
+	c.items[h] = item
+
+	item.next = c.head.next
+	item.prev = c.head
 	c.head.next.prev = item
 	c.head.next = item
-	c.items[key] = item
+
+	c.count++
 	c.resize()
+}
+
+// Unlink an item from both the index and the linked list.
+func (c *lruCache) unlink(item *cacheItem) {
+	item.prev.next = item.next
+	item.next.prev = item.prev
+	delete(c.items, c.hash(item.key))
+	c.count--
+}
+
+func (c *lruCache) hash(key lruKey) uint64 {
+	return maphash.Comparable(c.seed, key)
+}
+
+// Find an item by key without changing its position in the queue.
+func (c *lruCache) find(key lruKey) *cacheItem {
+	item := c.items[c.hash(key)]
+	if item == nil || item.key != key {
+		return nil
+	}
+	return item
 }
 
 // Loads a cache item and puts it to the top of the queue (most recent).
 func (c *lruCache) touch(key lruKey) *cacheItem {
-	item := c.items[key]
+	item := c.find(key)
 	if item == nil {
 		return nil
 	}
@@ -152,23 +230,15 @@ func (c *lruCache) touch(key lruKey) *cacheItem {
 }
 
 func (c *lruCache) delete(q *dns.Msg) {
-	key := lruKeyFromQuery(q)
-	item := c.items[key]
+	item := c.find(lruKeyFromQuery(q))
 	if item == nil {
 		return
 	}
-	item.prev.next = item.next
-	item.next.prev = item.prev
-	delete(c.items, key)
+	c.unlink(item)
 }
 
-func (c *lruCache) get(query *dns.Msg) *cacheAnswer {
-	key := lruKeyFromQuery(query)
-	item := c.touch(key)
-	if item != nil {
-		return item.Answer
-	}
-	return nil
+func (c *lruCache) get(query *dns.Msg) *cacheItem {
+	return c.touch(lruKeyFromQuery(query))
 }
 
 // Shrink the cache down to the maximum number of items.
@@ -176,12 +246,8 @@ func (c *lruCache) resize() {
 	if c.maxItems <= 0 { // no size limit
 		return
 	}
-	drop := len(c.items) - c.maxItems
-	for range drop {
-		item := c.tail.prev
-		item.prev.next = c.tail
-		c.tail.prev = item.prev
-		delete(c.items, item.Key)
+	for c.count > c.maxItems {
+		c.unlink(c.tail.prev)
 	}
 }
 
@@ -194,25 +260,25 @@ func (c *lruCache) reset() {
 
 	c.head = head
 	c.tail = tail
-	c.items = make(map[lruKey]*cacheItem)
+	c.items = make(map[uint64]*cacheItem)
+	c.count = 0
 }
 
-// Iterate over the cached answers and call the provided function. If it
+// Iterate over the cached items and call the provided function. If it
 // returns true, the item is deleted from the cache.
-func (c *lruCache) deleteFunc(f func(*cacheAnswer) bool) {
+func (c *lruCache) deleteFunc(f func(*cacheItem) bool) {
 	item := c.head.next
 	for item != c.tail {
-		if f(item.Answer) {
-			item.prev.next = item.next
-			item.next.prev = item.prev
-			delete(c.items, item.Key)
+		next := item.next
+		if f(item) {
+			c.unlink(item)
 		}
-		item = item.next
+		item = next
 	}
 }
 
 func (c *lruCache) size() int {
-	return len(c.items)
+	return c.count
 }
 
 func (c *lruCache) serialize(w io.Writer) error {

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -25,7 +25,6 @@ type lruCache struct {
 	items      map[uint64]*cacheItem
 	head, tail *cacheItem
 	seed       maphash.Seed
-	count      int
 }
 
 // cacheItem holds a cached answer inline rather than pointing at a
@@ -188,7 +187,6 @@ func (c *lruCache) insert(item *cacheItem) {
 	c.head.next.prev = item
 	c.head.next = item
 
-	c.count++
 	c.resize()
 }
 
@@ -197,7 +195,6 @@ func (c *lruCache) unlink(item *cacheItem) {
 	item.prev.next = item.next
 	item.next.prev = item.prev
 	delete(c.items, c.hash(item.key))
-	c.count--
 }
 
 func (c *lruCache) hash(key lruKey) uint64 {
@@ -246,7 +243,7 @@ func (c *lruCache) resize() {
 	if c.maxItems <= 0 { // no size limit
 		return
 	}
-	for c.count > c.maxItems {
+	for len(c.items) > c.maxItems {
 		c.unlink(c.tail.prev)
 	}
 }
@@ -261,7 +258,6 @@ func (c *lruCache) reset() {
 	c.head = head
 	c.tail = tail
 	c.items = make(map[uint64]*cacheItem)
-	c.count = 0
 }
 
 // Iterate over the cached items and call the provided function. If it
@@ -278,7 +274,7 @@ func (c *lruCache) deleteFunc(f func(*cacheItem) bool) {
 }
 
 func (c *lruCache) size() int {
-	return c.count
+	return len(c.items)
 }
 
 func (c *lruCache) serialize(w io.Writer) error {

--- a/lru-cache_test.go
+++ b/lru-cache_test.go
@@ -46,13 +46,12 @@ func TestLRUAddGet(t *testing.T) {
 
 	// Check it's the right items in the cache
 	for _, item := range items[:5] {
-		answer := c.get(item.query)
-		require.Nil(t, answer)
+		require.Nil(t, c.get(item.query))
 	}
 	for _, item := range items[5:] {
-		answer := c.get(item.query)
-		require.NotNil(t, answer)
-		require.Equal(t, item.answer, answer)
+		cached := c.get(item.query)
+		require.NotNil(t, cached)
+		require.Equal(t, item.answer.Msg, cached.msg)
 	}
 
 	// Delete one of the items directly
@@ -60,8 +59,8 @@ func TestLRUAddGet(t *testing.T) {
 	require.Equal(t, 4, c.size())
 
 	// Use an iterator to delete two more
-	c.deleteFunc(func(a *cacheAnswer) bool {
-		question := a.Msg.Question[0]
+	c.deleteFunc(func(item *cacheItem) bool {
+		question := item.msg.Question[0]
 		return question.Name == "test8.com." || question.Name == "test9.com."
 	})
 	require.Equal(t, 2, c.size())
@@ -100,13 +99,13 @@ func TestLRUKeyCD(t *testing.T) {
 		"CD=0 query must not be served the cached CD=1 response")
 
 	// The original CD=1 query still hits its own entry.
-	require.Equal(t, cdAnswer, c.get(queryCD("cd.example.com.", true)))
+	require.Equal(t, cdAnswer.Msg, c.get(queryCD("cd.example.com.", true)).msg)
 
 	// Storing a CD=0 answer is kept separate from the CD=1 one.
 	plainAnswer := answerFor("cd.example.com.")
 	c.add(queryCD("cd.example.com.", false), plainAnswer)
-	require.Equal(t, plainAnswer, c.get(queryCD("cd.example.com.", false)))
-	require.Equal(t, cdAnswer, c.get(queryCD("cd.example.com.", true)))
+	require.Equal(t, plainAnswer.Msg, c.get(queryCD("cd.example.com.", false)).msg)
+	require.Equal(t, cdAnswer.Msg, c.get(queryCD("cd.example.com.", true)).msg)
 	require.Equal(t, 2, c.size())
 }
 


### PR DESCRIPTION
First step towards making RouteDNS lighter on constrained hardware like OpenWrt routers. This one targets the memory cache's bookkeeping, which turned out to cost more per entry than the answers themselves: an entry holding an empty `cacheAnswer` measures 281 B, against 87 B for a typical single-A answer in wire format.

Three changes to how the LRU holds an entry:

**Index by key hash rather than by key.** `map[lruKey]*cacheItem` stored the 48-byte key in the map and again in the item. The index is now `map[uint64]*cacheItem` keyed by `maphash.Comparable` of the key. Lookups still compare the full key, so a hash collision can only ever produce a cache miss, never a wrong answer. Two distinct keys colliding on 64 bits is rare enough that the loser is dropped rather than chained, which keeps the eviction path to a single map delete. The seed is random per instance so a client cannot craft names that collide on purpose.

**Merge `cacheAnswer` into the LRU item.** The item pointed at a separately allocated `cacheAnswer`, so every entry cost two allocations and an extra pointer for the GC to follow. `cacheAnswer` stays as the value passed across the `CacheBackend` interface, but the LRU now copies its fields in and does not retain it.

**Timestamps as unix nanoseconds.** Each `time.Time` carried a location pointer the GC had to trace for every cached entry, for no more resolution than an int64 already gives. A record stored ahead of the current time, which a backwards clock step or a cache file from another machine can produce, now counts as brand new rather than wrapping the age calculation.

`CacheBackend`, `CacheOptions` and the Redis backend are untouched.

## Numbers

Measured on an i7-7600U over 20 000 mixed answers (50% single-A, 20% multi-A, 20% CNAME chain, 10% NXDOMAIN with SOA), benchstat against master:

| | master | this branch | |
|---|---|---|---|
| heap per entry | 734.5 B | 611.2 B | -16.8% |
| GC cycle, 20k entries live | 9.10 ms | 7.00 ms | -23% (p=0.000, n=12) |
| lookup | 393 ns/op | 351 ns/op | -10.9% (p=0.000, n=15) |
| store | 569 ns/op | 432 ns/op | -24% (p=0.000, n=10) |

The GC result is the one that matters most on a single-core router: it is per-cycle cost paid regardless of query rate. It comes from removing one traced object per entry plus the two location pointers, and from the index no longer holding two string pointers in every map slot.

The store benchmark shows the `cacheAnswer` allocation disappearing entirely. That is partly an artifact of the benchmark calling the LRU directly, where escape analysis can now stack-allocate it. Through the `CacheBackend` interface it still reaches the heap, but it is short-lived garbage instead of being retained for the lifetime of the entry.

## Cache file format

Unchanged, and it builds on the `cacheItemJSON`/`cacheAnswerJSON` pair from #607 rather than reworking it. The item's nanosecond timestamps convert back to `time.Time` on the way out, so `TestLRUSerializeFormatStable` still pins the same bytes.

One deliberate difference: records are written with their timestamps in UTC, so the file no longer depends on the timezone of the host that wrote it. An older file carrying a local offset parses to the same instant, and older builds read the UTC form fine, so it is compatible in both directions.

`TestLRUDeserializeLegacyFormat` needed a two-line adjustment for the new item layout (`c.find(key)` and the unexported fields). The other tests from #607 pass untouched.

## Not in this change

Storing answers in wire format is the larger remaining win, roughly halving what is left, but it trades about 0.4 to 1.7 us of CPU per cache hit and belongs behind a backend option rather than on by default. Worth measuring on real target hardware first, on top of this.