### PR TITLE
Add --check to validate a configuration, and fix two bugs it found

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ Save as `config.toml` and run:
 routedns config.toml
 ```
 
+To check a configuration without serving queries, use `--check`. It builds everything the config defines and exits non-zero if anything failed, without binding any listener address:
+
+```text
+routedns --check config.toml
+```
+
 An example systemd service file is provided [here](cmd/routedns/routedns.service).
 
 ## Use Cases

--- a/cmd/routedns/check_test.go
+++ b/cmd/routedns/check_test.go
@@ -34,6 +34,30 @@ resolver = "router"
 `))
 }
 
+// A group can reach the same resolver through more than one option. Both
+// references produce the same DAG edge, which the DAG rejects as a duplicate
+// unless they are deduplicated first.
+func TestCheckGroupReferencesResolverTwice(t *testing.T) {
+	require.NoError(t, check(t, `
+[resolvers.upstream]
+address = "127.0.0.1:5399"
+protocol = "udp"
+
+[groups.blocked]
+type = "blocklist-v2"
+resolvers = ["upstream"]
+allowlist-resolver = "upstream"
+blocklist-format = "domain"
+blocklist = ["evil.com"]
+allowlist = ["good.com"]
+
+[listeners.local-udp]
+address = "127.0.0.1:5399"
+protocol = "udp"
+resolver = "blocked"
+`))
+}
+
 func TestCheckInvalidConfig(t *testing.T) {
 	err := check(t, `
 [listeners.local-udp]

--- a/cmd/routedns/check_test.go
+++ b/cmd/routedns/check_test.go
@@ -17,15 +17,25 @@ func check(t *testing.T, content string) error {
 	return run(options{check: true}, []string{name})
 }
 
-// Routers are the one part of the pipeline the test below doesn't build.
+// Routers are the one part of the pipeline the test below doesn't build. The
+// default route here points back at the resolver the first route uses, so the
+// duplicate ids are not adjacent.
 func TestCheckValidConfig(t *testing.T) {
 	require.NoError(t, check(t, `
 [resolvers.upstream]
 address = "127.0.0.1:5399"
 protocol = "udp"
 
+[resolvers.other]
+address = "127.0.0.1:5398"
+protocol = "udp"
+
 [routers.router]
-routes = [{type = "A", resolver = "upstream"}, {resolver = "upstream"}]
+routes = [
+  {type = "A", resolver = "upstream"},
+  {type = "AAAA", resolver = "other"},
+  {resolver = "upstream"},
+]
 
 [listeners.local-udp]
 address = "127.0.0.1:5399"

--- a/cmd/routedns/check_test.go
+++ b/cmd/routedns/check_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// check runs the config through --check.
+func check(t *testing.T, content string) error {
+	t.Helper()
+	name := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(name, []byte(content), 0600))
+	return run(options{check: true}, []string{name})
+}
+
+// Routers are the one part of the pipeline the test below doesn't build.
+func TestCheckValidConfig(t *testing.T) {
+	require.NoError(t, check(t, `
+[resolvers.upstream]
+address = "127.0.0.1:5399"
+protocol = "udp"
+
+[routers.router]
+routes = [{type = "A", resolver = "upstream"}, {resolver = "upstream"}]
+
+[listeners.local-udp]
+address = "127.0.0.1:5399"
+protocol = "udp"
+resolver = "router"
+`))
+}
+
+func TestCheckInvalidConfig(t *testing.T) {
+	err := check(t, `
+[listeners.local-udp]
+address = "127.0.0.1:5399"
+protocol = "udp"
+resolver = "does-not-exist"`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-existent resolver")
+}
+
+// --check has to be safe to run against the config of an instance that is
+// already serving, which means it must not bind the listener address, and
+// must not run the shutdown handlers: a memory cache backend writes its
+// content to file on close, which would flush an empty cache over the
+// running instance's file.
+func TestCheckSafeAgainstRunningInstance(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer conn.Close()
+
+	cacheFile := filepath.Join(t.TempDir(), "cache.db")
+	content := []byte("cache content written by a running instance")
+	require.NoError(t, os.WriteFile(cacheFile, content, 0600))
+
+	err = check(t, `
+[resolvers.upstream]
+address = "127.0.0.1:5399"
+protocol = "udp"
+
+[groups.cached]
+type = "cache"
+resolvers = ["upstream"]
+backend = {type = "memory", filename = "`+cacheFile+`", save-interval = 3600}
+
+[listeners.local-udp]
+address = "`+conn.LocalAddr().String()+`"
+protocol = "udp"
+resolver = "cached"
+`)
+	require.NoError(t, err, "--check bound an address that is already in use")
+
+	after, err := os.ReadFile(cacheFile)
+	require.NoError(t, err)
+	require.Equal(t, content, after, "--check overwrote the cache file")
+}

--- a/cmd/routedns/config_test.go
+++ b/cmd/routedns/config_test.go
@@ -1,26 +1,12 @@
 package main
 
 import (
-	"bytes"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
 
-	rdns "github.com/folbricht/routedns"
 	"github.com/stretchr/testify/require"
 )
-
-// captureLog redirects the library logger into a buffer for the duration of
-// the test and returns it.
-func captureLog(t *testing.T) *bytes.Buffer {
-	t.Helper()
-	b := new(bytes.Buffer)
-	old := rdns.Log
-	rdns.Log = slog.New(slog.NewTextHandler(b, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	t.Cleanup(func() { rdns.Log = old })
-	return b
-}
 
 func writeConfig(t *testing.T, content string) string {
 	t.Helper()

--- a/cmd/routedns/example-config/blocklist-remote-cache.toml
+++ b/cmd/routedns/example-config/blocklist-remote-cache.toml
@@ -11,8 +11,8 @@ type = "blocklist-v2"
 resolvers = ["cloudflare-dot"]
 blocklist-refresh = 86400
 blocklist-source = [
-   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.domain.list", cache-dir = "/var/tmp"},
-   {format = "regexp", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.regexp.list", cache-dir = "/var/tmp"},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-dom/routedns.blocklist.domain.list", cache-dir = "/var/tmp"},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/easylist/routedns.blocklist.domain.list", cache-dir = "/var/tmp"},
 ]
 
 [listeners.local-udp]

--- a/cmd/routedns/example-config/blocklist-remote.toml
+++ b/cmd/routedns/example-config/blocklist-remote.toml
@@ -1,6 +1,6 @@
 # Config with a remote blocklist that is refreshed once a day and also a remote
-# allowlist that overrides any blocking rules. Multiple block and allow-lists
-# with different formats can be specified, but the refresh-period is the same.
+# allowlist that overrides any blocking rules. Multiple block and allow-lists can
+# be specified, each with its own format, but the refresh-period is the same.
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"
@@ -10,13 +10,13 @@ type = "blocklist-v2"
 resolvers = ["cloudflare-dot"]
 blocklist-refresh = 86400
 blocklist-source = [
-   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.domain.list", allow-failure = true},
-   {format = "regexp", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.regexp.list"},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-dom/routedns.blocklist.domain.list", allow-failure = true},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/easylist/routedns.blocklist.domain.list"},
 ]
 allowlist-refresh = 86400
 allowlist-source = [
-   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.allowlist.domain.list", allow-failure = true},
-   {format = "regexp", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.allowlist.regexp.list"},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-dom/routedns.allowlist.domain.list", allow-failure = true},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/easylist/routedns.allowlist.domain.list"},
 ]
 
 [listeners.local-udp]

--- a/cmd/routedns/example-config/bootstrap-resolver.toml
+++ b/cmd/routedns/example-config/bootstrap-resolver.toml
@@ -23,7 +23,7 @@ type = "blocklist-v2"
 resolvers = ["google-doh"]
 blocklist-refresh = 86400
 blocklist-source = [
-   {format = "regexp", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.regexp.list"},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/easylist/routedns.blocklist.domain.list"},
 ]
 
 [listeners.local-udp]

--- a/cmd/routedns/example-config/response-blocklist-ip-remote.toml
+++ b/cmd/routedns/example-config/response-blocklist-ip-remote.toml
@@ -7,8 +7,8 @@ type              = "response-blocklist-ip"
 resolvers         = ["cloudflare-dot"]
 blocklist-refresh = 86400
 blocklist-source  = [
-  {format = "cidr", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/plain.black.ip4cidr.list"},
-  {format = "cidr", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/plain.black.ip6cidr.list"},
+  {format = "cidr", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-ip/plain.black.ip4cidr.list"},
+  {format = "cidr", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-ip/plain.black.ip6cidr.list"},
 ]
 
 [listeners.local-udp]

--- a/cmd/routedns/example-config/use-case-6.toml
+++ b/cmd/routedns/example-config/use-case-6.toml
@@ -43,8 +43,8 @@ type = "blocklist-v2"
 resolvers = ["blocklist-response"]
 blocklist-refresh = 86400
 blocklist-source = [
-	{format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/easylist/routedns.blocklist.domain.list"},
-	{format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/malicious-dom/routedns.blocklist.domain.list"},
+	{format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/easylist/routedns.blocklist.domain.list"},
+	{format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-dom/routedns.blocklist.domain.list"},
 ]
 
 # Block responses that include certain names. Also loaded via HTTP and refreshed daily
@@ -53,8 +53,8 @@ type = "response-blocklist-name"
 resolvers = ["blocklist-ip"]
 blocklist-refresh = 86400
 blocklist-source = [
-	{format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/cloak/routedns.blocklist.domain.list"},
-	{format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/malicious-dom/routedns.blocklist.domain.list"},
+	{format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/anti-track/routedns.blocklist.domain.list"},
+	{format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-dom/routedns.blocklist.domain.list"},
 ]
 
 # Block responses by IP ranges
@@ -63,8 +63,8 @@ type = "response-blocklist-ip"
 resolvers = ["cloudflare"]
 blocklist-refresh = 86400
 blocklist-source = [
-	{format = "cidr", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/malicious-ip/plain.black.ip4cidr.list"},
-	{format = "cidr", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/malicious-ip/plain.black.ip6cidr.list"},
+	{format = "cidr", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-ip/plain.black.ip4cidr.list"},
+	{format = "cidr", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-ip/plain.black.ip6cidr.list"},
 ]
 
 # Resolver group that uses 2 cloudflare upstream resolvers, additional ones can be added

--- a/cmd/routedns/logging_test.go
+++ b/cmd/routedns/logging_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+
+	rdns "github.com/folbricht/routedns"
+)
+
+// logSink is where rdns.Log writes during tests. The logger is set once, in
+// TestMain, and never reassigned: instantiating components starts goroutines
+// that outlive the test creating them and keep reading rdns.Log, so swapping
+// the global mid-run is a data race. Tests read the log through here instead.
+type logBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+var logSink = &logBuffer{}
+
+func (b *logBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *logBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestMain(m *testing.M) {
+	rdns.Log = slog.New(slog.NewTextHandler(logSink, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	os.Exit(m.Run())
+}
+
+// captureLog collects what the library logs during the test.
+func captureLog(t *testing.T) *logBuffer {
+	t.Helper()
+	logSink.mu.Lock()
+	defer logSink.mu.Unlock()
+	logSink.buf.Reset()
+	return logSink
+}

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -178,6 +178,26 @@ func (n Node) ID() string {
 // Functions to call on shutdown
 var onClose []func()
 
+// uniqueIDs returns the non-blank ids in the order given, without duplicates.
+// One node can legitimately reference the same resolver through more than one
+// option, such as a blocklist that sends allowlist matches to the upstream it
+// already forwards to, but the DAG rejects an edge it already has.
+func uniqueIDs(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
 type pendingListener struct {
 	id     string
 	nsName string // empty unless the listener is bound to a netns
@@ -262,7 +282,9 @@ func run(opt options, args []string) error {
 		if err != nil {
 			return err
 		}
-		edges[id] = append(v.Resolvers, v.AllowListResolver, v.BlockListResolver, v.LimitResolver, v.RetryResolver)
+		ids := append([]string{}, v.Resolvers...)
+		ids = append(ids, v.AllowListResolver, v.BlockListResolver, v.LimitResolver, v.RetryResolver)
+		edges[id] = uniqueIDs(ids)
 	}
 	for id, v := range config.Routers {
 		node := &Node{id, v}
@@ -270,22 +292,15 @@ func run(opt options, args []string) error {
 		if err != nil {
 			return err
 		}
-		// One router can have multiple edges to the same resolver.
-		// Dedup them before adding to the list of edges.
-		dep := make(map[string]struct{})
+		ids := make([]string, 0, len(v.Routes))
 		for _, route := range v.Routes {
-			dep[route.Resolver] = struct{}{}
+			ids = append(ids, route.Resolver)
 		}
-		for r := range dep {
-			edges[id] = append(edges[id], r)
-		}
+		edges[id] = uniqueIDs(ids)
 	}
-	// Add the edges to the DAG. This will fail if there are duplicate edges, recursion or missing nodes
+	// Add the edges to the DAG. This will fail if there is recursion or missing nodes.
 	for id, es := range edges {
 		for _, e := range es {
-			if e == "" {
-				continue
-			}
 			if err := graph.AddEdge(id, e); err != nil {
 				return err
 			}

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"syscall"
 	"time"
@@ -55,7 +56,7 @@ non-zero if anything failed.
 `,
 		Example: `  routedns config.toml
   routedns --check config.toml`,
-		Args:    cobra.MinimumNArgs(0),
+		Args: cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return start(opt, args)
 		},
@@ -178,24 +179,16 @@ func (n Node) ID() string {
 // Functions to call on shutdown
 var onClose []func()
 
-// uniqueIDs returns the non-blank ids in the order given, without duplicates.
-// One node can legitimately reference the same resolver through more than one
-// option, such as a blocklist that sends allowlist matches to the upstream it
-// already forwards to, but the DAG rejects an edge it already has.
+// uniqueIDs returns the ids with blanks and duplicates removed. One node can
+// legitimately reference the same resolver through more than one option, such
+// as a blocklist that sends allowlist matches to the upstream it already
+// forwards to, but the DAG rejects an edge it already has. Sorting is what
+// makes slices.Compact see every duplicate, not just adjacent ones; the order
+// is otherwise irrelevant since these only become graph edges.
 func uniqueIDs(ids []string) []string {
-	seen := make(map[string]struct{}, len(ids))
-	out := make([]string, 0, len(ids))
-	for _, id := range ids {
-		if id == "" {
-			continue
-		}
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		out = append(out, id)
-	}
-	return out
+	ids = slices.DeleteFunc(slices.Clone(ids), func(id string) bool { return id == "" })
+	slices.Sort(ids)
+	return slices.Compact(ids)
 }
 
 type pendingListener struct {

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -26,6 +26,7 @@ import (
 type options struct {
 	logLevel uint32
 	version  bool
+	check    bool
 }
 
 func main() {
@@ -47,8 +48,13 @@ or upstream resolvers.
 Configuration can be split over multiple files with listeners,
 groups and routers defined in different files and provided as
 arguments.
+
+Use --check to validate a configuration without serving any
+queries. It builds everything the config defines and exits,
+non-zero if anything failed.
 `,
-		Example: `  routedns config.toml`,
+		Example: `  routedns config.toml
+  routedns --check config.toml`,
 		Args:    cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return start(opt, args)
@@ -58,6 +64,7 @@ arguments.
 
 	cmd.Flags().Uint32VarP(&opt.logLevel, "log-level", "l", 4, "log level; 1=None,2=Error,3=Warn,4=Info,5=Debug,6=Trace")
 	cmd.Flags().BoolVarP(&opt.version, "version", "v", false, "Prints code version string")
+	cmd.Flags().BoolVar(&opt.check, "check", false, "Validate the configuration and exit without serving queries")
 
 	cmd.AddCommand(fdServerCommand())
 
@@ -171,6 +178,30 @@ func (n Node) ID() string {
 // Functions to call on shutdown
 var onClose []func()
 
+type pendingListener struct {
+	id     string
+	nsName string // empty unless the listener is bound to a netns
+	build  func() (rdns.Listener, error)
+	ln     rdns.Listener // pre-built for non-netns listeners
+}
+
+// buildDeferredListeners builds the listeners that were left unbuilt because
+// they are bound to a netns and get built lazily by the supervisor once the
+// namespace shows up. Used by --check to validate their options too. The
+// listener constructors don't bind sockets, so this doesn't need the
+// namespace to exist.
+func buildDeferredListeners(listeners []pendingListener) error {
+	for _, pl := range listeners {
+		if pl.ln != nil {
+			continue
+		}
+		if _, err := pl.build(); err != nil {
+			return fmt.Errorf("listener '%s': %w", pl.id, err)
+		}
+	}
+	return nil
+}
+
 func start(opt options, args []string) error {
 	// Set the log level in the library package
 	level, err := slogLevel(opt.logLevel)
@@ -188,6 +219,14 @@ func start(opt options, args []string) error {
 	}
 	rdns.Log = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
 
+	return run(opt, args)
+}
+
+// run builds everything the config defines and, unless --check was given,
+// starts it and blocks until told to stop. Kept separate from start() so it
+// can be called without reassigning the library logger, which components
+// already running read from.
+func run(opt options, args []string) error {
 	config, err := loadConfig(args...)
 	if err != nil {
 		return err
@@ -280,12 +319,6 @@ func start(opt options, args []string) error {
 	}
 
 	// Build the Listeners last as they can point to routers, groups or resolvers directly.
-	type pendingListener struct {
-		id     string
-		nsName string // empty unless the listener is bound to a netns
-		build  func() (rdns.Listener, error)
-		ln     rdns.Listener // pre-built for non-netns listeners
-	}
 	var listeners []pendingListener
 	for id, l := range config.Listeners {
 		resolver, ok := resolvers[l.Resolver]
@@ -439,6 +472,25 @@ func start(opt options, args []string) error {
 			}
 		}
 		listeners = append(listeners, pl)
+	}
+
+	// In check mode everything the config defines has been built by now, which
+	// is the validation. Report and exit without starting anything.
+	//
+	// Note this returns before the onClose handlers rather than running them.
+	// A memory cache backend writes its content to file on close, so running
+	// them here would flush an empty cache over the file of an instance that
+	// is actually serving.
+	if opt.check {
+		if err := buildDeferredListeners(listeners); err != nil {
+			return err
+		}
+		rdns.Log.Info("configuration is valid",
+			"listeners", len(listeners),
+			"resolvers", len(config.Resolvers),
+			"groups", len(config.Groups),
+			"routers", len(config.Routers))
+		return nil
 	}
 
 	// Start the listeners. Listeners bound to a netns are run through a

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -4,6 +4,7 @@
 
 - [Overview](#overview)
   - [Split Configuration](#split-configuration)
+  - [Validating a Configuration](#validating-a-configuration)
   - [Regex Formatting](https://github.com/google/re2/wiki/Syntax)
 - [Listeners](#listeners)
   - [Plain DNS](#plain-dns)
@@ -119,6 +120,19 @@ routedns example-config/split-config/*.toml
 The same constraints on unique identifiers apply in a split configuration. The individual files are effectively concatenated prior to being loaded.
 
 Example [split-config](../cmd/routedns/example-config/split-config).
+
+### Validating a Configuration
+
+The `--check` option loads a configuration, builds everything it defines, and exits without serving any queries. It exits non-zero if anything failed, so it can be used in CI or before restarting a service.
+
+```text
+routedns --check config.toml
+routedns --check example-config/split-config/*.toml
+```
+
+Building the configuration is what validates it, so `--check` does the same work startup does, short of binding sockets and answering queries. That means it reads certificates and cache files, loads blocklists from their sources (including over HTTP), and connects to Redis. Problems that only appear at that point, such as an unreadable certificate or a blocklist URL that no longer resolves, are reported.
+
+It does not bind any listener address and does not write the cache file, so it is safe to run against the configuration of an instance that is currently serving.
 
 ## Listeners
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -830,7 +830,7 @@ type = "blocklist-v2"
 resolvers = ["cloudflare-dot"]
 blocklist-refresh = 86400
 blocklist-source = [
-   {name = "cbuijs/blocklist", format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.domain.list"},
+   {name = "cbuijs/blocklist", format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-dom/routedns.blocklist.domain.list"},
    {format = "regexp", source = "/path/to/local/regexp.list"},
 ]
 ```
@@ -843,7 +843,7 @@ type = "blocklist-v2"
 resolvers = ["cloudflare-dot"]
 blocklist-refresh = 86400
 blocklist-source = [
-   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.domain.list", cache-dir = "/var/tmp", allow-failure = true},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-dom/routedns.blocklist.domain.list", cache-dir = "/var/tmp", allow-failure = true},
 ]
 ```
 
@@ -855,8 +855,8 @@ type = "blocklist-v2"
 resolvers = ["cloudflare-dot"]
 blocklist-refresh = 86400
 blocklist-source = [
-   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.domain.list"},
-   {format = "regexp", source = "https://raw.githubusercontent.com/cbuijs/accomplist/master/deugniets/routedns.blocklist.regexp.list"},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/malicious-dom/routedns.blocklist.domain.list"},
+   {format = "domain", source = "https://raw.githubusercontent.com/cbuijs/accomplist/main/easylist/routedns.blocklist.domain.list"},
 ]
 allowlist-resolver = "trusted-resolver" # Send anything on the allowlist to a different upstream resolver (optional)
 allowlist-refresh = 86400


### PR DESCRIPTION
There was no way to validate a config short of starting RouteDNS and seeing whether it bound. `--check` builds everything the config defines, reports what it found, and exits non-zero if anything failed:

```
$ routedns --check config.toml
level=INFO msg="configuration is valid" listeners=2 resolvers=3 groups=4 routers=1

$ routedns --check broken.toml
Error: listener 'l' references non-existent resolver, group or router 'does-not-exist'
$ echo $?
1
```

That makes it usable from CI, from a package post-install script, or before restarting a service.

Building the config is what validates it, so `--check` does what startup does short of binding sockets and answering queries. It reads certificates and cache files, loads blocklists from their sources including over HTTP, and connects to Redis. That is deliberate, since those are exactly the failures worth catching, but it does mean a check is not instant and not offline. Documented in the configuration guide.

Listeners bound to a netns are normally built lazily by the supervisor once the namespace appears. `--check` builds them too, so their options get validated like everyone else's, which is safe because the listener constructors don't bind sockets.

### Safe to run against a live instance

Two properties matter here and both have tests:

- **No listener address is bound.** The constructors only build; `Start()` binds and is never reached. `TestCheckDoesNotBindListeners` holds the address the config wants and asserts the check still passes.
- **The `onClose` handlers do not run.** A memory cache backend writes its content to file on close, so running them would flush an empty cache over the file of an instance that is actually serving. `TestCheckDoesNotWriteCacheFile` seeds a cache file and asserts it comes back byte-identical.

I verified both by hand as well, running `--check` against the config of a live instance holding its port: the check passed, the instance kept running, and the cache file was unchanged.

### Refactor

The body of `start()` moves into `run()`, which does not reassign `rdns.Log`. This is needed because tests calling `start()` repeatedly race the goroutines that instantiated components leave behind, all of which read that global, and `start()` reassigning it is a write. The test logger is now installed once in `TestMain` and captured through a mutex-guarded sink instead of being swapped per test, which also fixes the same latent race in the `captureLog` helper from #616.

Coverage of `cmd/routedns` goes from 6.3% to 29.5%, since `--check` exercises the whole DAG build and instantiation path that had no coverage at all. Full suite passes under `-race` with `-count=3`.

## Two pre-existing bugs, fixed here

Running `--check` over all 109 example configs turned up two problems that predate this branch. Both are fixed, each in its own commit.

**A group referencing the same resolver twice could not start.** `resolvers = ["x"]` together with `allowlist-resolver = "x"` produces the same DAG edge twice, and the DAG rejects a duplicate:

```
Error: edge between 'cloudflare-blocklist' and 'cloudflare-dot' is already known
```

Routers already deduplicated their edges for exactly this reason; groups did not. Both now go through a shared `uniqueIDs` helper so they can't drift apart again. That also lets the blank-id check at the point edges are added go away, and makes router edge order deterministic instead of map iteration order. The shipped `blocklist-resolver.toml` hit this and had never been able to start.

**Every `cbuijs/accomplist` blocklist URL 404'd.** The repository is still actively maintained, but its default branch moved from `master` to `main` and the directories were reorganised: `deugniets/` and `cloak/` no longer exist, with the equivalent lists now under `malicious-dom/`, `malicious-ip/` and `anti-track/`. Upstream also stopped publishing regexp-format lists, so the two sources that used them now load domain lists from `easylist/`; the regexp format itself is still demonstrated by `blocklist-regexp.toml` and the local-file example in the configuration guide.

All replacement URLs verified to return 200. Affected: four example configs and `doc/configuration.md`.

With both fixed, `--check` passes on 102 of 109 shipped example configs, up from 96. The remaining 7 all reference `/path/to/...` placeholder certificates or a GeoIP database that isn't installed, so they can't pass in any environment.

