### PR TITLE
Add build tags to leave out redis and lua

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,3 +26,11 @@ jobs:
 
     - name: Test
       run: go test -race ./...
+
+    # The reduced release builds replace the Redis backend and the Lua
+    # resolver with stubs. Nothing else exercises those, so build and test
+    # them here or they break unnoticed.
+    - name: Build and test without optional features
+      run: |
+        go build -v -tags nolua,noredis ./...
+        go test -tags nolua,noredis ./...

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,12 +70,52 @@ builds:
     gomips:
       - softfloat
 
+  # Same small-device targets again, built without the Redis cache backend
+  # and without Lua. Those two dependencies are about a third of the binary,
+  # and neither is likely to be used on a router with 16MB of flash. The
+  # config options remain, a config that uses them fails at startup with a
+  # message saying the build doesn't support them.
+  - id: minimal
+    binary: routedns
+    main: ./cmd/routedns/
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    tags:
+      - nolua
+      - noredis
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+    goarch:
+      - arm
+      - arm64
+      - mips
+      - mipsle
+    goarm:
+      - "6"
+      - "7"
+    gomips:
+      - softfloat
+
 # Upload plain binaries named like the previous handcrafted releases
 # (routedns-linux-amd64, routedns-linux-armv7, ...) so existing download
-# links keep working.
+# links keep working. The reduced builds carry a -minimal suffix.
 archives:
-  - formats: [binary]
+  - id: default
+    ids:
+      - packaged
+      - embedded
+    formats: [binary]
     name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}'
+
+  - id: minimal
+    ids:
+      - minimal
+    formats: [binary]
+    name_template: '{{ .ProjectName }}-minimal-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}'
 
 nfpms:
   - package_name: routedns

--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ cd routedns/cmd/routedns && go install
 
 Pre-built binaries for Linux (amd64, arm64, armv6/armv7 for Raspberry Pi, mips/mipsle softfloat for OpenWrt routers), macOS (amd64, arm64), FreeBSD, and Windows are available on the [GitHub Releases](https://github.com/folbricht/routedns/releases) page.
 
+### Minimal builds
+
+Two of the larger dependencies can be left out at build time with Go build tags:
+
+| Tag | Leaves out |
+| --- | --- |
+| `noredis` | The `redis` cache backend |
+| `nolua` | `lua` groups |
+
+Together they take a linux/mipsle binary from 23.5MB to 17.0MB, which matters on a router with 16MB of flash. Releases include `routedns-minimal-linux-*` binaries built with both tags for arm, arm64, mips and mipsle. To build one:
+
+```text
+go build -tags nolua,noredis -ldflags="-s -w" -o routedns ./cmd/routedns
+```
+
+Configuration is unaffected, all options are still parsed. A config that asks for a feature the binary was built without fails at startup with an error naming it.
+
 ### Linux packages
 
 Releases include deb, rpm, apk, and Arch Linux packages for amd64, arm64, and armv7. They install the binary to `/usr/bin/routedns`, a default configuration to `/etc/routedns/config.toml`, and a systemd service:

--- a/cache-age_test.go
+++ b/cache-age_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,49 +16,4 @@ func TestCacheAgeIgnoresTimestampsInTheFuture(t *testing.T) {
 	now := time.Now().UnixNano()
 	require.Zero(t, cacheAge(now, now+int64(time.Minute)))
 	require.Equal(t, uint32(60), cacheAge(now, now-int64(time.Minute)))
-}
-
-// Both backends decode a stored entry differently but have to age it the same
-// way. The response carries an OPT record, which has no TTL and so must be
-// left out of the ageing: counting it would age out every EDNS0 response the
-// moment it was cached.
-func TestBackendsAgeIdentically(t *testing.T) {
-	q := new(dns.Msg)
-	q.SetQuestion("example.com.", dns.TypeA)
-
-	answer := new(dns.Msg)
-	answer.SetReply(q)
-	for _, rr := range []string{
-		"example.com. 300 IN A 192.0.2.1",
-		"example.com. 600 IN NS ns1.example.com.",
-	} {
-		parsed, err := dns.NewRR(rr)
-		require.NoError(t, err)
-		answer.Answer = append(answer.Answer, parsed)
-	}
-	answer.SetEdns0(4096, false)
-
-	stored := time.Now().Add(-90 * time.Second)
-	item := &cacheAnswer{Msg: answer, Timestamp: stored, Expiry: stored.Add(time.Hour)}
-
-	mem := NewMemoryBackend(MemoryBackendOptions{GCPeriod: time.Hour})
-	defer mem.Close()
-	mem.Store(q, item)
-	fromMemory, _, ok := mem.Lookup(q)
-	require.True(t, ok, "an answer carrying an OPT record must still be served")
-	require.Equal(t, uint32(210), fromMemory.Answer[0].Header().Ttl)
-	require.NotNil(t, fromMemory.IsEdns0(), "the OPT record must survive")
-
-	// Redis has no test server, so go through its codec and age the result the
-	// way redisBackend.Lookup does.
-	encoded, err := encodeCacheAnswer(make([]byte, 0, 2048), item)
-	require.NoError(t, err)
-	decoded, err := decodeCacheAnswer(encoded)
-	require.NoError(t, err)
-	require.True(t, ageCachedAnswer(decoded.Msg, q,
-		cacheAge(time.Now().UnixNano(), decoded.Timestamp.UnixNano())))
-
-	for i, rr := range fromMemory.Answer {
-		require.Equal(t, rr.Header().Ttl, decoded.Msg.Answer[i].Header().Ttl)
-	}
 }

--- a/cache-redis-disabled.go
+++ b/cache-redis-disabled.go
@@ -1,0 +1,12 @@
+//go:build noredis
+
+package rdns
+
+import "errors"
+
+// NewRedisBackend replaces the real backend in builds made with the "noredis"
+// tag, which leave out the Redis client. A configuration asking for the redis
+// cache backend fails at startup rather than silently falling back to memory.
+func NewRedisBackend(opt RedisBackendOptions) (CacheBackend, error) {
+	return nil, errors.New("this build does not support the redis cache backend")
+}

--- a/cache-redis-options.go
+++ b/cache-redis-options.go
@@ -1,0 +1,21 @@
+package rdns
+
+import "time"
+
+// RedisBackendOptions holds the connection settings for the Redis cache
+// backend. The fields mirror those of redis.Options so that callers don't
+// need to import the Redis client, which is what allows the backend itself
+// to be left out of a build with the "noredis" tag. This file is built
+// either way, so the config layer in cmd/routedns compiles unchanged.
+type RedisBackendOptions struct {
+	Network         string // Network type, "tcp" or "unix"
+	Address         string // Address of the Redis server
+	Username        string
+	Password        string
+	DB              int    // Database to select after connecting
+	KeyPrefix       string // Prefix for every cache entry
+	MaxRetries      int    // Retries before giving up. -1 disables retries.
+	MinRetryBackoff time.Duration
+	MaxRetryBackoff time.Duration
+	SyncSet         bool // When true, perform Redis SET synchronously. Default is false (async writes).
+}

--- a/cache-redis.go
+++ b/cache-redis.go
@@ -1,3 +1,5 @@
+//go:build !noredis
+
 package rdns
 
 import (
@@ -24,12 +26,6 @@ type redisBackend struct {
 	opt           RedisBackendOptions
 	asyncWriteSem chan struct{}
 	asyncSkipped  *expvar.Int
-}
-
-type RedisBackendOptions struct {
-	RedisOptions redis.Options
-	KeyPrefix    string
-	SyncSet      bool // When true, perform Redis SET synchronously. Default is false (async writes).
 }
 
 var _ CacheBackend = (*redisBackend)(nil)
@@ -119,14 +115,24 @@ func decodeCacheAnswer(b []byte) (*cacheAnswer, error) {
 	}, nil
 }
 
-func NewRedisBackend(opt RedisBackendOptions) *redisBackend {
+func NewRedisBackend(opt RedisBackendOptions) (CacheBackend, error) {
 	b := &redisBackend{
-		client:        redis.NewClient(&opt.RedisOptions),
+		client: redis.NewClient(&redis.Options{
+			Network:               opt.Network,
+			Addr:                  opt.Address,
+			Username:              opt.Username,
+			Password:              opt.Password,
+			DB:                    opt.DB,
+			MaxRetries:            opt.MaxRetries,
+			MinRetryBackoff:       opt.MinRetryBackoff,
+			MaxRetryBackoff:       opt.MaxRetryBackoff,
+			ContextTimeoutEnabled: true,
+		}),
 		opt:           opt,
 		asyncWriteSem: make(chan struct{}, redisAsyncWriteSemCapacity),
 		asyncSkipped:  getVarInt("cache", "redis", "async-skipped"),
 	}
-	return b
+	return b, nil
 }
 
 func (b *redisBackend) Store(query *dns.Msg, item *cacheAnswer) {

--- a/cache-redis_test.go
+++ b/cache-redis_test.go
@@ -1,3 +1,5 @@
+//go:build !noredis
+
 package rdns
 
 import (
@@ -297,5 +299,50 @@ func BenchmarkKeyFromQuery(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		_ = backend.keyFromQuery(q)
+	}
+}
+
+// Both backends decode a stored entry differently but have to age it the same
+// way. The response carries an OPT record, which has no TTL and so must be
+// left out of the ageing: counting it would age out every EDNS0 response the
+// moment it was cached.
+func TestBackendsAgeIdentically(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	answer := new(dns.Msg)
+	answer.SetReply(q)
+	for _, rr := range []string{
+		"example.com. 300 IN A 192.0.2.1",
+		"example.com. 600 IN NS ns1.example.com.",
+	} {
+		parsed, err := dns.NewRR(rr)
+		require.NoError(t, err)
+		answer.Answer = append(answer.Answer, parsed)
+	}
+	answer.SetEdns0(4096, false)
+
+	stored := time.Now().Add(-90 * time.Second)
+	item := &cacheAnswer{Msg: answer, Timestamp: stored, Expiry: stored.Add(time.Hour)}
+
+	mem := NewMemoryBackend(MemoryBackendOptions{GCPeriod: time.Hour})
+	defer mem.Close()
+	mem.Store(q, item)
+	fromMemory, _, ok := mem.Lookup(q)
+	require.True(t, ok, "an answer carrying an OPT record must still be served")
+	require.Equal(t, uint32(210), fromMemory.Answer[0].Header().Ttl)
+	require.NotNil(t, fromMemory.IsEdns0(), "the OPT record must survive")
+
+	// Redis has no test server, so go through its codec and age the result the
+	// way redisBackend.Lookup does.
+	encoded, err := encodeCacheAnswer(make([]byte, 0, 2048), item)
+	require.NoError(t, err)
+	decoded, err := decodeCacheAnswer(encoded)
+	require.NoError(t, err)
+	require.True(t, ageCachedAnswer(decoded.Msg, q,
+		cacheAge(time.Now().UnixNano(), decoded.Timestamp.UnixNano())))
+
+	for i, rr := range fromMemory.Answer {
+		require.Equal(t, rr.Header().Ttl, decoded.Msg.Answer[i].Header().Ttl)
 	}
 }

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -19,7 +19,6 @@ import (
 	syslog "github.com/RackSec/srslog"
 	rdns "github.com/folbricht/routedns"
 	"github.com/heimdalr/dag"
-	"github.com/redis/go-redis/v9"
 	"github.com/spf13/cobra"
 )
 
@@ -799,21 +798,22 @@ func instantiateGroup(id string, g group, resolvers map[string]rdns.Resolver) er
 				if g.Backend.RedisMaxRetryBackoff == -1 {
 					maxRetryBackoff = -1
 				}
-				backend = rdns.NewRedisBackend(rdns.RedisBackendOptions{
-					RedisOptions: redis.Options{
-						Network:               g.Backend.RedisNetwork,
-						Addr:                  g.Backend.RedisAddress,
-						Username:              g.Backend.RedisUsername,
-						Password:              g.Backend.RedisPassword,
-						DB:                    g.Backend.RedisDB,
-						ContextTimeoutEnabled: true,
-						MaxRetries:            g.Backend.RedisMaxRetries,
-						MinRetryBackoff:       minRetryBackoff,
-						MaxRetryBackoff:       maxRetryBackoff,
-					},
-					KeyPrefix: g.Backend.RedisKeyPrefix,
-					SyncSet:   g.Backend.RedisSyncSet,
+				var err error
+				backend, err = rdns.NewRedisBackend(rdns.RedisBackendOptions{
+					Network:         g.Backend.RedisNetwork,
+					Address:         g.Backend.RedisAddress,
+					Username:        g.Backend.RedisUsername,
+					Password:        g.Backend.RedisPassword,
+					DB:              g.Backend.RedisDB,
+					KeyPrefix:       g.Backend.RedisKeyPrefix,
+					MaxRetries:      g.Backend.RedisMaxRetries,
+					MinRetryBackoff: minRetryBackoff,
+					MaxRetryBackoff: maxRetryBackoff,
+					SyncSet:         g.Backend.RedisSyncSet,
 				})
+				if err != nil {
+					return err
+				}
 			default:
 				return fmt.Errorf("unsupported cache backend %q", g.Backend.Type)
 			}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -392,7 +392,7 @@ The memory backend will keep all cache items in memory. It can be configured to 
 
 **Redis backend**
 
-The `redis` backend stores cached items in a Redis database. This allows multiple instances of routedns to share a common cache backend. The following options are supported:
+The `redis` backend stores cached items in a Redis database. This allows multiple instances of routedns to share a common cache backend. It is not available in binaries built with the `noredis` tag, such as the `routedns-minimal-*` release artifacts. The following options are supported:
 
 - `type="redis"`
 - `redis-network` - The network type, either `tcp` or `unix`. Defaults to `tcp`.
@@ -1688,7 +1688,7 @@ Example config files: [syslog.toml](../cmd/routedns/example-config/query-log.tom
 
 ### Lua
 
-Lua groups allow writing custom query handling logic using Lua scripts. The script must define a `Resolve(msg, ci)` function that receives the DNS message and client info, and returns a response message and error. Scripts run in a sandboxed environment by default with access to DNS types, message construction, and upstream resolvers.
+Lua groups allow writing custom query handling logic using Lua scripts. The script must define a `Resolve(msg, ci)` function that receives the DNS message and client info, and returns a response message and error. Scripts run in a sandboxed environment by default with access to DNS types, message construction, and upstream resolvers. They are not available in binaries built with the `nolua` tag, such as the `routedns-minimal-*` release artifacts.
 
 #### Configuration
 

--- a/lua-clientinfo.go
+++ b/lua-clientinfo.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (

--- a/lua-disabled.go
+++ b/lua-disabled.go
@@ -1,0 +1,32 @@
+//go:build nolua
+
+package rdns
+
+import (
+	"errors"
+
+	"github.com/miekg/dns"
+)
+
+// Lua replaces the real resolver in builds made with the "nolua" tag, which
+// leave out the Lua interpreter. A configuration using a lua group fails at
+// startup rather than passing queries through unmodified.
+type Lua struct{}
+
+var _ Resolver = &Lua{}
+
+var errNoLua = errors.New("this build does not support lua")
+
+func NewLua(id string, opt LuaOptions, resolvers ...Resolver) (*Lua, error) {
+	return nil, errNoLua
+}
+
+func (r *Lua) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+	return nil, errNoLua
+}
+
+func (r *Lua) String() string {
+	return "lua"
+}
+
+func (r *Lua) Close() {}

--- a/lua-edns0.go
+++ b/lua-edns0.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (

--- a/lua-error.go
+++ b/lua-error.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (

--- a/lua-helpers.go
+++ b/lua-helpers.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (

--- a/lua-message.go
+++ b/lua-message.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (

--- a/lua-opt.go
+++ b/lua-opt.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (

--- a/lua-options.go
+++ b/lua-options.go
@@ -1,0 +1,10 @@
+package rdns
+
+// LuaOptions holds the settings for the Lua resolver. It is built with or
+// without the "nolua" tag, which leaves out the Lua interpreter, so that the
+// config layer in cmd/routedns compiles either way.
+type LuaOptions struct {
+	Script      string
+	Concurrency uint
+	NoSandbox   bool // Disables the sandbox. When false (default), scripts cannot access os/io/debug/etc.
+}

--- a/lua-question.go
+++ b/lua-question.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (

--- a/lua-resolver.go
+++ b/lua-resolver.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (

--- a/lua-rr.go
+++ b/lua-rr.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (

--- a/lua-script.go
+++ b/lua-script.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (

--- a/lua-types.go
+++ b/lua-types.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (

--- a/lua.go
+++ b/lua.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (
@@ -18,12 +20,6 @@ type Lua struct {
 }
 
 var _ Resolver = &Lua{}
-
-type LuaOptions struct {
-	Script      string
-	Concurrency uint
-	NoSandbox   bool // Disables the sandbox. When false (default), scripts cannot access os/io/debug/etc.
-}
 
 func NewLua(id string, opt LuaOptions, resolvers ...Resolver) (*Lua, error) {
 	if opt.Concurrency == 0 {

--- a/lua_test.go
+++ b/lua_test.go
@@ -1,3 +1,5 @@
+//go:build !nolua
+
 package rdns
 
 import (


### PR DESCRIPTION
Addresses #609.

The binary is almost entirely dependencies, and the two largest optional ones are the Redis client and the Lua interpreter. Two build tags leave them out:

| Tag | Leaves out |
| --- | --- |
| `noredis` | The `redis` cache backend |
| `nolua` | `lua` groups |

Sizes with `-trimpath -ldflags="-s -w"`, as the release builds use:

| Target | Current | Both tags |
| --- | ---: | ---: |
| linux/mipsle, softfloat | 23.5MB | 17.0MB |
| linux/armv6 | 20.6MB | 14.9MB |
| linux/arm64 | 20.4MB | 14.6MB |
| linux/amd64 | 22.2MB | 15.9MB |

Redis accounts for most of it. It contributes 2.75MB of text but takes 5.4MB off the binary because of its transitive tree. Lua is worth about 1MB.

One caveat on what this buys in practice: OpenWrt stores its root filesystem on squashfs and package payloads are compressed, so the number that matters there is the compressed size. For linux/mipsle that goes from 4.51MB to 3.74MB under xz, a 17% saving rather than the 28% the raw sizes suggest. Still useful on a 16MB device, but less dramatic.

## Approach

Configuration is unchanged in both builds. The config layer parses every option either way, and the stubs replacing the two features return an error naming the missing one, so a config asking for a feature the binary lacks fails at startup instead of being silently ignored:

```
$ routedns-minimal config.toml
Error: this build does not support the redis cache backend
```

`RedisBackendOptions` used to embed `redis.Options`, which meant `cmd/routedns` imported the client and kept it linked no matter what the library did. Its connection settings are now plain fields that the backend translates, and `NewRedisBackend` returns a `CacheBackend` and an error rather than the unexported `*redisBackend`. Both option structs live in untagged files so there is only one definition of each.

`TestBackendsAgeIdentically` moved from `cache-age_test.go` to `cache-redis_test.go`, since it goes through the Redis codec and cannot build without it. The rest of `cache-age_test.go` is backend independent and stays where it is.

## Release artifacts

A `minimal` goreleaser build produces `routedns-minimal-linux-{armv6,armv7,arm64,mips,mipsle}`. Existing artifact names and the deb/rpm/apk/archlinux packages are untouched. Verified with `goreleaser check` and a full `release --snapshot`.

CI builds and runs the test suite with both tags set, otherwise the stubs would drift out of sync unnoticed.
