### PR TITLE
Take the version from git tags instead of a committed file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,12 +72,26 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The build context excludes .git, so the version stamp has to be passed
+      # into the image build rather than derived from VCS as it is for the
+      # goreleaser builds. Read the commit from the checkout so it matches the
+      # tag being released, not whatever triggered the workflow.
+      - name: Build metadata
+        id: meta
+        run: |
+          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push images
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
+          build-args: |
+            VERSION=${{ inputs.tag || github.ref_name }}
+            COMMIT=${{ steps.meta.outputs.commit }}
+            DATE=${{ steps.meta.outputs.date }}
           tags: |
             folbricht/routedns:latest
             folbricht/routedns:${{ inputs.tag || github.ref_name }}

--- a/.github/workflows/version-bump-release.yaml
+++ b/.github/workflows/version-bump-release.yaml
@@ -1,8 +1,8 @@
-name: Version Bump and Release
+name: Tag and Release
 
-# Runs after the "build" workflow (which builds and runs the race-enabled
-# tests) completes on master. The version bump and release only proceed if
-# that build/test run succeeded, so a red test gates the release.
+# Runs after the "build" workflow (which builds, lints and runs the race-enabled
+# tests) completes on master. Tagging and release only proceed if that run
+# succeeded, so a red test or lint gates the release.
 on:
   workflow_run:
     workflows: ["build"]
@@ -15,17 +15,18 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  tag:
     # Only release when triggered manually, or when the upstream "build"
-    # workflow succeeded for a push to master that was NOT the bot's own
-    # automatic version-bump commit (otherwise each release would re-trigger
-    # build -> this workflow indefinitely).
+    # workflow succeeded for a push to master. The event check matters because
+    # "build" also runs on pull requests, which must not release.
+    #
+    # Releasing no longer pushes a commit to master, only a tag, so there is
+    # nothing for this to re-trigger on: "build" runs on pushes to master, and
+    # a tag push is not one.
     if: >-
       ${{ github.event_name == 'workflow_dispatch' ||
           (github.event.workflow_run.conclusion == 'success' &&
-           github.event.workflow_run.event == 'push' &&
-           !startsWith(github.event.workflow_run.head_commit.message, 'Automatic version bump from GitHub Action')) }}
+           github.event.workflow_run.event == 'push') }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     permissions:
@@ -39,65 +40,46 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: master
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
+          # Tags are the source of truth for the version, so the full history
+          # is needed for git describe to find the most recent one.
+          fetch-depth: 0
 
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
+      - name: Tag the next version
         id: version
         run: |
-          echo $PWD
+          set -euo pipefail
 
-          # PULL
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git pull origin HEAD:${{ github.event.pull_request.head.sha }} --rebase
 
-          # MODIFY BUILD NUMBER
-          export CURRENT_BUILD_NUMBER=$(grep BuildNumber version.go | awk -F= '{print $2}' | cut -d'"' -f 2-2 )
-          export CHANGE_BUILD_NUMBER=$(( $CURRENT_BUILD_NUMBER  + 1 ))
+          # The most recent release tag is the source of truth for the version.
+          # Nothing in the tree records it: the binaries get their version
+          # stamped in at link time from the tag, by goreleaser and by the
+          # Docker build.
+          CURRENT=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || echo "v0.0.0")
+          MAJOR_MINOR=$(echo "$CURRENT" | cut -d. -f1,2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
+          if ! [ "$PATCH" -eq "$PATCH" ] 2>/dev/null; then
+            echo "latest tag '$CURRENT' is not vMAJOR.MINOR.PATCH, refusing to guess"
+            exit 1
+          fi
+          NEXT="$MAJOR_MINOR.$((PATCH + 1))"
+          echo "latest tag $CURRENT, releasing $NEXT from $(git rev-parse --short HEAD)"
 
-          # GET CURRENT BUILD VERSION
-          export CURRENT_BUILD_VERSION=$(grep BuildVersion version.go | awk -F= '{print $2}' | cut -d'"' -f 2-2 )
-
-          # SPLIT BUILD VERSION
-          export PR_CHANGE_BUILD_VERION=$(echo $CURRENT_BUILD_VERSION | awk -F. '{print $3}' )
-          export OLD_BUILD_VERION_PART=$(echo $CURRENT_BUILD_VERSION | awk -F. '{print $1"."$2}')
-
-          # UPDATE BUILD VERSION
-          export CHANGE_BUILD_VERSION=$OLD_BUILD_VERION_PART.$(( $PR_CHANGE_BUILD_VERION + 1 ))
-
-          # INIT DATE
-          export CURRENT_BUILD_TIME=$(date)
-
-          # UPDATE
-          perl -0777 -i -pe "s/BuildVersion.*string = \".*\"/BuildVersion string = \"$CHANGE_BUILD_VERSION\"/g" version.go
-          perl -0777 -i -pe "s/BuildTime.*string = \".*\"/BuildTime    string = \"$CURRENT_BUILD_TIME\"/g" version.go
-          perl -0777 -i -pe "s/BuildNumber.*string = \".*\"/BuildNumber  string = \"$CHANGE_BUILD_NUMBER\"/g" version.go
-
-          # The padding above matches what gofmt wants for the current field
-          # names, but it is hardcoded and would go stale if a field is added
-          # or renamed. Run gofmt so the committed file is formatted either
-          # way; CI checks formatting and would otherwise fail on every bump.
-          gofmt -w version.go
-
-          # GIT
-          git add .
-          git commit -m "Automatic version bump from GitHub Action at: `date` $CHANGE_BUILD_VERSION"
-          git tag -a $CHANGE_BUILD_VERSION -m "Automatic release version number: $CHANGE_BUILD_NUMBER. Automatic build number: $CHANGE_BUILD_VERSION. Build date: $CURRENT_BUILD_TIME"
-          # PUSH
-          git push origin HEAD:master
-          git push origin --follow-tags
+          # Tag the commit that is already on master, which the build workflow
+          # has built, tested and linted. Tagging rather than committing means
+          # the released commit is one CI has actually run against.
+          git tag -a "$NEXT" -m "Automatic release $NEXT"
+          git push origin "$NEXT"
 
           # Output tag for release workflow
-          echo "tag=$CHANGE_BUILD_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$NEXT" >> "$GITHUB_OUTPUT"
 
   release:
-    needs: build
+    needs: tag
     uses: ./.github/workflows/release.yaml
     with:
-      tag: ${{ needs.build.outputs.tag }}
+      tag: ${{ needs.tag.outputs.tag }}
     # Repository secrets (DOCKERHUB_*) are not visible to reusable
     # workflows unless explicitly inherited.
     secrets: inherit

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,6 +23,9 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
+      - -X github.com/folbricht/routedns.BuildVersion={{.Tag}}
+      - -X github.com/folbricht/routedns.BuildCommit={{.FullCommit}}
+      - -X github.com/folbricht/routedns.BuildTime={{.Date}}
     goos:
       - linux
       - darwin
@@ -59,6 +62,9 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
+      - -X github.com/folbricht/routedns.BuildVersion={{.Tag}}
+      - -X github.com/folbricht/routedns.BuildCommit={{.FullCommit}}
+      - -X github.com/folbricht/routedns.BuildTime={{.Date}}
     goos:
       - linux
     goarch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,24 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
 
+# Version stamping. The build context excludes .git (see .dockerignore), so the
+# toolchain can't derive these from VCS the way a normal build does and they
+# have to be passed in. The release workflow supplies them; a plain
+# "docker build" leaves them empty and the binary reports "(devel)".
+ARG VERSION
+ARG COMMIT
+ARG DATE
+
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} CGO_ENABLED=0 \
-	go build -trimpath -ldflags="-s -w" -o /routedns ./cmd/routedns
+	go build -trimpath -ldflags="-s -w \
+	-X github.com/folbricht/routedns.BuildVersion=$VERSION \
+	-X github.com/folbricht/routedns.BuildCommit=$COMMIT \
+	-X github.com/folbricht/routedns.BuildTime=$DATE" \
+	-o /routedns ./cmd/routedns
 
 # Distroless static base: no shell, package manager, or userland — only the
 # static binary plus CA certs, tzdata, and /etc/passwd. The :latest tag runs as

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"syscall"
@@ -1420,7 +1421,14 @@ func buildNetNS(name, xsocket string) (*rdns.NetNS, error) {
 }
 
 func printVersion() {
-	fmt.Println("Build: ", rdns.BuildNumber)
-	fmt.Println("Build Time: ", rdns.BuildTime)
-	fmt.Println("Version: ", rdns.BuildVersion)
+	b := rdns.CurrentBuild()
+	fmt.Println("Version: ", b.Version)
+	if b.Commit != "" {
+		fmt.Println("Commit:  ", b.Commit)
+	}
+	if b.Date != "" {
+		fmt.Println("Built:   ", b.Date)
+	}
+	fmt.Println("Go:      ", runtime.Version())
+	fmt.Println("OS/Arch: ", runtime.GOOS+"/"+runtime.GOARCH)
 }

--- a/lua-types.go
+++ b/lua-types.go
@@ -9,7 +9,7 @@ func (s *LuaScript) RegisterConstants() {
 	L := s.L
 
 	// Register build version
-	L.SetGlobal("BuildVersion", lua.LString(BuildVersion))
+	L.SetGlobal("BuildVersion", lua.LString(CurrentBuild().Version))
 
 	// Register TypeA, TypeAAAA, etc
 	for value, name := range dns.TypeToString {

--- a/lua_test.go
+++ b/lua_test.go
@@ -1074,7 +1074,7 @@ end`,
 	txt, ok := answer.Answer[0].(*dns.TXT)
 	require.True(t, ok)
 	require.Equal(t, uint16(dns.ClassCHAOS), txt.Hdr.Class)
-	require.Equal(t, []string{BuildVersion}, txt.Txt)
+	require.Equal(t, []string{CurrentBuild().Version}, txt.Txt)
 }
 
 func TestLuaAuthoritativeField(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -1,7 +1,72 @@
 package rdns
 
+import "runtime/debug"
+
+// Populated at link time by goreleaser, for example
+//
+//	-X github.com/folbricht/routedns.BuildVersion=v0.1.241
+//
+// They are empty for 'go install' and for local builds, where the values come
+// from the build information the toolchain embeds instead. These have to stay
+// plain string variables without an initializer: the linker's -X flag cannot
+// set a variable whose value comes from a function call.
 var (
-	BuildVersion string = "v0.1.241"
-	BuildTime    string = "Sat Aug 29 13:48:26 UTC 2026"
-	BuildNumber  string = "221"
+	BuildVersion string
+	BuildTime    string
+	BuildCommit  string
 )
+
+// BuildInfo describes the running binary.
+type BuildInfo struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
+// CurrentBuild describes the running binary, preferring the values injected at
+// link time and falling back to what the toolchain embedded. A module
+// installed with 'go install' carries its version, and a build from a checkout
+// carries the revision and its timestamp, so only a build from a source
+// tarball has nothing to report.
+func CurrentBuild() BuildInfo {
+	b := BuildInfo{
+		Version: BuildVersion,
+		Commit:  BuildCommit,
+		Date:    BuildTime,
+	}
+
+	// Whether the version was injected at link time rather than derived below.
+	linked := b.Version != ""
+
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		if b.Version == "" {
+			b.Version = bi.Main.Version
+		}
+		var modified bool
+		for _, s := range bi.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				if b.Commit == "" {
+					b.Commit = s.Value
+				}
+			case "vcs.time":
+				if b.Date == "" {
+					b.Date = s.Value
+				}
+			case "vcs.modified":
+				modified = s.Value == "true"
+			}
+		}
+		// Built from a tree with uncommitted changes, which is worth knowing
+		// when the version is quoted in a bug report. Only needed for a linked
+		// version, since the toolchain already marks a derived one.
+		if modified && linked {
+			b.Version += "+dirty"
+		}
+	}
+
+	if b.Version == "" {
+		b.Version = "unknown"
+	}
+	return b
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,27 @@
+package rdns
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurrentBuild(t *testing.T) {
+	defer func(v, c, d string) {
+		BuildVersion, BuildCommit, BuildTime = v, c, d
+	}(BuildVersion, BuildCommit, BuildTime)
+
+	// Values injected at link time win over anything the toolchain embedded.
+	// The version can pick up a "+dirty" suffix when the tree is modified.
+	BuildVersion, BuildCommit, BuildTime = "v1.2.3", "abc123", "2026-01-01T00:00:00Z"
+	b := CurrentBuild()
+	require.True(t, strings.HasPrefix(b.Version, "v1.2.3"), b.Version)
+	require.Equal(t, "abc123", b.Commit)
+	require.Equal(t, "2026-01-01T00:00:00Z", b.Date)
+
+	// Without them there is still a version to report, from the build info the
+	// toolchain embeds. This is the 'go install' and local-build case.
+	BuildVersion, BuildCommit, BuildTime = "", "", ""
+	require.NotEmpty(t, CurrentBuild().Version)
+}


### PR DESCRIPTION
Following the question about whether the version bump could be lighter, and how desync does it.

Today `version.go` is the source of truth: a workflow reads it, increments the patch and a build counter with `perl`, rewrites the file, commits, tags that commit, and pushes. goreleaser builds with only `-s -w`, so the binary is correct solely because the value was committed.

This moves to the desync shape, adapted where routedns differs: the tag is the source of truth, and the version is stamped in at link time.

### The version file is gone

`version.go` keeps the variables but with no committed values. goreleaser injects them:

```yaml
- -X github.com/folbricht/routedns.BuildVersion={{.Tag}}
- -X github.com/folbricht/routedns.BuildCommit={{.FullCommit}}
- -X github.com/folbricht/routedns.BuildTime={{.Date}}
```

`CurrentBuild()` falls back to `runtime/debug.ReadBuildInfo()` when they are empty, so `go install` and local builds still report something real rather than a stale committed string.

Two things constrained the design, both different from desync:

- **The variables stay in package `rdns`, not `main`.** `BuildVersion` is exposed to Lua scripts as a global, documented in the configuration guide, and has an example config. `-X` targets any package, so this costs nothing.
- **They stay plain strings with no initializer.** `-X` cannot set a variable whose value comes from a function call, so the fallback lives in `CurrentBuild()` rather than in the declaration.

`BuildNumber` is dropped: a monotonic counter with no equivalent in a tag or in build info, read by nothing but the version output. The commit hash replaces it.

### Releases now tag instead of commit

This is the part that fixes a real bug rather than just tidying.

The bot pushed the bump commit using the default `GITHUB_TOKEN`, and GitHub deliberately does not let those pushes start workflows. **So the commit that got tagged and released was never built, tested or linted.** Verified against the last four releases: zero workflow runs on each bump commit.

The workflow now derives the next version from the most recent tag and pushes only the tag, so it lands on the merge commit the build workflow has already built, tested and linted. The gap closes as a side effect, without needing a PAT.

It also halves master's history, since there is no longer a bump commit between every pair of real ones.

A tag that is not `vMAJOR.MINOR.PATCH` now fails the job rather than being guessed at.

### Docker needed handling

`.dockerignore` excludes `.git`, so the image build cannot fall back to VCS stamping the way a normal build can. Without passing the values in, images would have reported `(devel)`, a silent regression. The Dockerfile takes `VERSION`/`COMMIT`/`DATE` build args and the release workflow supplies them, reading the commit back from its own checkout so it matches the tag rather than whatever triggered the run.

### Verified

Installed goreleaser and ran a snapshot build:

```
$ dist/packaged_linux_amd64_v1/routedns --version
Version:  v0.1.240+dirty
Commit:   fa6ac82042cca942b019eaf155131506931a09ee
Built:    2026-08-29T16:51:24Z
```

(`+dirty` because the working tree had uncommitted changes, which is the intended marker.)

Built the image both ways:

```
--build-arg VERSION=v9.9.9-test ...  ->  Version: v9.9.9-test, Commit: deadbeef
plain build, no args                 ->  Version: (devel)
```

Also ran the tag-increment shell logic against this repo (`v0.1.240` -> `v0.1.241`) and confirmed the malformed-tag guard fires on something like `v1.2.beta`. `goreleaser check` passes, both workflow files parse, lint is clean, full suite passes under `-race`, cross-compiled windows/darwin/mips.

### Note

The workflow's display name is now "Tag and Release" since it no longer bumps anything. The filename stays `version-bump-release.yaml`: renaming it would drop the workflow's run history from the Actions UI.
