### PR TITLE
Don't shut down on SIGHUP

### DIFF
--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -462,13 +462,34 @@ func start(opt options, args []string) error {
 	// Graceful shutdown
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
-	<-sig
+	waitForShutdownSignal(sig)
 	rdns.Log.Info("stopping")
 	for _, f := range onClose {
 		f()
 	}
 
 	return nil
+}
+
+// waitForShutdownSignal blocks until a signal arrives that should terminate
+// RouteDNS, and returns it.
+//
+// SIGHUP is logged and ignored. It conventionally asks a daemon to reload,
+// and RouteDNS has no reload support, so the useful choice is between exiting
+// and doing nothing. Exiting takes name resolution down for everything behind
+// the resolver, which is the worse outcome by far when an operator only meant
+// to refresh blocklists. Note that ignoring it requires catching it: the Go
+// runtime terminates the process for an un-notified SIGHUP, so leaving it out
+// of signal.Notify would not help.
+func waitForShutdownSignal(sig <-chan os.Signal) os.Signal {
+	for {
+		s := <-sig
+		if s != syscall.SIGHUP {
+			return s
+		}
+		rdns.Log.Warn("ignoring signal, RouteDNS cannot reload; restart it to apply config changes",
+			"signal", s.String())
+	}
 }
 
 // Instantiate a group object based on configuration and add to the map of resolvers by ID.

--- a/cmd/routedns/signal_test.go
+++ b/cmd/routedns/signal_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	rdns "github.com/folbricht/routedns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForShutdownSignal(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		signal os.Signal
+	}{
+		{"SIGTERM", syscall.SIGTERM},
+		{"SIGINT", os.Interrupt},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sig := make(chan os.Signal, 1)
+			sig <- tc.signal
+			require.Equal(t, tc.signal, waitForShutdownSignal(sig))
+		})
+	}
+}
+
+// SIGHUP conventionally means "reload" and must not stop RouteDNS.
+func TestWaitForShutdownSignalIgnoresSIGHUP(t *testing.T) {
+	b := new(bytes.Buffer)
+	old := rdns.Log
+	rdns.Log = slog.New(slog.NewTextHandler(b, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	t.Cleanup(func() { rdns.Log = old })
+
+	sig := make(chan os.Signal, 3)
+	sig <- syscall.SIGHUP
+	sig <- syscall.SIGHUP
+
+	done := make(chan os.Signal, 1)
+	go func() { done <- waitForShutdownSignal(sig) }()
+
+	// Both SIGHUPs have to be consumed without returning.
+	select {
+	case s := <-done:
+		t.Fatalf("returned on SIGHUP with %v, expected it to be ignored", s)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// A real shutdown signal still gets through afterwards.
+	sig <- syscall.SIGTERM
+	select {
+	case s := <-done:
+		require.Equal(t, syscall.SIGTERM, s)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for SIGTERM")
+	}
+
+	require.Contains(t, b.String(), "ignoring signal")
+	require.Equal(t, 2, bytes.Count(b.Bytes(), []byte("ignoring signal")))
+}


### PR DESCRIPTION
`signal.Notify` wired SIGHUP into the same channel as SIGINT and SIGTERM, so sending it shut RouteDNS down. SIGHUP conventionally asks a daemon to reload its configuration, so an operator reaching for it to refresh blocklists took name resolution down for everything behind the resolver instead.

RouteDNS has no reload support, so the realistic choice is between exiting and doing nothing. Doing nothing is clearly better here, given the blast radius of a resolver disappearing. SIGHUP is now logged and ignored:

```
level=WARN msg="ignoring signal, RouteDNS cannot reload; restart it to apply config changes" signal=hangup
```

Worth noting that it has to be caught in order to be ignored. The Go runtime terminates the process for a SIGHUP that isn't passed to `signal.Notify`, so simply dropping it from the list would have left the behaviour unchanged.

Verified against a running instance: two SIGHUPs are logged and survived, a following SIGTERM still shuts down cleanly through the normal `onClose` path.

The wait is extracted from `start()` into `waitForShutdownSignal` so it can be tested by feeding a channel rather than signalling the test process. Cross-checked that windows, darwin, freebsd and linux/mipsle still build, since this references `syscall.SIGHUP`.

If you'd rather SIGHUP did something useful, the natural follow-up is reloading blocklists and allowlists from their sources. That needs a "refresh now" entry point on `Blocklist` and the response/client blocklist variants plus a registry of them in `main.go`, so I kept it out of this change.