### PR TITLE
Give every static response its own copy of the records

### DIFF
--- a/message.go
+++ b/message.go
@@ -112,6 +112,20 @@ func ptr(q *dns.Msg, names []string) *dns.Msg {
 	return a
 }
 
+// Returns a deep copy of a set of records. Used where records are handed
+// out from state that is shared between queries, since consumers of a
+// response, packing it included, can modify the records in it.
+func copyRRs(rrs []dns.RR) []dns.RR {
+	if len(rrs) == 0 {
+		return nil
+	}
+	out := make([]dns.RR, 0, len(rrs))
+	for _, rr := range rrs {
+		out = append(out, dns.Copy(rr))
+	}
+	return out
+}
+
 // Changes the UDP size in the EDNS0 record and returns a
 // copy of the query. Adds an OPT record if there isn't one
 // already. If size is 0, the original query is returned.

--- a/static.go
+++ b/static.go
@@ -70,15 +70,16 @@ func (r *StaticResolver) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	answer.Authoritative = true      // we made that reply up
 	log := logger(r.id, q, ci)
 
+	// Every response gets its own copy of the records. They're shared state and
+	// whatever handles the response downstream is free to modify them.
+	answer.Answer = copyRRs(r.answer)
+	answer.Ns = copyRRs(r.ns)
+	answer.Extra = copyRRs(r.extra)
+
 	// Update the name of every answer record to match that of the query
-	answer.Answer = make([]dns.RR, 0, len(r.answer))
-	for _, rr := range r.answer {
-		r := dns.Copy(rr)
-		r.Header().Name = qName(q)
-		answer.Answer = append(answer.Answer, r)
+	for _, rr := range answer.Answer {
+		rr.Header().Name = qName(q)
 	}
-	answer.Ns = r.ns
-	answer.Extra = r.extra
 	answer.Rcode = r.rcode
 	answer.Truncated = r.truncate
 

--- a/static_test.go
+++ b/static_test.go
@@ -35,3 +35,50 @@ func TestStaticResolver(t *testing.T) {
 	require.Equal(t, "example.com.", a.Ns[0].Header().Name)
 	require.Equal(t, "ns1.example.com.", a.Extra[0].Header().Name)
 }
+
+// A response must not be modified by any query that follows it. The number of
+// Extra records matters here: append grows a nil slice 1 -> 2 -> 4, so three
+// records leave spare capacity for SetEdns0 to write into.
+func TestStaticResolverResponseIsolation(t *testing.T) {
+	tpl, err := NewEDNS0EDETemplate(dns.ExtendedErrorCodeBlocked, "blocked: {{ .Question }}")
+	require.NoError(t, err)
+
+	opt := StaticResolverOptions{
+		Answer: []string{"IN A 1.2.3.4"},
+		NS:     []string{"example.com. 18000 IN NS ns1.example.com."},
+		Extra: []string{
+			"ns1.example.com. IN A 1.1.1.1",
+			"ns2.example.com. IN A 1.1.1.2",
+			"ns3.example.com. IN A 1.1.1.3",
+		},
+		EDNS0EDETemplate: tpl,
+	}
+	r, err := NewStaticResolver("test-static", opt)
+	require.NoError(t, err)
+
+	resolve := func(name string) *dns.Msg {
+		q := new(dns.Msg)
+		q.SetQuestion(name, dns.TypeA)
+		a, err := r.Resolve(q, ClientInfo{})
+		require.NoError(t, err)
+		return a
+	}
+
+	edeText := func(a *dns.Msg) string {
+		opt := a.IsEdns0()
+		require.NotNil(t, opt)
+		require.Len(t, opt.Option, 1)
+		return opt.Option[0].(*dns.EDNS0_EDE).ExtraText
+	}
+
+	a1 := resolve("first.example.com.")
+	require.Equal(t, "blocked: first.example.com.", edeText(a1))
+
+	a2 := resolve("second.example.com.")
+	require.Equal(t, "blocked: second.example.com.", edeText(a2))
+
+	// The second query must have left the first response alone
+	require.Equal(t, "blocked: first.example.com.", edeText(a1))
+	require.Equal(t, "first.example.com.", a1.Answer[0].Header().Name)
+	require.Len(t, a1.Extra, len(opt.Extra)+1)
+}


### PR DESCRIPTION
Fixes #611.

`StaticResolver.Resolve` assigned its own template slices straight onto every response:

```go
answer.Ns = r.ns
answer.Extra = r.extra
```

Only the Answer section was deep-copied, and only because the per-query name rewrite forced it. NS and Extra were shared with every response the resolver ever produced.

That matters because a response is not read-only downstream:

- `EDNS0EDETemplate.Apply` calls `msg.SetEdns0`, which appends an OPT to Extra. When the configured Extra has spare capacity (three records give len 3, cap 4), the append writes into the shared backing array and rewrites the OPT of a response that has already been handed downstream. One client's response ends up carrying the EDE text naming another client's question.
- `dns.Msg.Pack` writes the extended rcode into the OPT record every time.
- TTL, ECS and padding modifiers all walk Ns and Extra and write to the records they find.
- Two goroutines resolving concurrently write the same slot, which the race detector flags.

The fix copies all three sections per query, the same treatment Answer already had, via a new `copyRRs` helper in `message.go`. `dns.Copy` deep-copies `OPT.Option`, so a configured OPT record no longer accumulates an EDE option per query for the life of the process. `StaticTemplateResolver` already built fresh records for all three sections and needed no change.

`TestStaticResolverResponseIsolation` covers it, reproducing the cross-contamination with three Extra records and an EDE template. It fails on the parent commit.