### PR TITLE
Add golangci-lint to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,27 @@ jobs:
     - name: Test
       run: go test -race ./...
 
+  # golangci-lint's standard linter set plus gofmt, configured in
+  # .golangci.yml. "run" reports formatting problems too, so this is the
+  # gofmt gate as well; nothing caught them before.
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: v2.12.2
+
   # Compile every target that .goreleaser.yaml ships. The library carries
   # per-platform files (netns_*, sockopts_*, xsocket_*) that the linux/amd64
   # build above never touches, so without this a break in one of them only

--- a/.github/workflows/version-bump-release.yaml
+++ b/.github/workflows/version-bump-release.yaml
@@ -74,7 +74,13 @@ jobs:
           # UPDATE
           perl -0777 -i -pe "s/BuildVersion.*string = \".*\"/BuildVersion string = \"$CHANGE_BUILD_VERSION\"/g" version.go
           perl -0777 -i -pe "s/BuildTime.*string = \".*\"/BuildTime    string = \"$CURRENT_BUILD_TIME\"/g" version.go
-          perl -0777 -i -pe "s/BuildNumber.*string = \".*\"/BuildNumber     string = \"$CHANGE_BUILD_NUMBER\"/g" version.go
+          perl -0777 -i -pe "s/BuildNumber.*string = \".*\"/BuildNumber  string = \"$CHANGE_BUILD_NUMBER\"/g" version.go
+
+          # The padding above matches what gofmt wants for the current field
+          # names, but it is hardcoded and would go stale if a field is added
+          # or renamed. Run gofmt so the committed file is formatted either
+          # way; CI checks formatting and would otherwise fail on every bump.
+          gofmt -w version.go
 
           # GIT
           git add .

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,56 @@
+# golangci-lint configuration. Run locally with:
+#   golangci-lint run ./...
+#   golangci-lint fmt ./...   (applies formatting fixes)
+#
+# The enabled set is deliberately the standard one. It passes clean today, so
+# it acts as a ratchet against new problems rather than demanding a cleanup
+# pass. Widening it later is a separate change.
+version: "2"
+
+linters:
+  default: standard # errcheck, govet, ineffassign, staticcheck, unused
+
+  settings:
+    staticcheck:
+      checks:
+        - all
+        # The ST* naming and comment-form checks that staticcheck itself
+        # leaves off by default. The codebase predates them and uses
+        # ALL_CAPS constants for ODoH paths and underscored struct fields in
+        # the dedup key, neither of which is worth churning.
+        - -ST1000
+        - -ST1003
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+        # QF* are "quickfix" refactoring suggestions (drop an embedded field
+        # from a selector, apply De Morgan's law, omit an inferable type).
+        # They are style preferences, not defects, and are also off by
+        # default in staticcheck.
+        - -QF1001
+        - -QF1002
+        - -QF1003
+        - -QF1008
+        - -QF1011
+
+  exclusions:
+    presets:
+      # Excludes the conventional unchecked-error cases, chiefly deferred
+      # Close on cleanup paths, which make up most of what errcheck finds here.
+      - std-error-handling
+    rules:
+      # pion/dtls deprecated its config and constructor API in favour of the
+      # options-based one. Migrating is a real change with behaviour risk, so
+      # it is tracked separately rather than blocking the linter landing.
+      - linters: [staticcheck]
+        text: "SA1019: dtls\\."
+        path: (dtls|dtlsclient|dtlslistener)\.go
+      # Tests take shortcuts with Start/Stop and Read return values that would
+      # only add noise if checked.
+      - linters: [errcheck]
+        path: _test\.go
+
+formatters:
+  enable:
+    - gofmt

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -166,10 +166,10 @@ func TestDomainDBOverlap(t *testing.T) {
 
 func TestDomainSubdomainDB(t *testing.T) {
 	loader := NewStaticLoader([]string{
-		"domain1.com",     // bare entry: apex + subdomains
-		".domain2.com",    // explicit dot: apex + subdomains (unchanged)
-		"*.domain3.com",   // explicit wildcard: subdomains-only opt-out
-		"DOMAIN4.com",     // capitalized bare entry
+		"domain1.com",   // bare entry: apex + subdomains
+		".domain2.com",  // explicit dot: apex + subdomains (unchanged)
+		"*.domain3.com", // explicit wildcard: subdomains-only opt-out
+		"DOMAIN4.com",   // capitalized bare entry
 		"trailing.dot.com.",
 	})
 

--- a/cache-memory.go
+++ b/cache-memory.go
@@ -49,7 +49,7 @@ func NewMemoryBackend(opt MemoryBackendOptions) *memoryBackend {
 	if opt.Filename != "" {
 		// Clean up temp files left behind by a run that was killed mid-write.
 		removeStaleTempFiles(filepath.Dir(opt.Filename))
-		b.loadFromFile(opt.Filename)
+		_ = b.loadFromFile(opt.Filename)
 	}
 	go b.startGC(opt.GCPeriod)
 	go b.intervalSave()
@@ -216,6 +216,6 @@ func (b *memoryBackend) intervalSave() {
 	}
 	for {
 		time.Sleep(b.opt.SaveInterval)
-		b.writeToFile(b.opt.Filename)
+		_ = b.writeToFile(b.opt.Filename)
 	}
 }

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -140,7 +140,7 @@ func runFDServer(opt fdServerOptions, path string) error {
 	go func() {
 		<-sig
 		rdns.Log.Info("stopping")
-		srv.Stop()
+		_ = srv.Stop()
 	}()
 	rdns.Log.Info("starting xsocket fd-server", "socket", path)
 	return srv.Start()

--- a/dnssec-iana.go
+++ b/dnssec-iana.go
@@ -14,8 +14,8 @@ const IANARootAnchorsURL = "https://data.iana.org/root-anchors/root-anchors.xml"
 
 // XML types for unmarshalling the IANA root-anchors.xml format.
 type ianaTrustAnchor struct {
-	XMLName    xml.Name         `xml:"TrustAnchor"`
-	KeyDigests []ianaKeyDigest  `xml:"KeyDigest"`
+	XMLName    xml.Name        `xml:"TrustAnchor"`
+	KeyDigests []ianaKeyDigest `xml:"KeyDigest"`
 }
 
 type ianaKeyDigest struct {

--- a/dnssec/keystore.go
+++ b/dnssec/keystore.go
@@ -91,8 +91,8 @@ func (s *keystore) addDNSKEY(name string, keys []*dns.DNSKEY) {
 	}
 	keyset := &dnskeySet{
 		expiresAt: s.now().Add(time.Duration(ttl) * time.Second),
-		zsk:    zsk,
-		ksk:    ksk,
+		zsk:       zsk,
+		ksk:       ksk,
 	}
 	item := s.getItem(name)
 	item.setDNSKEY(keyset)

--- a/dnssec/validator.go
+++ b/dnssec/validator.go
@@ -12,11 +12,11 @@ import (
 )
 
 var (
-	ErrNoSignature        = errors.New("dnssec: no RRSIG for RRset")
-	ErrNoKey              = errors.New("dnssec: no matching DNSKEY")
-	ErrSignatureInvalid   = errors.New("dnssec: signature verification failed")
-	ErrSignatureExpired   = errors.New("dnssec: RRSIG outside its validity period")
-	ErrDSMismatch         = errors.New("dnssec: DNSKEY doesn't match DS")
+	ErrNoSignature          = errors.New("dnssec: no RRSIG for RRset")
+	ErrNoKey                = errors.New("dnssec: no matching DNSKEY")
+	ErrSignatureInvalid     = errors.New("dnssec: signature verification failed")
+	ErrSignatureExpired     = errors.New("dnssec: RRSIG outside its validity period")
+	ErrDSMismatch           = errors.New("dnssec: DNSKEY doesn't match DS")
 	ErrNoTrustAnchor        = errors.New("dnssec: no trust anchor")
 	ErrInsecureDelegation   = errors.New("dnssec: insecure delegation")
 	ErrSignerOutOfBailiwick = errors.New("dnssec: RRSIG signer name out of bailiwick")

--- a/doc.go
+++ b/doc.go
@@ -5,24 +5,24 @@ such as DNS-over-TLS, DNS-over-HTTP, and plain wire format DNS. In addition it i
 possible to route queries based on the query name or type. There are 4 fundamental types
 of objects available in this library.
 
-Resolvers
+# Resolvers
 
 Resolvers implement name resolution with upstream resolvers. All of them implement connection
 reuse as well as pipelining (sending multiple queries and receiving them out-of-order).
 
-Groups
+# Groups
 
 Groups typically wrap multiple resolvers and implement failover or load-balancing algorithms
 across all resolvers in the group. Groups too are resolvers and can therefore be nested
 into other groups for more complex query routing.
 
-Routers
+# Routers
 
 Routers are used to send DNS queries to resolvers, groups, or even other routers based on
 the query content. As with groups, routers too are resolvers that can be combined to form
 more advanced configurations.
 
-Listeners
+# Listeners
 
 While resolvers handle outgoing queries to upstream servers, listeners are the receivers
 of queries. Multiple listeners can be started for different protocols and on different ports.
@@ -34,6 +34,5 @@ via DNS-over-TLS to provide privacy.
 	r := rdns.NewDoTClient("1.1.1.1:853")
 	l := rdns.NewDNSListener("127.0.0.1:53", "udp", r)
 	panic(l.Start())
-
 */
 package rdns

--- a/doqclient.go
+++ b/doqclient.go
@@ -29,7 +29,7 @@ type DoQClient struct {
 	log      *slog.Logger
 	metrics  *ListenerMetrics
 
-	connection  *quicConnection
+	connection   *quicConnection
 	connectionV4 *quicConnection // IPv4-specific connection, used in dual-stack mode
 	connectionV6 *quicConnection // IPv6-specific connection, used in dual-stack mode
 }

--- a/odohlistener.go
+++ b/odohlistener.go
@@ -263,7 +263,7 @@ func (s *ODoHListener) ODoHqueryHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	w.Header().Set("Content-Type", ODOH_CONTENT_TYPE)
-	w.Write(obliviousResponse.Marshal())
+	_, _ = w.Write(obliviousResponse.Marshal())
 }
 
 func (s *ODoHListener) String() string {
@@ -271,7 +271,7 @@ func (s *ODoHListener) String() string {
 }
 
 func (s *ODoHListener) configHandler(w http.ResponseWriter, r *http.Request) {
-	w.Write(s.config)
+	_, _ = w.Write(s.config)
 }
 
 func getKeyPair(opt ODoHListenerOptions) (odoh.ObliviousDoHKeyPair, error) {

--- a/rate-limiter.go
+++ b/rate-limiter.go
@@ -41,7 +41,7 @@ type RateLimiterMetrics struct {
 	drop *expvar.Int
 }
 
-// NewRateLimiterIP returns a new instance of a query rate limiter.
+// NewRateLimiter returns a new instance of a query rate limiter.
 func NewRateLimiter(id string, resolver Resolver, opt RateLimiterOptions) *RateLimiter {
 	if opt.Window == 0 {
 		opt.Window = 60

--- a/response-collapse.go
+++ b/response-collapse.go
@@ -18,7 +18,7 @@ type ResponseCollapseOptions struct {
 
 var _ Resolver = &ResponseCollapse{}
 
-// NewResponseMinimize returns a new instance of a response minimizer.
+// NewResponseCollapse returns a new instance of a response collapser.
 func NewResponseCollapse(id string, resolver Resolver, opt ResponseCollapseOptions) *ResponseCollapse {
 	return &ResponseCollapse{id: id, resolver: resolver, ResponseCollapseOptions: opt}
 }

--- a/version.go
+++ b/version.go
@@ -3,6 +3,5 @@ package rdns
 var (
 	BuildVersion string = "v0.1.240"
 	BuildTime    string = "Sat Aug 29 13:12:56 UTC 2026"
-	BuildNumber     string = "220"
+	BuildNumber  string = "220"
 )
-


### PR DESCRIPTION
Nothing in CI checked formatting or ran a linter. This is not hypothetical: a gofmt violation introduced in #619 survived a full green CI run and was only found by running `gofmt -l` by hand afterwards.

Four commits, because the linter could not simply be switched on.

### The release workflow had to be fixed first

`version.go` is regenerated on every release by `version-bump-release.yaml`, which rewrites the fields with perl and pads them by hand. The padding for `BuildNumber` did not match gofmt, so **every released commit carried an unformatted file**. A formatting gate would have failed on every automatic version bump.

Fixed by correcting the padding and running `gofmt -w version.go` afterwards regardless, so it stays formatted even if a field is added or renamed later. Verified by simulating the perl substitutions against the formatted file and confirming the result is gofmt-clean.

### Then gofmt over the repo

Six files: struct tag and field alignment drift, plus `doc.go`, where gofmt applies the Go 1.19 doc comment format and turns the section titles into real headings, so they render as headings on pkg.go.dev instead of running together as paragraphs. No behaviour change.

### Then the findings that survive the exclusions

Five deliberately ignored errors now assigned to `_`, so the intent is on the page rather than resting on an exclusion rule. The cache file load and periodic save both log their own failures, `srv.Stop` runs during shutdown, and the two ODoH writes have nowhere to report a failed write. `dohlistener.go` already used `_, _ = w.Write(...)`, so this matches existing practice.

The linter also found two doc comments naming a different function than the one they sit on, both copy-paste: `NewRateLimiter` documented as `NewRateLimiterIP`, `NewResponseCollapse` as `NewResponseMinimize`. Fixed rather than excluded.

### The config

Standard linter set (errcheck, govet, ineffassign, staticcheck, unused) plus gofmt. It passes clean at `0 issues`, so this is a ratchet against new problems, not a cleanup pass. Widening it later is a separate change.

Two groups of staticcheck checks are off, both of which staticcheck itself disables by default:

- **ST\*** naming and comment-form checks. The code predates them, and the ALL_CAPS ODoH path constants and underscored dedup-key fields are not worth churning.
- **QF\*** quickfix suggestions (drop an embedded field from a selector, apply De Morgan's law, omit an inferable type). Style preferences rather than defects.

**SA1019** is excluded by path for the three dtls files. pion/dtls deprecated its config and constructor API in favour of an options-based one; migrating is a real change with behaviour risk and wants its own PR rather than blocking this. The exclusion is scoped to those files so deprecations elsewhere still surface.

Starting from `all` rather than these defaults produced 25 findings, mostly ST1003 on existing names, which is what the exclusions above are calibrated against.

### Verification

`golangci-lint run ./...` reports `0 issues`. Full suite passes under `-race`. Cross-compiled windows/darwin/mips. Confirmed `run` catches formatting by reintroducing the exact `version.go` misalignment and watching it fail, so the single lint job covers the gofmt gate too.

The action is pinned to golangci-lint v2.12.2, the version these results were produced with.