### PR TITLE
Build every release target in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,61 @@ jobs:
         go-version-file: go.mod
 
     - name: Build
-      run: go build -v .
+      run: go build -v ./...
+
+    - name: Vet
+      run: go vet ./...
 
     - name: Test
       run: go test -race ./...
+
+  # Compile every target that .goreleaser.yaml ships. The library carries
+  # per-platform files (netns_*, sockopts_*, xsocket_*) that the linux/amd64
+  # build above never touches, so without this a break in one of them only
+  # turns up when a release is cut. Keep this list in sync with the build
+  # targets in .goreleaser.yaml.
+  cross-build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}${{ matrix.goarm && format('v{0}', matrix.goarm) || '' }}${{ matrix.gomips && format(' {0}', matrix.gomips) || '' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Targets packaged as deb/rpm/apk/archlinux, plus the plain binaries.
+          - {goos: linux, goarch: amd64}
+          - {goos: linux, goarch: arm64}
+          - {goos: linux, goarch: arm, goarm: "7"}
+          - {goos: darwin, goarch: amd64}
+          - {goos: darwin, goarch: arm64}
+          - {goos: windows, goarch: amd64}
+          - {goos: freebsd, goarch: amd64}
+          # Binary-only targets for small/embedded devices. armv6 covers older
+          # Raspberry Pis, mips/mipsle softfloat cover OpenWrt routers. These
+          # are the only 32-bit targets, so they also guard against word-size
+          # assumptions in the library.
+          - {goos: linux, goarch: arm, goarm: "6"}
+          - {goos: linux, goarch: mips, gomips: softfloat}
+          - {goos: linux, goarch: mipsle, gomips: softfloat}
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      GOARM: ${{ matrix.goarm }}
+      GOMIPS: ${{ matrix.gomips }}
+      CGO_ENABLED: "0"
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Build
+      run: go build -v ./...
+
+    # Type-checks and runs the analyzers against this platform's build tags,
+    # which catches more than compiling alone.
+    - name: Vet
+      run: go vet ./...


### PR DESCRIPTION
CI ran `go build -v .` on `ubuntu-latest`. That builds the library for linux/amd64 and nothing else. The `cmd/routedns` binary was never built, and neither were the other nine platforms `.goreleaser.yaml` ships.

The library carries per-platform files (`netns_linux.go` / `netns_other.go`, `sockopts_linux.go` / `sockopts_other.go`, `xsocket_linux.go` / `xsocket_other.go`, `netns_watch_*`, `xsocketserver_*`) that a linux/amd64 build never compiles. A break in any of them would have surfaced only when a release was cut, after the tag was already pushed.

This adds a `cross-build` matrix over the same ten targets goreleaser produces, verified against the `dist/` output of a local snapshot run:

| | |
|---|---|
| packaged | linux/amd64, linux/arm64, linux/armv7, darwin/amd64, darwin/arm64, windows/amd64, freebsd/amd64 |
| embedded | linux/armv6, linux/mips softfloat, linux/mipsle softfloat |

Each runs `go build ./...` and `go vet ./...` with `CGO_ENABLED=0`, matching the release build. Vet rather than build alone because it type-checks and runs the analyzers against that platform's build tags, so it catches more than compiling does. `fail-fast: false` so one broken platform doesn't hide the others.

The mips and arm targets are also the only 32-bit ones in the set, so they double as a guard against word-size assumptions.

The existing job is widened from `.` to `./...` so `cmd/routedns` is actually built, and picks up a vet step too. Its name is unchanged, so the README badge and any existing check references still resolve.

All ten targets build and vet clean on master today, so this should go green on the first run, being insurance against future breakage rather than a fix for anything currently broken.

### On keeping the list in sync

The matrix duplicates the target list from `.goreleaser.yaml`, so the two can drift. The alternative is running `goreleaser build --snapshot` in CI, which derives the targets from the config directly, but it builds serially in one job and loses per-target failure reporting. Given the release targets change rarely, the matrix plus a comment on both ends is the better trade.

