### PR TITLE
Store cache entries as packed bytes rather than dns.Msg trees

### DIFF
--- a/cache-blob.go
+++ b/cache-blob.go
@@ -20,16 +20,17 @@ import (
 // Layout. Offsets are fixed so the metadata can be read without decoding the
 // key or the message:
 //
-//	0      meta flags (prefetch-eligible)
-//	1..8   timestamp, unix nanoseconds
-//	9..16  expiry, unix nanoseconds
-//	17     key flags (DO, CD)          <- key region starts
-//	18..19 qtype
-//	20..21 qclass
-//	22     ECS source prefix length
-//	23..24 length of the ECS address
-//	25..26 length of the question name
-//	27..   ECS address, then question name
+//	0      version
+//	1      meta flags (prefetch-eligible)
+//	2..9   timestamp, unix nanoseconds
+//	10..17 expiry, unix nanoseconds
+//	18     key flags (DO, CD)          <- key region starts
+//	19..20 qtype
+//	21..22 qclass
+//	23     ECS source prefix length
+//	24..25 length of the ECS address
+//	26..27 length of the question name
+//	28..   ECS address, then question name
 //	       <- key region ends, packed message follows
 //
 // Everything the key is built from sits in one span, which keyRegion returns.
@@ -37,17 +38,25 @@ import (
 // blob be matched, or hashed, without decoding it back into an lruKey.
 type cacheBlob []byte
 
+// blobVersion is the version of the layout above. It is reserved rather than
+// used: every blob is freshly allocated and so carries 0, and nothing reads it
+// back. It is here so that a later change to the layout has somewhere to say
+// so, and can tell its own records from these. A writer that bumps it has to
+// start setting it explicitly.
+const blobVersion = 0
+
 const (
-	blobOffMetaFlags = 0
-	blobOffTimestamp = 1
-	blobOffExpiry    = 9
-	blobOffKeyFlags  = 17 // first byte of the key region
-	blobOffQtype     = 18
-	blobOffQclass    = 20
-	blobOffECSMask   = 22
-	blobOffNetLen    = 23
-	blobOffNameLen   = 25
-	blobHdrLen       = 27
+	blobOffVersion   = 0
+	blobOffMetaFlags = 1
+	blobOffTimestamp = 2
+	blobOffExpiry    = 10
+	blobOffKeyFlags  = 18 // first byte of the key region
+	blobOffQtype     = 19
+	blobOffQclass    = 21
+	blobOffECSMask   = 23
+	blobOffNetLen    = 24
+	blobOffNameLen   = 26
+	blobHdrLen       = 28
 )
 
 const (
@@ -126,6 +135,10 @@ func (b cacheBlob) timestamp() int64 {
 
 func (b cacheBlob) expiry() int64 {
 	return int64(binary.BigEndian.Uint64(b[blobOffExpiry:]))
+}
+
+func (b cacheBlob) version() byte {
+	return b[blobOffVersion]
 }
 
 func (b cacheBlob) prefetchEligible() bool {

--- a/cache-blob.go
+++ b/cache-blob.go
@@ -1,0 +1,190 @@
+package rdns
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/miekg/dns"
+)
+
+// cacheBlob is one cache entry in stored form: the key, its metadata and the
+// message in wire format, in a single allocation. It holds no pointers, so the
+// collector skips its contents where an unpacked dns.Msg is a tree of about a
+// dozen objects it has to trace on every cycle.
+//
+// A blob is never modified once built. Replacing an entry allocates a new one,
+// so a reader that took it under a lock can decode it after releasing the lock.
+//
+// Layout. Offsets are fixed so the metadata can be read without decoding the
+// key or the message:
+//
+//	0      version
+//	1      meta flags (prefetch-eligible)
+//	2..9   timestamp, unix nanoseconds
+//	10..17 expiry, unix nanoseconds
+//	18     key flags (DO, CD)          <- key region starts
+//	19..20 qtype
+//	21..22 qclass
+//	23     ECS source prefix length
+//	24..25 length of the ECS address
+//	26..27 length of the question name
+//	28..   ECS address, then question name
+//	       <- key region ends, packed message follows
+//
+// The key fields are contiguous so a lookup can compare them as one span, and
+// so an on-disk format can hash the same bytes.
+type cacheBlob []byte
+
+const (
+	blobVersion = 1
+
+	blobOffMetaFlags = 1
+	blobOffTimestamp = 2
+	blobOffExpiry    = 10
+	blobOffKeyFlags  = 18
+	blobOffQtype     = 19
+	blobOffQclass    = 21
+	blobOffECSMask   = 23
+	blobOffNetLen    = 24
+	blobOffNameLen   = 26
+	blobHdrLen       = 28
+)
+
+const (
+	blobMetaPrefetchEligible = 1 << 0
+
+	blobKeyDo = 1 << 0
+	blobKeyCD = 1 << 1
+)
+
+// newCacheBlob packs an answer's message into a pooled buffer and builds the
+// stored form from it. The message is not retained.
+func newCacheBlob(key lruKey, a *cacheAnswer) (cacheBlob, error) {
+	if a.Msg == nil {
+		return nil, errors.New("cache item has no message")
+	}
+	bufPtr := packBufPool.Get().(*[]byte)
+	wire, err := a.Msg.PackBuffer((*bufPtr)[:cap(*bufPtr)])
+	if err != nil {
+		putPackBuf(bufPtr)
+		return nil, err
+	}
+	// If packing outgrew the pooled buffer, keep the larger one so the pool
+	// adapts to the workload.
+	if cap(wire) > cap(*bufPtr) {
+		*bufPtr = wire
+	}
+	blob, err := newCacheBlobFromWire(key, unixNano(a.Timestamp), unixNano(a.Expiry), a.PrefetchEligible, wire)
+	putPackBuf(bufPtr)
+	return blob, err
+}
+
+// newCacheBlobFromWire builds the stored form in one exact-size allocation
+// from a message that is already packed.
+func newCacheBlobFromWire(key lruKey, timestamp, expiry int64, prefetchEligible bool, wire []byte) (cacheBlob, error) {
+	// The protocol caps a name at 255 octets on the wire, but this is the
+	// presentation form, where an unprintable octet escapes to \DDD and a
+	// legal name can run four times that. Both lengths get a uint16, which no
+	// name can outgrow; the checks are here so the encoding stays total.
+	if len(key.Question.Name) > math.MaxUint16 {
+		return nil, fmt.Errorf("question name too long to cache: %d bytes", len(key.Question.Name))
+	}
+	if len(key.Net) > math.MaxUint16 {
+		return nil, fmt.Errorf("ECS address too long to cache: %d bytes", len(key.Net))
+	}
+
+	blob := make(cacheBlob, blobHdrLen+len(key.Net)+len(key.Question.Name)+len(wire))
+	blob[0] = blobVersion
+	if prefetchEligible {
+		blob[blobOffMetaFlags] |= blobMetaPrefetchEligible
+	}
+	binary.BigEndian.PutUint64(blob[blobOffTimestamp:], uint64(timestamp))
+	binary.BigEndian.PutUint64(blob[blobOffExpiry:], uint64(expiry))
+	blob[blobOffKeyFlags] = keyFlags(key)
+	binary.BigEndian.PutUint16(blob[blobOffQtype:], key.Question.Qtype)
+	binary.BigEndian.PutUint16(blob[blobOffQclass:], key.Question.Qclass)
+	blob[blobOffECSMask] = key.ECSMask
+	binary.BigEndian.PutUint16(blob[blobOffNetLen:], uint16(len(key.Net)))
+	binary.BigEndian.PutUint16(blob[blobOffNameLen:], uint16(len(key.Question.Name)))
+
+	n := blobHdrLen
+	n += copy(blob[n:], key.Net)
+	n += copy(blob[n:], key.Question.Name)
+	copy(blob[n:], wire)
+	return blob, nil
+}
+
+func keyFlags(key lruKey) byte {
+	var flags byte
+	if key.Do {
+		flags |= blobKeyDo
+	}
+	if key.CD {
+		flags |= blobKeyCD
+	}
+	return flags
+}
+
+func (b cacheBlob) timestamp() int64 {
+	return int64(binary.BigEndian.Uint64(b[blobOffTimestamp:]))
+}
+
+func (b cacheBlob) expiry() int64 {
+	return int64(binary.BigEndian.Uint64(b[blobOffExpiry:]))
+}
+
+func (b cacheBlob) prefetchEligible() bool {
+	return b[blobOffMetaFlags]&blobMetaPrefetchEligible != 0
+}
+
+func (b cacheBlob) netLen() int {
+	return int(binary.BigEndian.Uint16(b[blobOffNetLen:]))
+}
+
+func (b cacheBlob) nameLen() int {
+	return int(binary.BigEndian.Uint16(b[blobOffNameLen:]))
+}
+
+// message returns the packed message, which aliases the blob.
+func (b cacheBlob) message() []byte {
+	return b[blobHdrLen+b.netLen()+b.nameLen():]
+}
+
+// matchesKey reports whether the blob was stored under key. Comparing a byte
+// slice against a string this way doesn't allocate.
+func (b cacheBlob) matchesKey(key lruKey) bool {
+	if len(b) < blobHdrLen {
+		return false
+	}
+	netLen, nameLen := b.netLen(), b.nameLen()
+	if len(b) < blobHdrLen+netLen+nameLen ||
+		b[blobOffKeyFlags] != keyFlags(key) ||
+		b[blobOffECSMask] != key.ECSMask ||
+		netLen != len(key.Net) ||
+		nameLen != len(key.Question.Name) ||
+		binary.BigEndian.Uint16(b[blobOffQtype:]) != key.Question.Qtype ||
+		binary.BigEndian.Uint16(b[blobOffQclass:]) != key.Question.Qclass {
+		return false
+	}
+	return string(b[blobHdrLen:blobHdrLen+netLen]) == key.Net &&
+		string(b[blobHdrLen+netLen:blobHdrLen+netLen+nameLen]) == key.Question.Name
+}
+
+// key rebuilds the key the blob was stored under. Used when writing the cache
+// file, not on the query path.
+func (b cacheBlob) key() lruKey {
+	netLen, nameLen := b.netLen(), b.nameLen()
+	return lruKey{
+		Question: dns.Question{
+			Name:   string(b[blobHdrLen+netLen : blobHdrLen+netLen+nameLen]),
+			Qtype:  binary.BigEndian.Uint16(b[blobOffQtype:]),
+			Qclass: binary.BigEndian.Uint16(b[blobOffQclass:]),
+		},
+		Net:     string(b[blobHdrLen : blobHdrLen+netLen]),
+		Do:      b[blobOffKeyFlags]&blobKeyDo != 0,
+		CD:      b[blobOffKeyFlags]&blobKeyCD != 0,
+		ECSMask: b[blobOffECSMask],
+	}
+}

--- a/cache-blob.go
+++ b/cache-blob.go
@@ -43,6 +43,10 @@ type cacheBlob []byte
 // back. It is here so that a later change to the layout has somewhere to say
 // so, and can tell its own records from these. A writer that bumps it has to
 // start setting it explicitly.
+//
+// Note that 1 is already taken: it is binaryFormatVersion, the Redis record
+// format, which is a different layout in the same first byte. A stored form
+// meant to be read by either backend has to start at 2.
 const blobVersion = 0
 
 const (

--- a/cache-blob.go
+++ b/cache-blob.go
@@ -20,36 +20,34 @@ import (
 // Layout. Offsets are fixed so the metadata can be read without decoding the
 // key or the message:
 //
-//	0      version
-//	1      meta flags (prefetch-eligible)
-//	2..9   timestamp, unix nanoseconds
-//	10..17 expiry, unix nanoseconds
-//	18     key flags (DO, CD)          <- key region starts
-//	19..20 qtype
-//	21..22 qclass
-//	23     ECS source prefix length
-//	24..25 length of the ECS address
-//	26..27 length of the question name
-//	28..   ECS address, then question name
+//	0      meta flags (prefetch-eligible)
+//	1..8   timestamp, unix nanoseconds
+//	9..16  expiry, unix nanoseconds
+//	17     key flags (DO, CD)          <- key region starts
+//	18..19 qtype
+//	20..21 qclass
+//	22     ECS source prefix length
+//	23..24 length of the ECS address
+//	25..26 length of the question name
+//	27..   ECS address, then question name
 //	       <- key region ends, packed message follows
 //
-// The key fields are contiguous so a lookup can compare them as one span, and
-// so an on-disk format can hash the same bytes.
+// Everything the key is built from sits in one span, which keyRegion returns.
+// Nothing on the query path needs that today, but it is what lets a stored
+// blob be matched, or hashed, without decoding it back into an lruKey.
 type cacheBlob []byte
 
 const (
-	blobVersion = 1
-
-	blobOffMetaFlags = 1
-	blobOffTimestamp = 2
-	blobOffExpiry    = 10
-	blobOffKeyFlags  = 18
-	blobOffQtype     = 19
-	blobOffQclass    = 21
-	blobOffECSMask   = 23
-	blobOffNetLen    = 24
-	blobOffNameLen   = 26
-	blobHdrLen       = 28
+	blobOffMetaFlags = 0
+	blobOffTimestamp = 1
+	blobOffExpiry    = 9
+	blobOffKeyFlags  = 17 // first byte of the key region
+	blobOffQtype     = 18
+	blobOffQclass    = 20
+	blobOffECSMask   = 22
+	blobOffNetLen    = 23
+	blobOffNameLen   = 25
+	blobHdrLen       = 27
 )
 
 const (
@@ -66,24 +64,20 @@ func newCacheBlob(key lruKey, a *cacheAnswer) (cacheBlob, error) {
 		return nil, errors.New("cache item has no message")
 	}
 	bufPtr := packBufPool.Get().(*[]byte)
+	defer putPackBuf(bufPtr)
+
 	wire, err := a.Msg.PackBuffer((*bufPtr)[:cap(*bufPtr)])
 	if err != nil {
-		putPackBuf(bufPtr)
 		return nil, err
 	}
-	// If packing outgrew the pooled buffer, keep the larger one so the pool
-	// adapts to the workload.
-	if cap(wire) > cap(*bufPtr) {
-		*bufPtr = wire
-	}
-	blob, err := newCacheBlobFromWire(key, unixNano(a.Timestamp), unixNano(a.Expiry), a.PrefetchEligible, wire)
-	putPackBuf(bufPtr)
-	return blob, err
+	adoptPackBuf(bufPtr, wire)
+	return newCacheBlobFromWire(key, a, wire)
 }
 
-// newCacheBlobFromWire builds the stored form in one exact-size allocation
-// from a message that is already packed.
-func newCacheBlobFromWire(key lruKey, timestamp, expiry int64, prefetchEligible bool, wire []byte) (cacheBlob, error) {
+// newCacheBlobFromWire builds the stored form in one exact-size allocation.
+// meta supplies the timestamps and flags; its Msg is ignored in favour of
+// wire, which is the message already in wire format.
+func newCacheBlobFromWire(key lruKey, meta *cacheAnswer, wire []byte) (cacheBlob, error) {
 	// The protocol caps a name at 255 octets on the wire, but this is the
 	// presentation form, where an unprintable octet escapes to \DDD and a
 	// legal name can run four times that. Both lengths get a uint16, which no
@@ -96,12 +90,11 @@ func newCacheBlobFromWire(key lruKey, timestamp, expiry int64, prefetchEligible 
 	}
 
 	blob := make(cacheBlob, blobHdrLen+len(key.Net)+len(key.Question.Name)+len(wire))
-	blob[0] = blobVersion
-	if prefetchEligible {
+	if meta.PrefetchEligible {
 		blob[blobOffMetaFlags] |= blobMetaPrefetchEligible
 	}
-	binary.BigEndian.PutUint64(blob[blobOffTimestamp:], uint64(timestamp))
-	binary.BigEndian.PutUint64(blob[blobOffExpiry:], uint64(expiry))
+	binary.BigEndian.PutUint64(blob[blobOffTimestamp:], uint64(unixNano(meta.Timestamp)))
+	binary.BigEndian.PutUint64(blob[blobOffExpiry:], uint64(unixNano(meta.Expiry)))
 	blob[blobOffKeyFlags] = keyFlags(key)
 	binary.BigEndian.PutUint16(blob[blobOffQtype:], key.Question.Qtype)
 	binary.BigEndian.PutUint16(blob[blobOffQclass:], key.Question.Qclass)
@@ -147,13 +140,21 @@ func (b cacheBlob) nameLen() int {
 	return int(binary.BigEndian.Uint16(b[blobOffNameLen:]))
 }
 
+// keyRegion returns the span that encodes the key, which is a pure function of
+// the key it was stored under and independent of the metadata and message.
+func (b cacheBlob) keyRegion() []byte {
+	return b[blobOffKeyFlags : blobHdrLen+b.netLen()+b.nameLen()]
+}
+
 // message returns the packed message, which aliases the blob.
 func (b cacheBlob) message() []byte {
 	return b[blobHdrLen+b.netLen()+b.nameLen():]
 }
 
-// matchesKey reports whether the blob was stored under key. Comparing a byte
-// slice against a string this way doesn't allocate.
+// matchesKey reports whether the blob was stored under key. Every field of
+// lruKey has to be checked here; TestBlobKeyComparisonCoversEveryField fails if
+// one is dropped, since missing one serves a response stored under a different
+// question. Comparing a byte slice against a string doesn't allocate.
 func (b cacheBlob) matchesKey(key lruKey) bool {
 	if len(b) < blobHdrLen {
 		return false

--- a/cache-memory.go
+++ b/cache-memory.go
@@ -60,7 +60,7 @@ func (b *memoryBackend) Store(query *dns.Msg, item *cacheAnswer) {
 	// Encode before locking. Packing the message is the expensive half of a
 	// store and it doesn't need the cache, so queries aren't held up for it.
 	key := lruKeyFromQuery(query)
-	blob, err := encodeCacheAnswerBlob(key, item)
+	blob, err := newCacheBlob(key, item)
 	if err != nil {
 		Log.Warn("failed to encode cache record", "error", err)
 		return
@@ -73,7 +73,7 @@ func (b *memoryBackend) Store(query *dns.Msg, item *cacheAnswer) {
 func (b *memoryBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 	// A stored blob is never modified, so only the reference is taken under
 	// the lock and everything below runs outside it.
-	var blob []byte
+	var blob cacheBlob
 	b.mu.Lock()
 	if item := b.lru.get(q); item != nil {
 		blob = item.blob
@@ -87,7 +87,7 @@ func (b *memoryBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 
 	// Check if item has expired from the cache
 	now := time.Now().UnixNano()
-	if now > blobExpiry(blob) {
+	if now > blob.expiry() {
 		b.Evict(q)
 		return nil, false, false
 	}
@@ -95,13 +95,13 @@ func (b *memoryBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 	// Unpacking yields a message owned by this caller, so later elements in
 	// the chain can modify it without affecting the cached original.
 	answer := new(dns.Msg)
-	if err := answer.Unpack(blobMessage(blob)); err != nil {
+	if err := answer.Unpack(blob.message()); err != nil {
 		Log.Warn("failed to decode cache record", "error", err)
 		b.Evict(q)
 		return nil, false, false
 	}
-	timestamp := blobTimestamp(blob)
-	prefetchEligible := blobPrefetchEligible(blob)
+	timestamp := blob.timestamp()
+	prefetchEligible := blob.prefetchEligible()
 
 	answer.Id = q.Id
 	answer.Question = q.Question // restore the case used in the question
@@ -161,7 +161,7 @@ func (b *memoryBackend) startGC(period time.Duration) {
 		var total, removed int
 		b.mu.Lock()
 		b.lru.deleteFunc(func(item *cacheItem) bool {
-			if now > blobExpiry(item.blob) {
+			if now > item.blob.expiry() {
 				removed++
 				return true
 			}

--- a/cache-memory.go
+++ b/cache-memory.go
@@ -57,38 +57,51 @@ func NewMemoryBackend(opt MemoryBackendOptions) *memoryBackend {
 }
 
 func (b *memoryBackend) Store(query *dns.Msg, item *cacheAnswer) {
+	// Encode before locking. Packing the message is the expensive half of a
+	// store and it doesn't need the cache, so queries aren't held up for it.
+	key := lruKeyFromQuery(query)
+	blob, err := encodeCacheAnswerBlob(key, item)
+	if err != nil {
+		Log.Warn("failed to encode cache record", "error", err)
+		return
+	}
 	b.mu.Lock()
-	b.lru.add(query, item)
+	b.lru.addKey(key, blob)
 	b.mu.Unlock()
 }
 
 func (b *memoryBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
-	var answer *dns.Msg
-	var timestamp int64
-	var prefetchEligible bool
-	var expiry int64
+	// A stored blob is never modified, so only the reference is taken under
+	// the lock and everything below runs outside it.
+	var blob []byte
 	b.mu.Lock()
 	if item := b.lru.get(q); item != nil {
-		// Copy the message so later elements can modify the response
-		// without affecting the cached original.
-		answer = item.msg.Copy()
-		timestamp = item.timestamp
-		prefetchEligible = item.prefetchEligible
-		expiry = item.expiry
+		blob = item.blob
 	}
 	b.mu.Unlock()
 
 	// Return a cache-miss if there's no answer record in the map
-	if answer == nil {
+	if blob == nil {
 		return nil, false, false
 	}
 
 	// Check if item has expired from the cache
 	now := time.Now().UnixNano()
-	if now > expiry {
+	if now > blobExpiry(blob) {
 		b.Evict(q)
 		return nil, false, false
 	}
+
+	// Unpacking yields a message owned by this caller, so later elements in
+	// the chain can modify it without affecting the cached original.
+	answer := new(dns.Msg)
+	if err := answer.Unpack(blobMessage(blob)); err != nil {
+		Log.Warn("failed to decode cache record", "error", err)
+		b.Evict(q)
+		return nil, false, false
+	}
+	timestamp := blobTimestamp(blob)
+	prefetchEligible := blobPrefetchEligible(blob)
 
 	answer.Id = q.Id
 	answer.Question = q.Question // restore the case used in the question
@@ -148,7 +161,7 @@ func (b *memoryBackend) startGC(period time.Duration) {
 		var total, removed int
 		b.mu.Lock()
 		b.lru.deleteFunc(func(item *cacheItem) bool {
-			if now > item.expiry {
+			if now > blobExpiry(item.blob) {
 				removed++
 				return true
 			}

--- a/cache-redis.go
+++ b/cache-redis.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/miekg/dns"
@@ -34,19 +33,6 @@ type RedisBackendOptions struct {
 }
 
 var _ CacheBackend = (*redisBackend)(nil)
-
-// Buffer pool for encoding cache records to minimize allocations.
-var packBufPool = sync.Pool{
-	New: func() any {
-		b := make([]byte, 0, 2048)
-		return &b
-	},
-}
-
-func putPackBuf(bufPtr *[]byte) {
-	*bufPtr = (*bufPtr)[:0]
-	packBufPool.Put(bufPtr)
-}
 
 const (
 	binaryFormatVersion = 1
@@ -162,11 +148,7 @@ func (b *redisBackend) Store(query *dns.Msg, item *cacheAnswer) {
 		Log.Error("failed to encode cache record", "error", err)
 		return
 	}
-	// If encoding outgrew the pooled buffer, keep the larger one so the
-	// pool adapts to the workload
-	if cap(value) > cap(*bufPtr) {
-		*bufPtr = value
-	}
+	adoptPackBuf(bufPtr, value)
 
 	if b.opt.SyncSet {
 		b.set(key, value, ttl)

--- a/cache.go
+++ b/cache.go
@@ -81,6 +81,11 @@ type CacheBackend interface {
 	// Store a response. The query and the message belong to the caller and may
 	// be modified once Store returns, so a backend has to encode or copy what
 	// it needs before then rather than holding on to them.
+	//
+	// Packing a message is not read-only: dns.Msg.Pack writes the extended
+	// rcode into an OPT record in Extra, if there is one. A backend encodes
+	// during Store, so the caller must not hand over a message whose records
+	// another goroutine is reading at the same time.
 	Store(query *dns.Msg, item *cacheAnswer)
 
 	// Lookup a cached response

--- a/cache.go
+++ b/cache.go
@@ -77,6 +77,28 @@ type CacheOptions struct {
 	Backend CacheBackend
 }
 
+// Buffer pool for encoding cache records to minimize allocations. Shared by
+// the backends, which all encode a message into wire format to store it.
+var packBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 2048)
+		return &b
+	},
+}
+
+func putPackBuf(bufPtr *[]byte) {
+	*bufPtr = (*bufPtr)[:0]
+	packBufPool.Put(bufPtr)
+}
+
+// adoptPackBuf keeps a buffer that outgrew the pooled one, so the pool adapts
+// to the workload rather than reallocating for every large answer.
+func adoptPackBuf(bufPtr *[]byte, encoded []byte) {
+	if cap(encoded) > cap(*bufPtr) {
+		*bufPtr = encoded
+	}
+}
+
 type CacheBackend interface {
 	// Store a response. The query and the message belong to the caller and may
 	// be modified once Store returns, so a backend has to encode or copy what

--- a/cache.go
+++ b/cache.go
@@ -78,6 +78,9 @@ type CacheOptions struct {
 }
 
 type CacheBackend interface {
+	// Store a response. The query and the message belong to the caller and may
+	// be modified once Store returns, so a backend has to encode or copy what
+	// it needs before then rather than holding on to them.
 	Store(query *dns.Msg, item *cacheAnswer)
 
 	// Lookup a cached response
@@ -205,9 +208,10 @@ func (r *Cache) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		return a, nil
 	}
 
-	// Put the upstream response into the cache and return it. Need to store
-	// a copy since other elements might modify the response, like the replacer.
-	r.storeInCache(q, a.Copy())
+	// Put the upstream response into the cache and return it. Backends encode
+	// the message during Store and don't retain it, so the copy other elements
+	// like the replacer would otherwise need isn't made here.
+	r.storeInCache(q, a)
 	return a, nil
 }
 

--- a/lru-cache-blob_test.go
+++ b/lru-cache-blob_test.go
@@ -2,6 +2,7 @@ package rdns
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"strings"
 	"sync"
@@ -112,11 +113,46 @@ func TestBlobRoundTripWithoutECS(t *testing.T) {
 	require.True(t, blobMatchesKey(blob, key))
 }
 
-// Both lengths live in one byte each, so a name that can't be represented has
-// to be refused rather than silently truncated into a key that collides.
+// A question name arrives in presentation form, where every unprintable octet
+// escapes to \DDD. A single 63-octet binary label is perfectly legal on the
+// wire and lands well past 255 characters, so the length fields have to hold
+// more than a byte. Getting this wrong doesn't corrupt anything: it makes the
+// entry uncacheable and logs a warning on every query for it, which any client
+// can trigger at will.
+func TestBlobLongPresentationName(t *testing.T) {
+	name := strings.Repeat(`\001`, 63) + ".com."
+	require.Greater(t, len(name), 255, "the presentation form must exceed a uint8")
+
+	q := new(dns.Msg)
+	q.SetQuestion(name, dns.TypeA)
+	a := new(dns.Msg)
+	a.SetReply(q)
+	rr, err := dns.NewRR(name + " 300 IN A 192.0.2.1")
+	require.NoError(t, err)
+	a.Answer = []dns.RR{rr}
+
+	// It has to survive the wire, which is the whole point: the name is legal.
+	wire, err := a.Pack()
+	require.NoError(t, err)
+	require.Less(t, len(wire), 255, "the wire form is well within the protocol limit")
+
+	b := NewMemoryBackend(MemoryBackendOptions{GCPeriod: time.Hour})
+	defer b.Close()
+	now := time.Now()
+	b.Store(q, &cacheAnswer{Msg: a, Timestamp: now, Expiry: now.Add(time.Hour)})
+
+	got, _, ok := b.Lookup(q)
+	require.True(t, ok, "a name this long must still cache")
+	require.Equal(t, name, got.Question[0].Name)
+	require.Len(t, got.Answer, 1)
+}
+
+// The length fields still have a ceiling, so the encoding stays total rather
+// than silently truncating into a key that collides with another name.
 func TestBlobRejectsOversizedName(t *testing.T) {
-	long := strings.Repeat("a", 250) + "." + strings.Repeat("b", 10) + "."
-	key := lruKey{Question: dns.Question{Name: long, Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+	key := lruKey{
+		Question: dns.Question{Name: strings.Repeat("a", math.MaxUint16+1), Qtype: dns.TypeA, Qclass: dns.ClassINET},
+	}
 	msg := new(dns.Msg)
 	msg.SetQuestion("short.example.com.", dns.TypeA)
 

--- a/lru-cache-blob_test.go
+++ b/lru-cache-blob_test.go
@@ -274,3 +274,13 @@ func TestBlobKeyRegionDependsOnlyOnTheKey(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, first.keyRegion(), third.keyRegion())
 }
+
+// The version byte is reserved, not yet used: blobs are freshly allocated so
+// it reads as 0 without being written. Pinning it means a later layout change
+// bumps it deliberately, and notices it has to start setting it.
+func TestBlobVersionIsReserved(t *testing.T) {
+	blob, err := newCacheBlob(blobTestKey(), &cacheAnswer{Msg: blobTestAnswer(t)})
+	require.NoError(t, err)
+	require.Equal(t, byte(blobVersion), blob.version())
+	require.Zero(t, blobVersion, "still reserved; bumping it means writing it too")
+}

--- a/lru-cache-blob_test.go
+++ b/lru-cache-blob_test.go
@@ -1,0 +1,205 @@
+package rdns
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func blobTestKey() lruKey {
+	return lruKey{
+		Question: dns.Question{Name: "a.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+		Net:      "192.0.2.0",
+		Do:       true,
+		CD:       true,
+		ECSMask:  24,
+	}
+}
+
+func blobTestAnswer(t *testing.T) *dns.Msg {
+	t.Helper()
+	msg := new(dns.Msg)
+	msg.SetQuestion("a.example.com.", dns.TypeA)
+	msg.Id = 4242
+	rr, err := dns.NewRR("a.example.com. 300 IN A 192.0.2.7")
+	require.NoError(t, err)
+	msg.Answer = []dns.RR{rr}
+	return msg
+}
+
+// Every field of the key has to take part in the comparison. Leaving one out
+// would serve a response stored under a different question, and the DO and CD
+// bits are the easiest to miss because they share a byte.
+func TestBlobKeyComparisonCoversEveryField(t *testing.T) {
+	key := blobTestKey()
+	blob, err := encodeCacheAnswerBlob(key, &cacheAnswer{Msg: blobTestAnswer(t)})
+	require.NoError(t, err)
+	require.True(t, blobMatchesKey(blob, key), "the key it was stored under must match")
+
+	differs := map[string]func(*lruKey){
+		// same length, different content, so this can't pass on a length check
+		"name":     func(k *lruKey) { k.Question.Name = "z.example.com." },
+		"name len": func(k *lruKey) { k.Question.Name = "aa.example.com." },
+		"qtype":    func(k *lruKey) { k.Question.Qtype = dns.TypeAAAA },
+		"qclass":   func(k *lruKey) { k.Question.Qclass = dns.ClassCHAOS },
+		"net":      func(k *lruKey) { k.Net = "198.51.100.0" },
+		"net len":  func(k *lruKey) { k.Net = "10.0.0.0" },
+		"no net":   func(k *lruKey) { k.Net = "" },
+		"do":       func(k *lruKey) { k.Do = false },
+		"cd":       func(k *lruKey) { k.CD = false },
+		"ecs mask": func(k *lruKey) { k.ECSMask = 16 },
+	}
+	for name, mutate := range differs {
+		t.Run(name, func(t *testing.T) {
+			other := blobTestKey()
+			mutate(&other)
+			require.False(t, blobMatchesKey(blob, other),
+				"a key differing only in %s must not match", name)
+		})
+	}
+}
+
+// The prefetch-eligible flag is metadata, not part of the key, so it must not
+// affect whether an entry is found.
+func TestBlobKeyIgnoresMetadata(t *testing.T) {
+	key := blobTestKey()
+	for _, eligible := range []bool{false, true} {
+		blob, err := encodeCacheAnswerBlob(key, &cacheAnswer{Msg: blobTestAnswer(t), PrefetchEligible: eligible})
+		require.NoError(t, err)
+		require.True(t, blobMatchesKey(blob, key))
+		require.Equal(t, eligible, blobPrefetchEligible(blob))
+	}
+}
+
+func TestBlobRoundTrip(t *testing.T) {
+	key := blobTestKey()
+	msg := blobTestAnswer(t)
+	ts := time.Date(2026, 8, 15, 9, 30, 0, 123456789, time.UTC)
+
+	blob, err := encodeCacheAnswerBlob(key, &cacheAnswer{
+		Timestamp:        ts,
+		Expiry:           ts.Add(time.Hour),
+		PrefetchEligible: true,
+		Msg:              msg,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, key, blobKey(blob))
+	require.Equal(t, ts.UnixNano(), blobTimestamp(blob))
+	require.Equal(t, ts.Add(time.Hour).UnixNano(), blobExpiry(blob))
+	require.True(t, blobPrefetchEligible(blob))
+
+	got := new(dns.Msg)
+	require.NoError(t, got.Unpack(blobMessage(blob)))
+	require.Equal(t, mustPack(t, msg), mustPack(t, got))
+}
+
+// A key with no ECS option is the common case and has an empty Net.
+func TestBlobRoundTripWithoutECS(t *testing.T) {
+	key := lruKey{Question: dns.Question{Name: "plain.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+	msg := new(dns.Msg)
+	msg.SetQuestion("plain.example.com.", dns.TypeA)
+
+	blob, err := encodeCacheAnswerBlob(key, &cacheAnswer{Msg: msg})
+	require.NoError(t, err)
+	require.Equal(t, key, blobKey(blob))
+	require.True(t, blobMatchesKey(blob, key))
+}
+
+// Both lengths live in one byte each, so a name that can't be represented has
+// to be refused rather than silently truncated into a key that collides.
+func TestBlobRejectsOversizedName(t *testing.T) {
+	long := strings.Repeat("a", 250) + "." + strings.Repeat("b", 10) + "."
+	key := lruKey{Question: dns.Question{Name: long, Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+	msg := new(dns.Msg)
+	msg.SetQuestion("short.example.com.", dns.TypeA)
+
+	_, err := encodeCacheAnswerBlob(key, &cacheAnswer{Msg: msg})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too long")
+}
+
+// Store encodes the message and must not hold on to it, and Lookup must hand
+// back one the caller owns. Both directions matter: Cache.Resolve now passes
+// the same message it returns to its caller.
+func TestMemoryBackendDoesNotShareMessages(t *testing.T) {
+	b := NewMemoryBackend(MemoryBackendOptions{GCPeriod: time.Hour})
+	defer b.Close()
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	a := new(dns.Msg)
+	a.SetReply(q)
+	rr, err := dns.NewRR("example.com. 3600 IN A 192.0.2.1")
+	require.NoError(t, err)
+	a.Answer = []dns.RR{rr}
+
+	now := time.Now()
+	b.Store(q, &cacheAnswer{Msg: a, Timestamp: now, Expiry: now.Add(time.Hour)})
+
+	// Whatever happens to the message afterwards must not reach the cache.
+	a.Answer[0].(*dns.A).A = net.IP{10, 0, 0, 1}
+	a.Answer = append(a.Answer, rr)
+	a.Rcode = dns.RcodeServerFailure
+
+	got, _, ok := b.Lookup(q)
+	require.True(t, ok)
+	require.Equal(t, dns.RcodeSuccess, got.Rcode)
+	require.Len(t, got.Answer, 1)
+	require.Equal(t, "192.0.2.1", got.Answer[0].(*dns.A).A.String())
+
+	// And the message handed out is the caller's to modify.
+	got.Answer[0].(*dns.A).A = net.IP{172, 16, 0, 1}
+	again, _, ok := b.Lookup(q)
+	require.True(t, ok)
+	require.Equal(t, "192.0.2.1", again.Answer[0].(*dns.A).A.String())
+}
+
+// Lookup takes only the blob reference under the lock and decodes it after
+// releasing, which is only safe because a stored blob is never modified. A
+// concurrent Store replaces the slice rather than writing into it.
+func TestMemoryBackendConcurrentStoreAndLookup(t *testing.T) {
+	b := NewMemoryBackend(MemoryBackendOptions{GCPeriod: time.Hour})
+	defer b.Close()
+
+	const names = 8
+	queries := make([]*dns.Msg, names)
+	answers := make([]*dns.Msg, names)
+	for i := range names {
+		name := fmt.Sprintf("host%d.example.com.", i)
+		q := new(dns.Msg)
+		q.SetQuestion(name, dns.TypeA)
+		a := new(dns.Msg)
+		a.SetReply(q)
+		rr, err := dns.NewRR(fmt.Sprintf("%s 300 IN A 192.0.2.%d", name, i+1))
+		require.NoError(t, err)
+		a.Answer = []dns.RR{rr}
+		queries[i], answers[i] = q, a
+	}
+
+	var wg sync.WaitGroup
+	for w := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			now := time.Now()
+			for range 500 {
+				i := w % names
+				b.Store(queries[i], &cacheAnswer{
+					Msg: answers[i].Copy(), Timestamp: now, Expiry: now.Add(time.Hour),
+				})
+				if got, _, ok := b.Lookup(queries[i]); ok {
+					// whatever is found must be the record for that name
+					require.Equal(t, queries[i].Question[0].Name, got.Question[0].Name)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/lru-cache-blob_test.go
+++ b/lru-cache-blob_test.go
@@ -39,9 +39,9 @@ func blobTestAnswer(t *testing.T) *dns.Msg {
 // bits are the easiest to miss because they share a byte.
 func TestBlobKeyComparisonCoversEveryField(t *testing.T) {
 	key := blobTestKey()
-	blob, err := encodeCacheAnswerBlob(key, &cacheAnswer{Msg: blobTestAnswer(t)})
+	blob, err := newCacheBlob(key, &cacheAnswer{Msg: blobTestAnswer(t)})
 	require.NoError(t, err)
-	require.True(t, blobMatchesKey(blob, key), "the key it was stored under must match")
+	require.True(t, blob.matchesKey(key), "the key it was stored under must match")
 
 	differs := map[string]func(*lruKey){
 		// same length, different content, so this can't pass on a length check
@@ -60,7 +60,7 @@ func TestBlobKeyComparisonCoversEveryField(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			other := blobTestKey()
 			mutate(&other)
-			require.False(t, blobMatchesKey(blob, other),
+			require.False(t, blob.matchesKey(other),
 				"a key differing only in %s must not match", name)
 		})
 	}
@@ -71,10 +71,10 @@ func TestBlobKeyComparisonCoversEveryField(t *testing.T) {
 func TestBlobKeyIgnoresMetadata(t *testing.T) {
 	key := blobTestKey()
 	for _, eligible := range []bool{false, true} {
-		blob, err := encodeCacheAnswerBlob(key, &cacheAnswer{Msg: blobTestAnswer(t), PrefetchEligible: eligible})
+		blob, err := newCacheBlob(key, &cacheAnswer{Msg: blobTestAnswer(t), PrefetchEligible: eligible})
 		require.NoError(t, err)
-		require.True(t, blobMatchesKey(blob, key))
-		require.Equal(t, eligible, blobPrefetchEligible(blob))
+		require.True(t, blob.matchesKey(key))
+		require.Equal(t, eligible, blob.prefetchEligible())
 	}
 }
 
@@ -83,7 +83,7 @@ func TestBlobRoundTrip(t *testing.T) {
 	msg := blobTestAnswer(t)
 	ts := time.Date(2026, 8, 15, 9, 30, 0, 123456789, time.UTC)
 
-	blob, err := encodeCacheAnswerBlob(key, &cacheAnswer{
+	blob, err := newCacheBlob(key, &cacheAnswer{
 		Timestamp:        ts,
 		Expiry:           ts.Add(time.Hour),
 		PrefetchEligible: true,
@@ -91,13 +91,13 @@ func TestBlobRoundTrip(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, key, blobKey(blob))
-	require.Equal(t, ts.UnixNano(), blobTimestamp(blob))
-	require.Equal(t, ts.Add(time.Hour).UnixNano(), blobExpiry(blob))
-	require.True(t, blobPrefetchEligible(blob))
+	require.Equal(t, key, blob.key())
+	require.Equal(t, ts.UnixNano(), blob.timestamp())
+	require.Equal(t, ts.Add(time.Hour).UnixNano(), blob.expiry())
+	require.True(t, blob.prefetchEligible())
 
 	got := new(dns.Msg)
-	require.NoError(t, got.Unpack(blobMessage(blob)))
+	require.NoError(t, got.Unpack(blob.message()))
 	require.Equal(t, mustPack(t, msg), mustPack(t, got))
 }
 
@@ -107,10 +107,10 @@ func TestBlobRoundTripWithoutECS(t *testing.T) {
 	msg := new(dns.Msg)
 	msg.SetQuestion("plain.example.com.", dns.TypeA)
 
-	blob, err := encodeCacheAnswerBlob(key, &cacheAnswer{Msg: msg})
+	blob, err := newCacheBlob(key, &cacheAnswer{Msg: msg})
 	require.NoError(t, err)
-	require.Equal(t, key, blobKey(blob))
-	require.True(t, blobMatchesKey(blob, key))
+	require.Equal(t, key, blob.key())
+	require.True(t, blob.matchesKey(key))
 }
 
 // A question name arrives in presentation form, where every unprintable octet
@@ -156,7 +156,7 @@ func TestBlobRejectsOversizedName(t *testing.T) {
 	msg := new(dns.Msg)
 	msg.SetQuestion("short.example.com.", dns.TypeA)
 
-	_, err := encodeCacheAnswerBlob(key, &cacheAnswer{Msg: msg})
+	_, err := newCacheBlob(key, &cacheAnswer{Msg: msg})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "too long")
 }

--- a/lru-cache-blob_test.go
+++ b/lru-cache-blob_test.go
@@ -239,3 +239,38 @@ func TestMemoryBackendConcurrentStoreAndLookup(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// The layout keeps everything the key is built from in one span, so a stored
+// blob can be matched or hashed without decoding it back into an lruKey. That
+// only holds while no volatile field sits inside the region, so pin it: two
+// entries under the same key must have identical key regions however much
+// their metadata and messages differ.
+func TestBlobKeyRegionDependsOnlyOnTheKey(t *testing.T) {
+	key := blobTestKey()
+	ts := time.Date(2026, 8, 15, 9, 30, 0, 0, time.UTC)
+
+	first, err := newCacheBlob(key, &cacheAnswer{
+		Timestamp: ts, Expiry: ts.Add(time.Hour), PrefetchEligible: true, Msg: blobTestAnswer(t),
+	})
+	require.NoError(t, err)
+
+	other := blobTestAnswer(t)
+	rr, err := dns.NewRR("a.example.com. 60 IN A 198.51.100.9")
+	require.NoError(t, err)
+	other.Answer = append(other.Answer, rr)
+	other.Id = 9
+	second, err := newCacheBlob(key, &cacheAnswer{
+		Timestamp: ts.Add(time.Minute), Expiry: ts.Add(2 * time.Hour), PrefetchEligible: false, Msg: other,
+	})
+	require.NoError(t, err)
+
+	require.NotEqual(t, first.message(), second.message(), "the messages must actually differ")
+	require.Equal(t, first.keyRegion(), second.keyRegion())
+
+	// And a different key has to change it.
+	otherKey := blobTestKey()
+	otherKey.Question.Name = "z.example.com."
+	third, err := newCacheBlob(otherKey, &cacheAnswer{Msg: blobTestAnswer(t)})
+	require.NoError(t, err)
+	require.NotEqual(t, first.keyRegion(), third.keyRegion())
+}

--- a/lru-cache-serialize_test.go
+++ b/lru-cache-serialize_test.go
@@ -32,7 +32,7 @@ func TestLRUDeserializeLegacyFormat(t *testing.T) {
 	item := c.find(key)
 	require.NotNil(t, item, "the record's key must survive unchanged")
 	require.Equal(t, "host.example.com.", storedMsg(t, item).Question[0].Name)
-	require.True(t, blobPrefetchEligible(item.blob))
+	require.True(t, item.blob.prefetchEligible())
 }
 
 // Pins the exact bytes written for a fully-populated record. The cache file
@@ -60,7 +60,7 @@ func TestLRUSerializeFormatStable(t *testing.T) {
 		CD:       true,
 		ECSMask:  24,
 	}
-	blob, err := encodeCacheAnswerBlob(key, &cacheAnswer{
+	blob, err := newCacheBlob(key, &cacheAnswer{
 		Timestamp:        ts,
 		Expiry:           ts.Add(time.Hour),
 		PrefetchEligible: true,

--- a/lru-cache-serialize_test.go
+++ b/lru-cache-serialize_test.go
@@ -31,8 +31,8 @@ func TestLRUDeserializeLegacyFormat(t *testing.T) {
 	}
 	item := c.find(key)
 	require.NotNil(t, item, "the record's key must survive unchanged")
-	require.Equal(t, "host.example.com.", item.msg.Question[0].Name)
-	require.True(t, item.prefetchEligible)
+	require.Equal(t, "host.example.com.", storedMsg(t, item).Question[0].Name)
+	require.True(t, blobPrefetchEligible(item.blob))
 }
 
 // Pins the exact bytes written for a fully-populated record. The cache file
@@ -53,19 +53,23 @@ func TestLRUSerializeFormatStable(t *testing.T) {
 		},
 	}
 
-	c := newLRUCache(0)
-	c.addKey(lruKey{
+	key := lruKey{
 		Question: dns.Question{Name: "host.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
 		Net:      "192.0.2.0",
 		Do:       true,
 		CD:       true,
 		ECSMask:  24,
-	}, &cacheAnswer{
+	}
+	blob, err := encodeCacheAnswerBlob(key, &cacheAnswer{
 		Timestamp:        ts,
 		Expiry:           ts.Add(time.Hour),
 		PrefetchEligible: true,
 		Msg:              msg,
 	})
+	require.NoError(t, err)
+
+	c := newLRUCache(0)
+	c.addKey(key, blob)
 
 	var buf bytes.Buffer
 	require.NoError(t, c.serialize(&buf))

--- a/lru-cache-serialize_test.go
+++ b/lru-cache-serialize_test.go
@@ -29,7 +29,7 @@ func TestLRUDeserializeLegacyFormat(t *testing.T) {
 		CD:       true,
 		ECSMask:  24,
 	}
-	item := c.find(key)
+	item := c.find(c.hash(key), key)
 	require.NotNil(t, item, "the record's key must survive unchanged")
 	require.Equal(t, "host.example.com.", storedMsg(t, item).Question[0].Name)
 	require.True(t, item.blob.prefetchEligible())

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -1,8 +1,10 @@
 package rdns
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"hash/maphash"
 	"io"
 	"strings"
@@ -27,19 +29,180 @@ type lruCache struct {
 	seed       maphash.Seed
 }
 
-// cacheItem holds a cached answer inline rather than pointing at a
-// cacheAnswer, which saves an allocation and a traced pointer per entry.
+// cacheItem holds an entry as a single packed byte slice: the key, its
+// metadata and the message in wire format. A []byte holds no pointers, so the
+// collector skips its contents entirely, where an unpacked dns.Msg is a tree
+// of about a dozen objects it has to trace on every cycle.
+//
+// A blob is never modified once built. Replacing an entry allocates a new one,
+// so a reader that took the slice under the lock can decode it after releasing
+// the lock.
 type cacheItem struct {
-	key        lruKey
 	prev, next *cacheItem
+	hash       uint64 // key hash, kept so eviction doesn't have to decode the blob
+	blob       []byte
+}
 
-	msg *dns.Msg
-	// Unix nanoseconds. A time.Time would carry a location pointer that the
-	// GC has to trace for every entry in the cache, for no more resolution
-	// than an int64 already gives.
-	timestamp        int64 // time the record was cached, used to adjust TTL
-	expiry           int64 // time the record expires and should be removed
-	prefetchEligible bool  // the cache can prefetch this record
+// Layout of the blob. Offsets are fixed so the metadata can be read without
+// decoding the key or the message.
+//
+//	0      version
+//	1      meta flags (prefetch-eligible)
+//	2..9   timestamp, unix nanoseconds
+//	10..17 expiry, unix nanoseconds
+//	18     key flags (DO, CD)          <- key region starts
+//	19..20 qtype
+//	21..22 qclass
+//	23     ECS source prefix length
+//	24     length of the ECS address
+//	25     length of the question name
+//	26..   ECS address, then question name
+//	       <- key region ends, packed message follows
+//
+// The key fields are contiguous so a lookup can compare them as one span, and
+// so an on-disk format can hash the same bytes.
+const (
+	blobVersion = 1
+
+	blobOffMetaFlags = 1
+	blobOffTimestamp = 2
+	blobOffExpiry    = 10
+	blobOffKeyFlags  = 18
+	blobOffQtype     = 19
+	blobOffQclass    = 21
+	blobOffECSMask   = 23
+	blobOffNetLen    = 24
+	blobOffNameLen   = 25
+	blobHdrLen       = 26
+)
+
+const (
+	blobMetaPrefetchEligible = 1 << 0
+
+	blobKeyDo = 1 << 0
+	blobKeyCD = 1 << 1
+)
+
+// encodeCacheItem builds the stored form of an entry in one exact-size
+// allocation. wire must already hold the packed message.
+func encodeCacheItem(key lruKey, timestamp, expiry int64, prefetchEligible bool, wire []byte) ([]byte, error) {
+	// Both lengths are held in a single byte. A question name is capped at 255
+	// by the protocol and an address string is far shorter, so this only trips
+	// on a synthesised query.
+	if len(key.Question.Name) > 255 {
+		return nil, fmt.Errorf("question name too long to cache: %d bytes", len(key.Question.Name))
+	}
+	if len(key.Net) > 255 {
+		return nil, fmt.Errorf("ECS address too long to cache: %d bytes", len(key.Net))
+	}
+
+	blob := make([]byte, blobHdrLen+len(key.Net)+len(key.Question.Name)+len(wire))
+	blob[0] = blobVersion
+	if prefetchEligible {
+		blob[blobOffMetaFlags] |= blobMetaPrefetchEligible
+	}
+	binary.BigEndian.PutUint64(blob[blobOffTimestamp:], uint64(timestamp))
+	binary.BigEndian.PutUint64(blob[blobOffExpiry:], uint64(expiry))
+	if key.Do {
+		blob[blobOffKeyFlags] |= blobKeyDo
+	}
+	if key.CD {
+		blob[blobOffKeyFlags] |= blobKeyCD
+	}
+	binary.BigEndian.PutUint16(blob[blobOffQtype:], key.Question.Qtype)
+	binary.BigEndian.PutUint16(blob[blobOffQclass:], key.Question.Qclass)
+	blob[blobOffECSMask] = key.ECSMask
+	blob[blobOffNetLen] = byte(len(key.Net))
+	blob[blobOffNameLen] = byte(len(key.Question.Name))
+
+	n := blobHdrLen
+	n += copy(blob[n:], key.Net)
+	n += copy(blob[n:], key.Question.Name)
+	copy(blob[n:], wire)
+	return blob, nil
+}
+
+// encodeCacheAnswer packs a cacheAnswer's message into a pooled buffer and
+// builds the stored form from it. The message is not retained.
+func encodeCacheAnswerBlob(key lruKey, a *cacheAnswer) ([]byte, error) {
+	if a.Msg == nil {
+		return nil, errors.New("cache item has no message")
+	}
+	bufPtr := packBufPool.Get().(*[]byte)
+	wire, err := a.Msg.PackBuffer((*bufPtr)[:cap(*bufPtr)])
+	if err != nil {
+		putPackBuf(bufPtr)
+		return nil, err
+	}
+	// If packing outgrew the pooled buffer, keep the larger one so the pool
+	// adapts to the workload.
+	if cap(wire) > cap(*bufPtr) {
+		*bufPtr = wire
+	}
+	blob, err := encodeCacheItem(key, unixNano(a.Timestamp), unixNano(a.Expiry), a.PrefetchEligible, wire)
+	putPackBuf(bufPtr)
+	return blob, err
+}
+
+func blobTimestamp(blob []byte) int64 {
+	return int64(binary.BigEndian.Uint64(blob[blobOffTimestamp:]))
+}
+
+func blobExpiry(blob []byte) int64 {
+	return int64(binary.BigEndian.Uint64(blob[blobOffExpiry:]))
+}
+
+func blobPrefetchEligible(blob []byte) bool {
+	return blob[blobOffMetaFlags]&blobMetaPrefetchEligible != 0
+}
+
+// blobMessage returns the packed message, which aliases the blob.
+func blobMessage(blob []byte) []byte {
+	return blob[blobHdrLen+int(blob[blobOffNetLen])+int(blob[blobOffNameLen]):]
+}
+
+// blobMatchesKey reports whether the blob was stored under key. Comparing a
+// byte slice against a string this way doesn't allocate.
+func blobMatchesKey(blob []byte, key lruKey) bool {
+	if len(blob) < blobHdrLen {
+		return false
+	}
+	var flags byte
+	if key.Do {
+		flags |= blobKeyDo
+	}
+	if key.CD {
+		flags |= blobKeyCD
+	}
+	netLen, nameLen := int(blob[blobOffNetLen]), int(blob[blobOffNameLen])
+	if len(blob) < blobHdrLen+netLen+nameLen ||
+		blob[blobOffKeyFlags] != flags ||
+		blob[blobOffECSMask] != key.ECSMask ||
+		netLen != len(key.Net) ||
+		nameLen != len(key.Question.Name) ||
+		binary.BigEndian.Uint16(blob[blobOffQtype:]) != key.Question.Qtype ||
+		binary.BigEndian.Uint16(blob[blobOffQclass:]) != key.Question.Qclass {
+		return false
+	}
+	return string(blob[blobHdrLen:blobHdrLen+netLen]) == key.Net &&
+		string(blob[blobHdrLen+netLen:blobHdrLen+netLen+nameLen]) == key.Question.Name
+}
+
+// blobKey rebuilds the key a blob was stored under. Used when writing the
+// cache file, not on the query path.
+func blobKey(blob []byte) lruKey {
+	netLen, nameLen := int(blob[blobOffNetLen]), int(blob[blobOffNameLen])
+	return lruKey{
+		Question: dns.Question{
+			Name:   string(blob[blobHdrLen+netLen : blobHdrLen+netLen+nameLen]),
+			Qtype:  binary.BigEndian.Uint16(blob[blobOffQtype:]),
+			Qclass: binary.BigEndian.Uint16(blob[blobOffQclass:]),
+		},
+		Net:     string(blob[blobHdrLen : blobHdrLen+netLen]),
+		Do:      blob[blobOffKeyFlags]&blobKeyDo != 0,
+		CD:      blob[blobOffKeyFlags]&blobKeyCD != 0,
+		ECSMask: blob[blobOffECSMask],
+	}
 }
 
 type lruKey struct {
@@ -76,22 +239,20 @@ type cacheAnswerJSON struct {
 	Msg              []byte
 }
 
-// Builds the on-disk form of an item, packing its message to wire format.
+// Builds the on-disk form of an item. The stored blob already holds the
+// message in wire format, so the record borrows those bytes rather than
+// packing again.
 func newCacheItemJSON(item *cacheItem) (cacheItemJSON, error) {
-	if item.msg == nil {
-		return cacheItemJSON{}, errors.New("cache item has no message")
-	}
-	msg, err := item.msg.Pack()
-	if err != nil {
-		return cacheItemJSON{}, err
+	if len(item.blob) < blobHdrLen {
+		return cacheItemJSON{}, errors.New("cache item is malformed")
 	}
 	return cacheItemJSON{
-		Key: item.key,
+		Key: blobKey(item.blob),
 		Answer: cacheAnswerJSON{
-			Timestamp:        nanoTime(item.timestamp),
-			Expiry:           nanoTime(item.expiry),
-			PrefetchEligible: item.prefetchEligible,
-			Msg:              msg,
+			Timestamp:        nanoTime(blobTimestamp(item.blob)),
+			Expiry:           nanoTime(blobExpiry(item.blob)),
+			PrefetchEligible: blobPrefetchEligible(item.blob),
+			Msg:              blobMessage(item.blob),
 		},
 	}, nil
 }
@@ -114,23 +275,26 @@ func nanoTime(n int64) time.Time {
 	return time.Unix(0, n).UTC()
 }
 
-// Rebuilds a cache item from its on-disk form, unpacking the wire-format
-// message. Returns false for a record that can't be used, which includes ones
-// written by a version that stored different fields.
-func (r cacheItemJSON) toCacheItem() (lruKey, *cacheAnswer, bool) {
+// Rebuilds a stored item from its on-disk form. Returns false for a record
+// that can't be used, which includes ones written by a version that stored
+// different fields.
+//
+// The file already holds the message in wire format, so it goes into the blob
+// as-is. It is still unpacked once here to reject a corrupt record at load
+// time rather than on every lookup that finds it.
+func (r cacheItemJSON) toCacheItem() (lruKey, []byte, bool) {
 	if r.Key.Question.Name == "" || len(r.Answer.Msg) == 0 {
 		return lruKey{}, nil, false
 	}
-	msg := new(dns.Msg)
-	if err := msg.Unpack(r.Answer.Msg); err != nil {
+	if err := new(dns.Msg).Unpack(r.Answer.Msg); err != nil {
 		return lruKey{}, nil, false
 	}
-	return r.Key, &cacheAnswer{
-		Timestamp:        r.Answer.Timestamp,
-		Expiry:           r.Answer.Expiry,
-		PrefetchEligible: r.Answer.PrefetchEligible,
-		Msg:              msg,
-	}, true
+	blob, err := encodeCacheItem(r.Key, unixNano(r.Answer.Timestamp), unixNano(r.Answer.Expiry),
+		r.Answer.PrefetchEligible, r.Answer.Msg)
+	if err != nil {
+		return lruKey{}, nil, false
+	}
+	return r.Key, blob, true
 }
 
 func newLRUCache(capacity int) *lruCache {
@@ -148,39 +312,35 @@ func newLRUCache(capacity int) *lruCache {
 	}
 }
 
-func (c *lruCache) add(query *dns.Msg, answer *cacheAnswer) {
+// add packs an answer and stores it under the query's key. Packing is done by
+// the caller's goroutine before the cache is locked; see memoryBackend.Store.
+func (c *lruCache) add(query *dns.Msg, answer *cacheAnswer) error {
 	key := lruKeyFromQuery(query)
-	c.addKey(key, answer)
+	blob, err := encodeCacheAnswerBlob(key, answer)
+	if err != nil {
+		return err
+	}
+	c.addKey(key, blob)
+	return nil
 }
 
-func (c *lruCache) addKey(key lruKey, answer *cacheAnswer) {
+func (c *lruCache) addKey(key lruKey, blob []byte) {
 	item := c.touch(key)
 	if item != nil {
-		// Update the item, it's already at the top of the list
-		// so we can just change the value
-		item.setAnswer(answer)
+		// Already at the top of the list, so only the blob changes. The old
+		// one is left for the collector; a reader may still be decoding it.
+		item.blob = blob
 		return
 	}
-	item = &cacheItem{key: key}
-	item.setAnswer(answer)
-	c.insert(item)
-}
-
-// Copies an answer into the item. The cacheAnswer itself is not retained.
-func (i *cacheItem) setAnswer(a *cacheAnswer) {
-	i.msg = a.Msg
-	i.timestamp = unixNano(a.Timestamp)
-	i.expiry = unixNano(a.Expiry)
-	i.prefetchEligible = a.PrefetchEligible
+	c.insert(&cacheItem{hash: c.hash(key), blob: blob})
 }
 
 // Link a new item into the index and the top of the linked list.
 func (c *lruCache) insert(item *cacheItem) {
-	h := c.hash(item.key)
-	if existing := c.items[h]; existing != nil {
+	if existing := c.items[item.hash]; existing != nil {
 		c.unlink(existing)
 	}
-	c.items[h] = item
+	c.items[item.hash] = item
 
 	item.next = c.head.next
 	item.prev = c.head
@@ -194,7 +354,7 @@ func (c *lruCache) insert(item *cacheItem) {
 func (c *lruCache) unlink(item *cacheItem) {
 	item.prev.next = item.next
 	item.next.prev = item.prev
-	delete(c.items, c.hash(item.key))
+	delete(c.items, item.hash)
 }
 
 func (c *lruCache) hash(key lruKey) uint64 {
@@ -204,7 +364,7 @@ func (c *lruCache) hash(key lruKey) uint64 {
 // Find an item by key without changing its position in the queue.
 func (c *lruCache) find(key lruKey) *cacheItem {
 	item := c.items[c.hash(key)]
-	if item == nil || item.key != key {
+	if item == nil || !blobMatchesKey(item.blob, key) {
 		return nil
 	}
 	return item
@@ -299,11 +459,11 @@ func (c *lruCache) deserialize(r io.Reader) error {
 			return err
 		}
 		// Skip bad (or incompatible) records
-		key, answer, ok := record.toCacheItem()
+		key, blob, ok := record.toCacheItem()
 		if !ok {
 			continue
 		}
-		c.addKey(key, answer)
+		c.addKey(key, blob)
 	}
 	return nil
 }

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -1,13 +1,10 @@
 package rdns
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"hash/maphash"
 	"io"
-	"math"
 	"strings"
 	"time"
 
@@ -30,189 +27,11 @@ type lruCache struct {
 	seed       maphash.Seed
 }
 
-// cacheItem holds an entry as a single packed byte slice: the key, its
-// metadata and the message in wire format. A []byte holds no pointers, so the
-// collector skips its contents entirely, where an unpacked dns.Msg is a tree
-// of about a dozen objects it has to trace on every cycle.
-//
-// A blob is never modified once built. Replacing an entry allocates a new one,
-// so a reader that took the slice under the lock can decode it after releasing
-// the lock.
+// cacheItem is one entry in the queue, holding the stored form of a response.
 type cacheItem struct {
 	prev, next *cacheItem
 	hash       uint64 // key hash, kept so eviction doesn't have to decode the blob
-	blob       []byte
-}
-
-// Layout of the blob. Offsets are fixed so the metadata can be read without
-// decoding the key or the message.
-//
-//	0      version
-//	1      meta flags (prefetch-eligible)
-//	2..9   timestamp, unix nanoseconds
-//	10..17 expiry, unix nanoseconds
-//	18     key flags (DO, CD)          <- key region starts
-//	19..20 qtype
-//	21..22 qclass
-//	23     ECS source prefix length
-//	24..25 length of the ECS address
-//	26..27 length of the question name
-//	28..   ECS address, then question name
-//	       <- key region ends, packed message follows
-//
-// The key fields are contiguous so a lookup can compare them as one span, and
-// so an on-disk format can hash the same bytes.
-const (
-	blobVersion = 1
-
-	blobOffMetaFlags = 1
-	blobOffTimestamp = 2
-	blobOffExpiry    = 10
-	blobOffKeyFlags  = 18
-	blobOffQtype     = 19
-	blobOffQclass    = 21
-	blobOffECSMask   = 23
-	blobOffNetLen    = 24
-	blobOffNameLen   = 26
-	blobHdrLen       = 28
-)
-
-const (
-	blobMetaPrefetchEligible = 1 << 0
-
-	blobKeyDo = 1 << 0
-	blobKeyCD = 1 << 1
-)
-
-// encodeCacheItem builds the stored form of an entry in one exact-size
-// allocation. wire must already hold the packed message.
-func encodeCacheItem(key lruKey, timestamp, expiry int64, prefetchEligible bool, wire []byte) ([]byte, error) {
-	// The protocol caps a name at 255 octets on the wire, but this is the
-	// presentation form, where an unprintable octet escapes to \DDD and a
-	// legal name can run four times that. Both lengths get a uint16, which no
-	// name can outgrow; the checks are here so the encoding stays total.
-	if len(key.Question.Name) > math.MaxUint16 {
-		return nil, fmt.Errorf("question name too long to cache: %d bytes", len(key.Question.Name))
-	}
-	if len(key.Net) > math.MaxUint16 {
-		return nil, fmt.Errorf("ECS address too long to cache: %d bytes", len(key.Net))
-	}
-
-	blob := make([]byte, blobHdrLen+len(key.Net)+len(key.Question.Name)+len(wire))
-	blob[0] = blobVersion
-	if prefetchEligible {
-		blob[blobOffMetaFlags] |= blobMetaPrefetchEligible
-	}
-	binary.BigEndian.PutUint64(blob[blobOffTimestamp:], uint64(timestamp))
-	binary.BigEndian.PutUint64(blob[blobOffExpiry:], uint64(expiry))
-	if key.Do {
-		blob[blobOffKeyFlags] |= blobKeyDo
-	}
-	if key.CD {
-		blob[blobOffKeyFlags] |= blobKeyCD
-	}
-	binary.BigEndian.PutUint16(blob[blobOffQtype:], key.Question.Qtype)
-	binary.BigEndian.PutUint16(blob[blobOffQclass:], key.Question.Qclass)
-	blob[blobOffECSMask] = key.ECSMask
-	binary.BigEndian.PutUint16(blob[blobOffNetLen:], uint16(len(key.Net)))
-	binary.BigEndian.PutUint16(blob[blobOffNameLen:], uint16(len(key.Question.Name)))
-
-	n := blobHdrLen
-	n += copy(blob[n:], key.Net)
-	n += copy(blob[n:], key.Question.Name)
-	copy(blob[n:], wire)
-	return blob, nil
-}
-
-// encodeCacheAnswer packs a cacheAnswer's message into a pooled buffer and
-// builds the stored form from it. The message is not retained.
-func encodeCacheAnswerBlob(key lruKey, a *cacheAnswer) ([]byte, error) {
-	if a.Msg == nil {
-		return nil, errors.New("cache item has no message")
-	}
-	bufPtr := packBufPool.Get().(*[]byte)
-	wire, err := a.Msg.PackBuffer((*bufPtr)[:cap(*bufPtr)])
-	if err != nil {
-		putPackBuf(bufPtr)
-		return nil, err
-	}
-	// If packing outgrew the pooled buffer, keep the larger one so the pool
-	// adapts to the workload.
-	if cap(wire) > cap(*bufPtr) {
-		*bufPtr = wire
-	}
-	blob, err := encodeCacheItem(key, unixNano(a.Timestamp), unixNano(a.Expiry), a.PrefetchEligible, wire)
-	putPackBuf(bufPtr)
-	return blob, err
-}
-
-func blobTimestamp(blob []byte) int64 {
-	return int64(binary.BigEndian.Uint64(blob[blobOffTimestamp:]))
-}
-
-func blobExpiry(blob []byte) int64 {
-	return int64(binary.BigEndian.Uint64(blob[blobOffExpiry:]))
-}
-
-func blobPrefetchEligible(blob []byte) bool {
-	return blob[blobOffMetaFlags]&blobMetaPrefetchEligible != 0
-}
-
-// blobMessage returns the packed message, which aliases the blob.
-func blobMessage(blob []byte) []byte {
-	return blob[blobHdrLen+blobNetLen(blob)+blobNameLen(blob):]
-}
-
-func blobNetLen(blob []byte) int {
-	return int(binary.BigEndian.Uint16(blob[blobOffNetLen:]))
-}
-
-func blobNameLen(blob []byte) int {
-	return int(binary.BigEndian.Uint16(blob[blobOffNameLen:]))
-}
-
-// blobMatchesKey reports whether the blob was stored under key. Comparing a
-// byte slice against a string this way doesn't allocate.
-func blobMatchesKey(blob []byte, key lruKey) bool {
-	if len(blob) < blobHdrLen {
-		return false
-	}
-	var flags byte
-	if key.Do {
-		flags |= blobKeyDo
-	}
-	if key.CD {
-		flags |= blobKeyCD
-	}
-	netLen, nameLen := blobNetLen(blob), blobNameLen(blob)
-	if len(blob) < blobHdrLen+netLen+nameLen ||
-		blob[blobOffKeyFlags] != flags ||
-		blob[blobOffECSMask] != key.ECSMask ||
-		netLen != len(key.Net) ||
-		nameLen != len(key.Question.Name) ||
-		binary.BigEndian.Uint16(blob[blobOffQtype:]) != key.Question.Qtype ||
-		binary.BigEndian.Uint16(blob[blobOffQclass:]) != key.Question.Qclass {
-		return false
-	}
-	return string(blob[blobHdrLen:blobHdrLen+netLen]) == key.Net &&
-		string(blob[blobHdrLen+netLen:blobHdrLen+netLen+nameLen]) == key.Question.Name
-}
-
-// blobKey rebuilds the key a blob was stored under. Used when writing the
-// cache file, not on the query path.
-func blobKey(blob []byte) lruKey {
-	netLen, nameLen := blobNetLen(blob), blobNameLen(blob)
-	return lruKey{
-		Question: dns.Question{
-			Name:   string(blob[blobHdrLen+netLen : blobHdrLen+netLen+nameLen]),
-			Qtype:  binary.BigEndian.Uint16(blob[blobOffQtype:]),
-			Qclass: binary.BigEndian.Uint16(blob[blobOffQclass:]),
-		},
-		Net:     string(blob[blobHdrLen : blobHdrLen+netLen]),
-		Do:      blob[blobOffKeyFlags]&blobKeyDo != 0,
-		CD:      blob[blobOffKeyFlags]&blobKeyCD != 0,
-		ECSMask: blob[blobOffECSMask],
-	}
+	blob       cacheBlob
 }
 
 type lruKey struct {
@@ -257,12 +76,12 @@ func newCacheItemJSON(item *cacheItem) (cacheItemJSON, error) {
 		return cacheItemJSON{}, errors.New("cache item is malformed")
 	}
 	return cacheItemJSON{
-		Key: blobKey(item.blob),
+		Key: item.blob.key(),
 		Answer: cacheAnswerJSON{
-			Timestamp:        nanoTime(blobTimestamp(item.blob)),
-			Expiry:           nanoTime(blobExpiry(item.blob)),
-			PrefetchEligible: blobPrefetchEligible(item.blob),
-			Msg:              blobMessage(item.blob),
+			Timestamp:        nanoTime(item.blob.timestamp()),
+			Expiry:           nanoTime(item.blob.expiry()),
+			PrefetchEligible: item.blob.prefetchEligible(),
+			Msg:              item.blob.message(),
 		},
 	}, nil
 }
@@ -292,14 +111,14 @@ func nanoTime(n int64) time.Time {
 // The file already holds the message in wire format, so it goes into the blob
 // as-is. It is still unpacked once here to reject a corrupt record at load
 // time rather than on every lookup that finds it.
-func (r cacheItemJSON) toCacheItem() (lruKey, []byte, bool) {
+func (r cacheItemJSON) toCacheItem() (lruKey, cacheBlob, bool) {
 	if r.Key.Question.Name == "" || len(r.Answer.Msg) == 0 {
 		return lruKey{}, nil, false
 	}
 	if err := new(dns.Msg).Unpack(r.Answer.Msg); err != nil {
 		return lruKey{}, nil, false
 	}
-	blob, err := encodeCacheItem(r.Key, unixNano(r.Answer.Timestamp), unixNano(r.Answer.Expiry),
+	blob, err := newCacheBlobFromWire(r.Key, unixNano(r.Answer.Timestamp), unixNano(r.Answer.Expiry),
 		r.Answer.PrefetchEligible, r.Answer.Msg)
 	if err != nil {
 		return lruKey{}, nil, false
@@ -326,7 +145,7 @@ func newLRUCache(capacity int) *lruCache {
 // the caller's goroutine before the cache is locked; see memoryBackend.Store.
 func (c *lruCache) add(query *dns.Msg, answer *cacheAnswer) error {
 	key := lruKeyFromQuery(query)
-	blob, err := encodeCacheAnswerBlob(key, answer)
+	blob, err := newCacheBlob(key, answer)
 	if err != nil {
 		return err
 	}
@@ -334,7 +153,7 @@ func (c *lruCache) add(query *dns.Msg, answer *cacheAnswer) error {
 	return nil
 }
 
-func (c *lruCache) addKey(key lruKey, blob []byte) {
+func (c *lruCache) addKey(key lruKey, blob cacheBlob) {
 	item := c.touch(key)
 	if item != nil {
 		// Already at the top of the list, so only the blob changes. The old
@@ -374,7 +193,7 @@ func (c *lruCache) hash(key lruKey) uint64 {
 // Find an item by key without changing its position in the queue.
 func (c *lruCache) find(key lruKey) *cacheItem {
 	item := c.items[c.hash(key)]
-	if item == nil || !blobMatchesKey(item.blob, key) {
+	if item == nil || !item.blob.matchesKey(key) {
 		return nil
 	}
 	return item

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/maphash"
 	"io"
+	"math"
 	"strings"
 	"time"
 
@@ -54,9 +55,9 @@ type cacheItem struct {
 //	19..20 qtype
 //	21..22 qclass
 //	23     ECS source prefix length
-//	24     length of the ECS address
-//	25     length of the question name
-//	26..   ECS address, then question name
+//	24..25 length of the ECS address
+//	26..27 length of the question name
+//	28..   ECS address, then question name
 //	       <- key region ends, packed message follows
 //
 // The key fields are contiguous so a lookup can compare them as one span, and
@@ -72,8 +73,8 @@ const (
 	blobOffQclass    = 21
 	blobOffECSMask   = 23
 	blobOffNetLen    = 24
-	blobOffNameLen   = 25
-	blobHdrLen       = 26
+	blobOffNameLen   = 26
+	blobHdrLen       = 28
 )
 
 const (
@@ -86,13 +87,14 @@ const (
 // encodeCacheItem builds the stored form of an entry in one exact-size
 // allocation. wire must already hold the packed message.
 func encodeCacheItem(key lruKey, timestamp, expiry int64, prefetchEligible bool, wire []byte) ([]byte, error) {
-	// Both lengths are held in a single byte. A question name is capped at 255
-	// by the protocol and an address string is far shorter, so this only trips
-	// on a synthesised query.
-	if len(key.Question.Name) > 255 {
+	// The protocol caps a name at 255 octets on the wire, but this is the
+	// presentation form, where an unprintable octet escapes to \DDD and a
+	// legal name can run four times that. Both lengths get a uint16, which no
+	// name can outgrow; the checks are here so the encoding stays total.
+	if len(key.Question.Name) > math.MaxUint16 {
 		return nil, fmt.Errorf("question name too long to cache: %d bytes", len(key.Question.Name))
 	}
-	if len(key.Net) > 255 {
+	if len(key.Net) > math.MaxUint16 {
 		return nil, fmt.Errorf("ECS address too long to cache: %d bytes", len(key.Net))
 	}
 
@@ -112,8 +114,8 @@ func encodeCacheItem(key lruKey, timestamp, expiry int64, prefetchEligible bool,
 	binary.BigEndian.PutUint16(blob[blobOffQtype:], key.Question.Qtype)
 	binary.BigEndian.PutUint16(blob[blobOffQclass:], key.Question.Qclass)
 	blob[blobOffECSMask] = key.ECSMask
-	blob[blobOffNetLen] = byte(len(key.Net))
-	blob[blobOffNameLen] = byte(len(key.Question.Name))
+	binary.BigEndian.PutUint16(blob[blobOffNetLen:], uint16(len(key.Net)))
+	binary.BigEndian.PutUint16(blob[blobOffNameLen:], uint16(len(key.Question.Name)))
 
 	n := blobHdrLen
 	n += copy(blob[n:], key.Net)
@@ -158,7 +160,15 @@ func blobPrefetchEligible(blob []byte) bool {
 
 // blobMessage returns the packed message, which aliases the blob.
 func blobMessage(blob []byte) []byte {
-	return blob[blobHdrLen+int(blob[blobOffNetLen])+int(blob[blobOffNameLen]):]
+	return blob[blobHdrLen+blobNetLen(blob)+blobNameLen(blob):]
+}
+
+func blobNetLen(blob []byte) int {
+	return int(binary.BigEndian.Uint16(blob[blobOffNetLen:]))
+}
+
+func blobNameLen(blob []byte) int {
+	return int(binary.BigEndian.Uint16(blob[blobOffNameLen:]))
 }
 
 // blobMatchesKey reports whether the blob was stored under key. Comparing a
@@ -174,7 +184,7 @@ func blobMatchesKey(blob []byte, key lruKey) bool {
 	if key.CD {
 		flags |= blobKeyCD
 	}
-	netLen, nameLen := int(blob[blobOffNetLen]), int(blob[blobOffNameLen])
+	netLen, nameLen := blobNetLen(blob), blobNameLen(blob)
 	if len(blob) < blobHdrLen+netLen+nameLen ||
 		blob[blobOffKeyFlags] != flags ||
 		blob[blobOffECSMask] != key.ECSMask ||
@@ -191,7 +201,7 @@ func blobMatchesKey(blob []byte, key lruKey) bool {
 // blobKey rebuilds the key a blob was stored under. Used when writing the
 // cache file, not on the query path.
 func blobKey(blob []byte) lruKey {
-	netLen, nameLen := int(blob[blobOffNetLen]), int(blob[blobOffNameLen])
+	netLen, nameLen := blobNetLen(blob), blobNameLen(blob)
 	return lruKey{
 		Question: dns.Question{
 			Name:   string(blob[blobHdrLen+netLen : blobHdrLen+netLen+nameLen]),

--- a/lru-cache.go
+++ b/lru-cache.go
@@ -2,7 +2,6 @@ package rdns
 
 import (
 	"encoding/json"
-	"errors"
 	"hash/maphash"
 	"io"
 	"strings"
@@ -71,10 +70,7 @@ type cacheAnswerJSON struct {
 // Builds the on-disk form of an item. The stored blob already holds the
 // message in wire format, so the record borrows those bytes rather than
 // packing again.
-func newCacheItemJSON(item *cacheItem) (cacheItemJSON, error) {
-	if len(item.blob) < blobHdrLen {
-		return cacheItemJSON{}, errors.New("cache item is malformed")
-	}
+func newCacheItemJSON(item *cacheItem) cacheItemJSON {
 	return cacheItemJSON{
 		Key: item.blob.key(),
 		Answer: cacheAnswerJSON{
@@ -83,7 +79,7 @@ func newCacheItemJSON(item *cacheItem) (cacheItemJSON, error) {
 			PrefetchEligible: item.blob.prefetchEligible(),
 			Msg:              item.blob.message(),
 		},
-	}, nil
+	}
 }
 
 // Conversions between the time.Time a cacheAnswer carries and the unix
@@ -104,26 +100,30 @@ func nanoTime(n int64) time.Time {
 	return time.Unix(0, n).UTC()
 }
 
-// Rebuilds a stored item from its on-disk form. Returns false for a record
-// that can't be used, which includes ones written by a version that stored
-// different fields.
+// Builds the stored form of a record read from the cache file, returning false
+// for one that can't be used, which includes records written by a version that
+// stored different fields.
 //
 // The file already holds the message in wire format, so it goes into the blob
-// as-is. It is still unpacked once here to reject a corrupt record at load
-// time rather than on every lookup that finds it.
-func (r cacheItemJSON) toCacheItem() (lruKey, cacheBlob, bool) {
+// as-is rather than being unpacked and packed again. It is still unpacked once
+// to validate it, so a record that can't be decoded is kept out of the cache
+// rather than taking up an entry until the lookup that finds it evicts it.
+func (r cacheItemJSON) toCacheBlob() (cacheBlob, bool) {
 	if r.Key.Question.Name == "" || len(r.Answer.Msg) == 0 {
-		return lruKey{}, nil, false
+		return nil, false
 	}
 	if err := new(dns.Msg).Unpack(r.Answer.Msg); err != nil {
-		return lruKey{}, nil, false
+		return nil, false
 	}
-	blob, err := newCacheBlobFromWire(r.Key, unixNano(r.Answer.Timestamp), unixNano(r.Answer.Expiry),
-		r.Answer.PrefetchEligible, r.Answer.Msg)
+	blob, err := newCacheBlobFromWire(r.Key, &cacheAnswer{
+		Timestamp:        r.Answer.Timestamp,
+		Expiry:           r.Answer.Expiry,
+		PrefetchEligible: r.Answer.PrefetchEligible,
+	}, r.Answer.Msg)
 	if err != nil {
-		return lruKey{}, nil, false
+		return nil, false
 	}
-	return r.Key, blob, true
+	return blob, true
 }
 
 func newLRUCache(capacity int) *lruCache {
@@ -141,27 +141,15 @@ func newLRUCache(capacity int) *lruCache {
 	}
 }
 
-// add packs an answer and stores it under the query's key. Packing is done by
-// the caller's goroutine before the cache is locked; see memoryBackend.Store.
-func (c *lruCache) add(query *dns.Msg, answer *cacheAnswer) error {
-	key := lruKeyFromQuery(query)
-	blob, err := newCacheBlob(key, answer)
-	if err != nil {
-		return err
-	}
-	c.addKey(key, blob)
-	return nil
-}
-
 func (c *lruCache) addKey(key lruKey, blob cacheBlob) {
-	item := c.touch(key)
-	if item != nil {
+	h := c.hash(key)
+	if item := c.touch(h, key); item != nil {
 		// Already at the top of the list, so only the blob changes. The old
 		// one is left for the collector; a reader may still be decoding it.
 		item.blob = blob
 		return
 	}
-	c.insert(&cacheItem{hash: c.hash(key), blob: blob})
+	c.insert(&cacheItem{hash: h, blob: blob})
 }
 
 // Link a new item into the index and the top of the linked list.
@@ -190,9 +178,10 @@ func (c *lruCache) hash(key lruKey) uint64 {
 	return maphash.Comparable(c.seed, key)
 }
 
-// Find an item by key without changing its position in the queue.
-func (c *lruCache) find(key lruKey) *cacheItem {
-	item := c.items[c.hash(key)]
+// Find an item by key without changing its position in the queue. The hash is
+// passed in so a caller that needs it again, like addKey, computes it once.
+func (c *lruCache) find(h uint64, key lruKey) *cacheItem {
+	item := c.items[h]
 	if item == nil || !item.blob.matchesKey(key) {
 		return nil
 	}
@@ -200,8 +189,8 @@ func (c *lruCache) find(key lruKey) *cacheItem {
 }
 
 // Loads a cache item and puts it to the top of the queue (most recent).
-func (c *lruCache) touch(key lruKey) *cacheItem {
-	item := c.find(key)
+func (c *lruCache) touch(h uint64, key lruKey) *cacheItem {
+	item := c.find(h, key)
 	if item == nil {
 		return nil
 	}
@@ -216,7 +205,8 @@ func (c *lruCache) touch(key lruKey) *cacheItem {
 }
 
 func (c *lruCache) delete(q *dns.Msg) {
-	item := c.find(lruKeyFromQuery(q))
+	key := lruKeyFromQuery(q)
+	item := c.find(c.hash(key), key)
 	if item == nil {
 		return
 	}
@@ -224,7 +214,8 @@ func (c *lruCache) delete(q *dns.Msg) {
 }
 
 func (c *lruCache) get(query *dns.Msg) *cacheItem {
-	return c.touch(lruKeyFromQuery(query))
+	key := lruKeyFromQuery(query)
+	return c.touch(c.hash(key), key)
 }
 
 // Shrink the cache down to the maximum number of items.
@@ -269,11 +260,7 @@ func (c *lruCache) size() int {
 func (c *lruCache) serialize(w io.Writer) error {
 	enc := json.NewEncoder(w)
 	for item := c.tail.prev; item != c.head; item = item.prev {
-		record, err := newCacheItemJSON(item)
-		if err != nil {
-			return err
-		}
-		if err := enc.Encode(record); err != nil {
+		if err := enc.Encode(newCacheItemJSON(item)); err != nil {
 			return err
 		}
 	}
@@ -288,11 +275,11 @@ func (c *lruCache) deserialize(r io.Reader) error {
 			return err
 		}
 		// Skip bad (or incompatible) records
-		key, blob, ok := record.toCacheItem()
+		blob, ok := record.toCacheBlob()
 		if !ok {
 			continue
 		}
-		c.addKey(key, blob)
+		c.addKey(record.Key, blob)
 	}
 	return nil
 }

--- a/lru-cache_test.go
+++ b/lru-cache_test.go
@@ -26,6 +26,15 @@ func storedMsg(t *testing.T, item *cacheItem) *dns.Msg {
 	return m
 }
 
+// store puts an answer in the cache the way memoryBackend.Store does.
+func store(t *testing.T, c *lruCache, query *dns.Msg, answer *cacheAnswer) {
+	t.Helper()
+	key := lruKeyFromQuery(query)
+	blob, err := newCacheBlob(key, answer)
+	require.NoError(t, err)
+	c.addKey(key, blob)
+}
+
 func TestLRUAddGet(t *testing.T) {
 	c := newLRUCache(5)
 
@@ -55,7 +64,7 @@ func TestLRUAddGet(t *testing.T) {
 			answer: answer,
 		})
 		// Load into the cache
-		require.NoError(t, c.add(msg, answer))
+		store(t, c, msg, answer)
 	}
 
 	// Since the capacity is only 5 and we loaded 10, only the last 5 should be in there
@@ -109,7 +118,7 @@ func TestLRUKeyCD(t *testing.T) {
 
 	// Store an (unvalidated) answer for a CD=1 query.
 	cdAnswer := answerFor("cd.example.com.")
-	require.NoError(t, c.add(queryCD("cd.example.com.", true), cdAnswer))
+	store(t, c, queryCD("cd.example.com.", true), cdAnswer)
 
 	// A CD=0 lookup for the same name must NOT hit the CD=1 entry.
 	require.Nil(t, c.get(queryCD("cd.example.com.", false)),
@@ -120,7 +129,7 @@ func TestLRUKeyCD(t *testing.T) {
 
 	// Storing a CD=0 answer is kept separate from the CD=1 one.
 	plainAnswer := answerFor("cd.example.com.")
-	require.NoError(t, c.add(queryCD("cd.example.com.", false), plainAnswer))
+	store(t, c, queryCD("cd.example.com.", false), plainAnswer)
 	require.Equal(t, mustPack(t, plainAnswer.Msg), c.get(queryCD("cd.example.com.", false)).blob.message())
 	require.Equal(t, mustPack(t, cdAnswer.Msg), c.get(queryCD("cd.example.com.", true)).blob.message())
 	require.Equal(t, 2, c.size())
@@ -146,7 +155,7 @@ func TestLRUKeyECSMask(t *testing.T) {
 	c := newLRUCache(10)
 
 	answer24 := &cacheAnswer{Msg: new(dns.Msg)}
-	require.NoError(t, c.add(queryECS(24), answer24))
+	store(t, c, queryECS(24), answer24)
 
 	// Same address, different prefix length must be a distinct entry.
 	require.Nil(t, c.get(queryECS(16)),

--- a/lru-cache_test.go
+++ b/lru-cache_test.go
@@ -22,7 +22,7 @@ func storedMsg(t *testing.T, item *cacheItem) *dns.Msg {
 	t.Helper()
 	require.NotNil(t, item)
 	m := new(dns.Msg)
-	require.NoError(t, m.Unpack(blobMessage(item.blob)))
+	require.NoError(t, m.Unpack(item.blob.message()))
 	return m
 }
 
@@ -68,7 +68,7 @@ func TestLRUAddGet(t *testing.T) {
 	for _, item := range items[5:] {
 		cached := c.get(item.query)
 		require.NotNil(t, cached)
-		require.Equal(t, mustPack(t, item.answer.Msg), blobMessage(cached.blob))
+		require.Equal(t, mustPack(t, item.answer.Msg), cached.blob.message())
 	}
 
 	// Delete one of the items directly
@@ -77,7 +77,7 @@ func TestLRUAddGet(t *testing.T) {
 
 	// Use an iterator to delete two more
 	c.deleteFunc(func(item *cacheItem) bool {
-		name := blobKey(item.blob).Question.Name
+		name := item.blob.key().Question.Name
 		return name == "test8.com." || name == "test9.com."
 	})
 	require.Equal(t, 2, c.size())
@@ -116,13 +116,13 @@ func TestLRUKeyCD(t *testing.T) {
 		"CD=0 query must not be served the cached CD=1 response")
 
 	// The original CD=1 query still hits its own entry.
-	require.Equal(t, mustPack(t, cdAnswer.Msg), blobMessage(c.get(queryCD("cd.example.com.", true)).blob))
+	require.Equal(t, mustPack(t, cdAnswer.Msg), c.get(queryCD("cd.example.com.", true)).blob.message())
 
 	// Storing a CD=0 answer is kept separate from the CD=1 one.
 	plainAnswer := answerFor("cd.example.com.")
 	require.NoError(t, c.add(queryCD("cd.example.com.", false), plainAnswer))
-	require.Equal(t, mustPack(t, plainAnswer.Msg), blobMessage(c.get(queryCD("cd.example.com.", false)).blob))
-	require.Equal(t, mustPack(t, cdAnswer.Msg), blobMessage(c.get(queryCD("cd.example.com.", true)).blob))
+	require.Equal(t, mustPack(t, plainAnswer.Msg), c.get(queryCD("cd.example.com.", false)).blob.message())
+	require.Equal(t, mustPack(t, cdAnswer.Msg), c.get(queryCD("cd.example.com.", true)).blob.message())
 	require.Equal(t, 2, c.size())
 }
 

--- a/lru-cache_test.go
+++ b/lru-cache_test.go
@@ -9,6 +9,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mustPack returns the wire form of a message, which is what the cache stores.
+func mustPack(t *testing.T, m *dns.Msg) []byte {
+	t.Helper()
+	b, err := m.Pack()
+	require.NoError(t, err)
+	return b
+}
+
+// storedMsg decodes the message held by a cached item.
+func storedMsg(t *testing.T, item *cacheItem) *dns.Msg {
+	t.Helper()
+	require.NotNil(t, item)
+	m := new(dns.Msg)
+	require.NoError(t, m.Unpack(blobMessage(item.blob)))
+	return m
+}
+
 func TestLRUAddGet(t *testing.T) {
 	c := newLRUCache(5)
 
@@ -38,7 +55,7 @@ func TestLRUAddGet(t *testing.T) {
 			answer: answer,
 		})
 		// Load into the cache
-		c.add(msg, answer)
+		require.NoError(t, c.add(msg, answer))
 	}
 
 	// Since the capacity is only 5 and we loaded 10, only the last 5 should be in there
@@ -51,7 +68,7 @@ func TestLRUAddGet(t *testing.T) {
 	for _, item := range items[5:] {
 		cached := c.get(item.query)
 		require.NotNil(t, cached)
-		require.Equal(t, item.answer.Msg, cached.msg)
+		require.Equal(t, mustPack(t, item.answer.Msg), blobMessage(cached.blob))
 	}
 
 	// Delete one of the items directly
@@ -60,8 +77,8 @@ func TestLRUAddGet(t *testing.T) {
 
 	// Use an iterator to delete two more
 	c.deleteFunc(func(item *cacheItem) bool {
-		question := item.msg.Question[0]
-		return question.Name == "test8.com." || question.Name == "test9.com."
+		name := blobKey(item.blob).Question.Name
+		return name == "test8.com." || name == "test9.com."
 	})
 	require.Equal(t, 2, c.size())
 }
@@ -92,20 +109,20 @@ func TestLRUKeyCD(t *testing.T) {
 
 	// Store an (unvalidated) answer for a CD=1 query.
 	cdAnswer := answerFor("cd.example.com.")
-	c.add(queryCD("cd.example.com.", true), cdAnswer)
+	require.NoError(t, c.add(queryCD("cd.example.com.", true), cdAnswer))
 
 	// A CD=0 lookup for the same name must NOT hit the CD=1 entry.
 	require.Nil(t, c.get(queryCD("cd.example.com.", false)),
 		"CD=0 query must not be served the cached CD=1 response")
 
 	// The original CD=1 query still hits its own entry.
-	require.Equal(t, cdAnswer.Msg, c.get(queryCD("cd.example.com.", true)).msg)
+	require.Equal(t, mustPack(t, cdAnswer.Msg), blobMessage(c.get(queryCD("cd.example.com.", true)).blob))
 
 	// Storing a CD=0 answer is kept separate from the CD=1 one.
 	plainAnswer := answerFor("cd.example.com.")
-	c.add(queryCD("cd.example.com.", false), plainAnswer)
-	require.Equal(t, plainAnswer.Msg, c.get(queryCD("cd.example.com.", false)).msg)
-	require.Equal(t, cdAnswer.Msg, c.get(queryCD("cd.example.com.", true)).msg)
+	require.NoError(t, c.add(queryCD("cd.example.com.", false), plainAnswer))
+	require.Equal(t, mustPack(t, plainAnswer.Msg), blobMessage(c.get(queryCD("cd.example.com.", false)).blob))
+	require.Equal(t, mustPack(t, cdAnswer.Msg), blobMessage(c.get(queryCD("cd.example.com.", true)).blob))
 	require.Equal(t, 2, c.size())
 }
 
@@ -129,7 +146,7 @@ func TestLRUKeyECSMask(t *testing.T) {
 	c := newLRUCache(10)
 
 	answer24 := &cacheAnswer{Msg: new(dns.Msg)}
-	c.add(queryECS(24), answer24)
+	require.NoError(t, c.add(queryECS(24), answer24))
 
 	// Same address, different prefix length must be a distinct entry.
 	require.Nil(t, c.get(queryECS(16)),


### PR DESCRIPTION
Follow-on to #608, and the change the [storage investigation](https://claude.ai/code/artifact/bca96b44-a78a-438f-b9e3-33abea32ed43) recommended. The memory backend now holds each entry as one packed byte slice instead of a live `dns.Msg`.

Scope is memory only. **The cache file format is unchanged and stays JSON**, so this is a drop-in swap of how entries are held in RAM. A raw on-disk format is the obvious next step but is not in here.

## Why

An entry used to be a node pointing at an unpacked `dns.Msg`: about a dozen separately allocated objects, all of them traced by the collector on every cycle, for a record that is only ever read back out whole. A `[]byte` carries no pointers, so the collector skips its contents entirely.

| | master | this branch | |
|---|---|---|---|
| heap per entry | 611.2 B | 290.4 B | -53% |
| heap objects per entry | 11.70 | 2.00 | -83% |
| GC CPU per cycle, 20k entries live | 14.6 ms | 3.2 ms | -78% |
| cache file write, 20k records | 66.0 ms | 46.4 ms | -30% |
| lookup | 1.27 us / 6 allocs | 1.89 us / 12 allocs | +49% |
| store | 1.12 us / 6 allocs | 1.40 us / 1 alloc | +25% |

Measured on an idle i7-7600U over 20 000 mixed answers (single-A, multi-A, CNAME chain, NXDOMAIN), through `memoryBackend.Store` and `Lookup`, with each side doing what its own `Cache.Resolve` does. Ten runs per side through benchstat, every difference above at p < 0.01.

GC is reported as CPU seconds from `/cpu/classes/gc/total`, accumulated over 60 forced cycles. Timing `runtime.GC()` in a benchmark loop turns out to be hopelessly noisy for this (+/-80% across runs, on an idle machine as much as a busy one); the CPU counter reproduces to within a few percent, and agrees with the object count, which is deterministic.

The lookup cost is `Unpack` replacing `Msg.Copy`, and it is the one real regression. At the query rates the constrained devices this targets actually see, roughly 100/s, it works out to about 0.06% of a core. The GC saving is 11.4 ms of CPU per cycle, paid whether or not traffic is flowing.

## The blob

```
0      version
1      meta flags (prefetch-eligible)
2..9   timestamp, unix nanoseconds
10..17 expiry, unix nanoseconds
18     key flags (DO, CD)          <- key region starts
19..20 qtype
21..22 qclass
23     ECS source prefix length
24     length of the ECS address
25     length of the question name
26..   ECS address, then question name
       <- key region ends, packed message follows
```

The key fields are contiguous and separated from the volatile ones, so a lookup can compare them as one span and a future on-disk format can hash the same bytes. Metadata sits at fixed offsets and is read without decoding the key or the message.

A lookup hashes the key as before, then compares the blob's key bytes. Comparing a byte slice against a string does not allocate, so the hit path stays allocation-free up to the `Unpack`.

## Two consequences of blobs being immutable

**The copy leaves the critical section.** `Lookup` takes only the slice reference under `b.mu` and decodes after releasing it. Replacing an entry allocates a new blob rather than writing into the old one, so a reader mid-decode is unaffected. This also settles the audit's finding #04.

**Backends no longer retain the message.** `Store` encodes and is done with it, so `Cache.Resolve` stops making the defensive `a.Copy()` it used to. That accounts for the drop from 6 allocations to 1 on the store path. The `CacheBackend` interface now states the rule explicitly; it is what the Redis backend already assumed and documented on its own `Store`.

## Tests

`TestBlobKeyComparisonCoversEveryField` walks every field of the key and asserts a lookup misses when it differs. This exists because the investigation prototype had a real bug here, comparing from byte 18 onward and so ignoring the DO and CD bits that share a byte. I verified the test catches it by reintroducing the defect: the `do` and `cd` subtests fail, and so does `TestLRUKeyCD`.

Also added: blob round-trip with and without ECS, rejection of a question name too long to encode, `TestMemoryBackendDoesNotShareMessages` covering the ownership rule in both directions, and a concurrent store/lookup test that runs clean under `-race`.

The serialization tests from #607 pass untouched, including `TestLRUSerializeFormatStable`, which pins the exact bytes of the cache file. That is the evidence the format really is unchanged.

## Not in this change

- The raw on-disk format. The investigation measured it at 2.2x smaller, 165x faster to write and 31x faster to read, and the blob layout here is built to make it straightforward.
- DNS name compression on the stored copy, worth another 41% off the wire bytes. It needs `Msg.Compress` set on a message that is also being returned to the caller, which wants more care than this change should carry.
