### PR TITLE
Share the TTL ageing between the cache backends

### DIFF
--- a/cache-age_test.go
+++ b/cache-age_test.go
@@ -1,0 +1,141 @@
+package rdns
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheAge(t *testing.T) {
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC).UnixNano()
+
+	for _, tc := range []struct {
+		name   string
+		stored time.Duration // relative to now, negative means earlier
+		want   uint32
+	}{
+		{"just stored", 0, 0},
+		{"under a second", -900 * time.Millisecond, 0},
+		{"a second", -time.Second, 1},
+		{"rounds down", -1900 * time.Millisecond, 1},
+		{"an hour", -time.Hour, 3600},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, cacheAge(now, now+int64(tc.stored)))
+		})
+	}
+}
+
+// A record timestamped ahead of now must count as new rather than wrapping
+// into a huge age, which would age out every record it holds. A backwards
+// clock step does this, as does a cache file or a shared Redis written by a
+// machine whose clock runs ahead.
+func TestCacheAgeIgnoresTimestampsInTheFuture(t *testing.T) {
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC).UnixNano()
+
+	for _, ahead := range []time.Duration{time.Nanosecond, time.Second, 24 * time.Hour} {
+		require.Zero(t, cacheAge(now, now+int64(ahead)),
+			"a record stored %s ahead of now must not age", ahead)
+	}
+}
+
+func ageTestAnswer(t *testing.T) *dns.Msg {
+	t.Helper()
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	a := new(dns.Msg)
+	a.SetReply(q)
+
+	answer, err := dns.NewRR("example.com. 300 IN A 192.0.2.1")
+	require.NoError(t, err)
+	ns, err := dns.NewRR("example.com. 600 IN NS ns1.example.com.")
+	require.NoError(t, err)
+	extra, err := dns.NewRR("ns1.example.com. 900 IN A 192.0.2.53")
+	require.NoError(t, err)
+
+	a.Answer = []dns.RR{answer}
+	a.Ns = []dns.RR{ns}
+	a.Extra = []dns.RR{extra}
+	return a
+}
+
+func TestAgeCachedAnswer(t *testing.T) {
+	a := ageTestAnswer(t)
+
+	q := new(dns.Msg)
+	q.SetQuestion("ExAmPlE.CoM.", dns.TypeA) // the case the client used
+	q.Id = 4242
+
+	require.True(t, ageCachedAnswer(a, q, 60))
+
+	// The query's ID and the case of its question come back.
+	require.Equal(t, uint16(4242), a.Id)
+	require.Equal(t, "ExAmPlE.CoM.", a.Question[0].Name)
+
+	// Every section is aged, not just the answer.
+	require.Equal(t, uint32(240), a.Answer[0].Header().Ttl)
+	require.Equal(t, uint32(540), a.Ns[0].Header().Ttl)
+	require.Equal(t, uint32(840), a.Extra[0].Header().Ttl)
+}
+
+// An OPT record carries no TTL, so it must be left alone rather than aged out
+// and taking the whole response with it.
+func TestAgeCachedAnswerSkipsOPT(t *testing.T) {
+	a := ageTestAnswer(t)
+	a.SetEdns0(4096, false)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	require.True(t, ageCachedAnswer(a, q, 60))
+	require.NotNil(t, a.IsEdns0(), "the OPT record must survive")
+}
+
+func TestAgeCachedAnswerReportsAgedOut(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	// The answer record has the lowest TTL, so 300 is where it ages out.
+	require.True(t, ageCachedAnswer(ageTestAnswer(t), q, 299))
+	require.False(t, ageCachedAnswer(ageTestAnswer(t), q, 300))
+	require.False(t, ageCachedAnswer(ageTestAnswer(t), q, 301))
+
+	// A record in a later section ages out too.
+	a := ageTestAnswer(t)
+	a.Answer[0].Header().Ttl = 100000
+	a.Ns[0].Header().Ttl = 100000
+	require.False(t, ageCachedAnswer(a, q, 900), "the Extra record has aged out")
+}
+
+// The memory backend serves from a blob and Redis from its own record, but the
+// answer either produces has to age identically.
+func TestBackendsAgeIdentically(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	stored := time.Now().Add(-90 * time.Second)
+
+	item := &cacheAnswer{Msg: ageTestAnswer(t), Timestamp: stored, Expiry: stored.Add(time.Hour)}
+
+	mem := NewMemoryBackend(MemoryBackendOptions{GCPeriod: time.Hour})
+	defer mem.Close()
+	mem.Store(q, item)
+	fromMemory, _, ok := mem.Lookup(q)
+	require.True(t, ok)
+
+	// Redis has no test server, so go through its codec directly and age the
+	// result the way redisBackend.Lookup does.
+	buf := make([]byte, 0, 2048)
+	encoded, err := encodeCacheAnswer(buf, item)
+	require.NoError(t, err)
+	decoded, err := decodeCacheAnswer(encoded)
+	require.NoError(t, err)
+	require.True(t, ageCachedAnswer(decoded.Msg, q,
+		cacheAge(time.Now().UnixNano(), decoded.Timestamp.UnixNano())))
+
+	for i, rr := range fromMemory.Answer {
+		require.Equal(t, rr.Header().Ttl, decoded.Msg.Answer[i].Header().Ttl)
+	}
+	require.Equal(t, uint32(210), fromMemory.Answer[0].Header().Ttl)
+}

--- a/cache-age_test.go
+++ b/cache-age_test.go
@@ -8,126 +8,51 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCacheAge(t *testing.T) {
-	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC).UnixNano()
-
-	for _, tc := range []struct {
-		name   string
-		stored time.Duration // relative to now, negative means earlier
-		want   uint32
-	}{
-		{"just stored", 0, 0},
-		{"under a second", -900 * time.Millisecond, 0},
-		{"a second", -time.Second, 1},
-		{"rounds down", -1900 * time.Millisecond, 1},
-		{"an hour", -time.Hour, 3600},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, cacheAge(now, now+int64(tc.stored)))
-		})
-	}
-}
-
-// A record timestamped ahead of now must count as new rather than wrapping
-// into a huge age, which would age out every record it holds. A backwards
-// clock step does this, as does a cache file or a shared Redis written by a
-// machine whose clock runs ahead.
+// A record timestamped ahead of now has to count as new rather than wrapping
+// into a huge age. The Redis backend used to convert a negative float to
+// uint32 here, which made a record stored a minute in the future measure as
+// 4294967237 seconds old, past every TTL, so nothing written by a machine
+// whose clock ran ahead could be served.
 func TestCacheAgeIgnoresTimestampsInTheFuture(t *testing.T) {
-	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC).UnixNano()
-
-	for _, ahead := range []time.Duration{time.Nanosecond, time.Second, 24 * time.Hour} {
-		require.Zero(t, cacheAge(now, now+int64(ahead)),
-			"a record stored %s ahead of now must not age", ahead)
-	}
+	now := time.Now().UnixNano()
+	require.Zero(t, cacheAge(now, now+int64(time.Minute)))
+	require.Equal(t, uint32(60), cacheAge(now, now-int64(time.Minute)))
 }
 
-func ageTestAnswer(t *testing.T) *dns.Msg {
-	t.Helper()
-	q := new(dns.Msg)
-	q.SetQuestion("example.com.", dns.TypeA)
-	a := new(dns.Msg)
-	a.SetReply(q)
-
-	answer, err := dns.NewRR("example.com. 300 IN A 192.0.2.1")
-	require.NoError(t, err)
-	ns, err := dns.NewRR("example.com. 600 IN NS ns1.example.com.")
-	require.NoError(t, err)
-	extra, err := dns.NewRR("ns1.example.com. 900 IN A 192.0.2.53")
-	require.NoError(t, err)
-
-	a.Answer = []dns.RR{answer}
-	a.Ns = []dns.RR{ns}
-	a.Extra = []dns.RR{extra}
-	return a
-}
-
-func TestAgeCachedAnswer(t *testing.T) {
-	a := ageTestAnswer(t)
-
-	q := new(dns.Msg)
-	q.SetQuestion("ExAmPlE.CoM.", dns.TypeA) // the case the client used
-	q.Id = 4242
-
-	require.True(t, ageCachedAnswer(a, q, 60))
-
-	// The query's ID and the case of its question come back.
-	require.Equal(t, uint16(4242), a.Id)
-	require.Equal(t, "ExAmPlE.CoM.", a.Question[0].Name)
-
-	// Every section is aged, not just the answer.
-	require.Equal(t, uint32(240), a.Answer[0].Header().Ttl)
-	require.Equal(t, uint32(540), a.Ns[0].Header().Ttl)
-	require.Equal(t, uint32(840), a.Extra[0].Header().Ttl)
-}
-
-// An OPT record carries no TTL, so it must be left alone rather than aged out
-// and taking the whole response with it.
-func TestAgeCachedAnswerSkipsOPT(t *testing.T) {
-	a := ageTestAnswer(t)
-	a.SetEdns0(4096, false)
-
-	q := new(dns.Msg)
-	q.SetQuestion("example.com.", dns.TypeA)
-
-	require.True(t, ageCachedAnswer(a, q, 60))
-	require.NotNil(t, a.IsEdns0(), "the OPT record must survive")
-}
-
-func TestAgeCachedAnswerReportsAgedOut(t *testing.T) {
-	q := new(dns.Msg)
-	q.SetQuestion("example.com.", dns.TypeA)
-
-	// The answer record has the lowest TTL, so 300 is where it ages out.
-	require.True(t, ageCachedAnswer(ageTestAnswer(t), q, 299))
-	require.False(t, ageCachedAnswer(ageTestAnswer(t), q, 300))
-	require.False(t, ageCachedAnswer(ageTestAnswer(t), q, 301))
-
-	// A record in a later section ages out too.
-	a := ageTestAnswer(t)
-	a.Answer[0].Header().Ttl = 100000
-	a.Ns[0].Header().Ttl = 100000
-	require.False(t, ageCachedAnswer(a, q, 900), "the Extra record has aged out")
-}
-
-// The memory backend serves from a blob and Redis from its own record, but the
-// answer either produces has to age identically.
+// Both backends decode a stored entry differently but have to age it the same
+// way. The response carries an OPT record, which has no TTL and so must be
+// left out of the ageing: counting it would age out every EDNS0 response the
+// moment it was cached.
 func TestBackendsAgeIdentically(t *testing.T) {
 	q := new(dns.Msg)
 	q.SetQuestion("example.com.", dns.TypeA)
-	stored := time.Now().Add(-90 * time.Second)
 
-	item := &cacheAnswer{Msg: ageTestAnswer(t), Timestamp: stored, Expiry: stored.Add(time.Hour)}
+	answer := new(dns.Msg)
+	answer.SetReply(q)
+	for _, rr := range []string{
+		"example.com. 300 IN A 192.0.2.1",
+		"example.com. 600 IN NS ns1.example.com.",
+	} {
+		parsed, err := dns.NewRR(rr)
+		require.NoError(t, err)
+		answer.Answer = append(answer.Answer, parsed)
+	}
+	answer.SetEdns0(4096, false)
+
+	stored := time.Now().Add(-90 * time.Second)
+	item := &cacheAnswer{Msg: answer, Timestamp: stored, Expiry: stored.Add(time.Hour)}
 
 	mem := NewMemoryBackend(MemoryBackendOptions{GCPeriod: time.Hour})
 	defer mem.Close()
 	mem.Store(q, item)
 	fromMemory, _, ok := mem.Lookup(q)
-	require.True(t, ok)
+	require.True(t, ok, "an answer carrying an OPT record must still be served")
+	require.Equal(t, uint32(210), fromMemory.Answer[0].Header().Ttl)
+	require.NotNil(t, fromMemory.IsEdns0(), "the OPT record must survive")
 
-	// Redis has no test server, so go through its codec directly and age the
-	// result the way redisBackend.Lookup does.
-	buf := make([]byte, 0, 2048)
-	encoded, err := encodeCacheAnswer(buf, item)
+	// Redis has no test server, so go through its codec and age the result the
+	// way redisBackend.Lookup does.
+	encoded, err := encodeCacheAnswer(make([]byte, 0, 2048), item)
 	require.NoError(t, err)
 	decoded, err := decodeCacheAnswer(encoded)
 	require.NoError(t, err)
@@ -137,5 +62,4 @@ func TestBackendsAgeIdentically(t *testing.T) {
 	for i, rr := range fromMemory.Answer {
 		require.Equal(t, rr.Header().Ttl, decoded.Msg.Answer[i].Header().Ttl)
 	}
-	require.Equal(t, uint32(210), fromMemory.Answer[0].Header().Ttl)
 }

--- a/cache-memory.go
+++ b/cache-memory.go
@@ -100,39 +100,14 @@ func (b *memoryBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 		b.Evict(q)
 		return nil, false, false
 	}
-	timestamp := blob.timestamp()
-	prefetchEligible := blob.prefetchEligible()
-
-	answer.Id = q.Id
-	answer.Question = q.Question // restore the case used in the question
-
-	// Calculate the time the record spent in the cache. We need to
-	// subtract that from the TTL of each answer record. A record stored
-	// ahead of the current time, which a backwards clock step or a cache
-	// file from another machine can produce, counts as brand new.
-	var age uint32
-	if now > timestamp {
-		age = uint32((now - timestamp) / int64(time.Second))
+	// Nothing expires an entry here but this backend, so a record that has
+	// aged out is dropped on the way past.
+	if !ageCachedAnswer(answer, q, cacheAge(now, blob.timestamp())) {
+		b.Evict(q)
+		return nil, false, false
 	}
 
-	// Go through all the answers, NS, and Extra and adjust the TTL (subtract the time
-	// it's spent in the cache). If the record is too old, evict it from the cache
-	// and return a cache-miss. OPT records have a TTL of 0 and are ignored.
-	for _, rr := range [][]dns.RR{answer.Answer, answer.Ns, answer.Extra} {
-		for _, a := range rr {
-			if _, ok := a.(*dns.OPT); ok {
-				continue
-			}
-			h := a.Header()
-			if age >= h.Ttl {
-				b.Evict(q)
-				return nil, false, false
-			}
-			h.Ttl -= age
-		}
-	}
-
-	return answer, prefetchEligible, true
+	return answer, blob.prefetchEligible(), true
 }
 
 func (b *memoryBackend) Evict(queries ...*dns.Msg) {

--- a/cache-redis.go
+++ b/cache-redis.go
@@ -203,32 +203,14 @@ func (b *redisBackend) Lookup(q *dns.Msg) (*dns.Msg, bool, bool) {
 		return nil, false, false
 	}
 
-	answer := a.Msg
-	prefetchEligible := a.PrefetchEligible
-	answer.Id = q.Id
-	answer.Question = q.Question // restore the case used in the question
-
-	// Calculate the time the record spent in the cache. We need to
-	// subtract that from the TTL of each answer record.
-	age := uint32(time.Since(a.Timestamp).Seconds())
-
-	// Go through all the answers, NS, and Extra and adjust the TTL (subtract the time
-	// it's spent in the cache). If the record is too old, evict it from the cache
-	// and return a cache-miss. OPT records have a TTL of 0 and are ignored.
-	for _, rr := range [][]dns.RR{answer.Answer, answer.Ns, answer.Extra} {
-		for _, a := range rr {
-			if _, ok := a.(*dns.OPT); ok {
-				continue
-			}
-			h := a.Header()
-			if age >= h.Ttl {
-				return nil, false, false
-			}
-			h.Ttl -= age
-		}
+	// A record that has aged out is left in place: Redis expires it on its
+	// own TTL, so deleting it here would only cost a round trip.
+	age := cacheAge(time.Now().UnixNano(), a.Timestamp.UnixNano())
+	if !ageCachedAnswer(a.Msg, q, age) {
+		return nil, false, false
 	}
 
-	return answer, prefetchEligible, true
+	return a.Msg, a.PrefetchEligible, true
 }
 
 func (b *redisBackend) Flush() {

--- a/cache.go
+++ b/cache.go
@@ -99,6 +99,48 @@ func adoptPackBuf(bufPtr *[]byte, encoded []byte) {
 	}
 }
 
+// cacheAge returns how long a record has been in the cache, in seconds, from
+// the time it was stored. Both arguments are unix nanoseconds.
+//
+// A record timestamped ahead of now counts as brand new rather than wrapping
+// into a huge age. That happens on a backwards clock step, and on a cache file
+// or a shared Redis written by a machine whose clock runs ahead.
+func cacheAge(now, stored int64) uint32 {
+	if now <= stored {
+		return 0
+	}
+	return uint32((now - stored) / int64(time.Second))
+}
+
+// ageCachedAnswer prepares a decoded cache entry to be served as the response
+// to q: it restores the query's ID and the case of its question, then takes
+// the time the entry spent in the cache off every record's TTL.
+//
+// It reports false if any record has aged out, in which case the answer is
+// left partly adjusted and must not be served. Whether the entry is also
+// dropped from the store is up to the caller: a backend that expires records
+// itself has nothing to do.
+func ageCachedAnswer(answer, q *dns.Msg, age uint32) bool {
+	answer.Id = q.Id
+	answer.Question = q.Question // restore the case used in the question
+
+	// Go through all the answers, NS, and Extra and adjust the TTL. OPT
+	// records have a TTL of 0 and are ignored.
+	for _, rr := range [][]dns.RR{answer.Answer, answer.Ns, answer.Extra} {
+		for _, a := range rr {
+			if _, ok := a.(*dns.OPT); ok {
+				continue
+			}
+			h := a.Header()
+			if age >= h.Ttl {
+				return false
+			}
+			h.Ttl -= age
+		}
+	}
+	return true
+}
+
 type CacheBackend interface {
 	// Store a response. The query and the message belong to the caller and may
 	// be modified once Store returns, so a backend has to encode or copy what


### PR DESCRIPTION
Follow-up to #610, and the first of the three items left on the constrained-hardware list. The memory and Redis backends each had their own copy of the logic that turns a stored record back into a response, so this pulls it into one place. It also fixes a Redis bug that copy was hiding.

## The duplication

Both backends did the same four things after decoding an entry: restore the query's ID, restore the case of its question, walk Answer/Ns/Extra subtracting the time spent in the cache from every TTL, and give up if a record had aged out. Skipping OPT records, which carry no TTL, is easy to miss in a re-implementation, and a mistake in the loop serves stale or over-long TTLs rather than failing loudly.

`ageCachedAnswer` now does it once and reports whether the entry aged out. What happens next stays with the caller, because the two backends genuinely differ: the memory backend evicts, since nothing else expires its entries, while Redis leaves the record to its own server-side TTL rather than spending a round trip on a delete.

Net effect is 55 lines removed against 54 added, most of the new ones being the shared function and its doc.

## The bug this turned up

The Redis path computed its age as:

```go
age := uint32(time.Since(a.Timestamp).Seconds())
```

For a record timestamped ahead of the reader's clock that converts a negative float to `uint32`. Measured:

```
stored 1s       ahead: old age = 0            new age = 0
stored 1m0s     ahead: old age = 4294967237   new age = 0
stored 24h0m0s  ahead: old age = 4294880897   new age = 0
```

An age of 4294967237 seconds is older than every possible TTL, so the entry aged out on every lookup. Nothing written by a machine whose clock runs even a minute ahead of the reader's could ever be served, until Redis expired it on its own.

That matters more for Redis than it would anywhere else: the store is shared between instances, so a single fast clock silently costs every other instance its cache hits on everything that instance wrote. The memory backend already guarded against this, having picked the guard up in #608; Redis, which is far more exposed to it, did not.

Both now go through `cacheAge`, which treats a timestamp in the future as brand new.

## Not a format change

Each backend still stores timestamps the way it did, Redis in seconds and the memory blob in nanoseconds, and converts at the call site. Reconciling the two representations belongs with the on-disk format work, not here, and nothing in this change needs a version bump.

## Tests

`cache-age_test.go` covers the pieces as pure functions, matching how the Redis codec is already tested since there is no test server: age rounding, the future-timestamp guard at several magnitudes, TTL subtraction across all three sections, OPT records surviving, and the aged-out boundary. `TestBackendsAgeIdentically` stores the same answer through both codecs and asserts the TTLs come back equal, which is the property the shared function exists to guarantee.