### PR TITLE
Give the systemd service somewhere to write, and harden it

### DIFF
--- a/cmd/routedns/routedns.service
+++ b/cmd/routedns/routedns.service
@@ -7,6 +7,17 @@ Type=simple
 DynamicUser=true
 NoNewPrivileges=true
 WorkingDirectory=/opt/routedns
+
+# DynamicUser implies ProtectSystem=strict and PrivateTmp, so without these the
+# service can only write to a private /tmp that is discarded when it stops, and
+# anywhere else is read-only. Options that write to disk have to point into one
+# of these directories, which systemd creates and keeps across restarts even
+# though the UID changes each time:
+#   /var/cache/routedns - cache "filename", blocklist "cache-dir"
+#   /var/log/routedns   - query-log "output-file"
+CacheDirectory=routedns
+LogsDirectory=routedns
+
 # Add capabilities below as needed by the configuration. Append them to the
 # AmbientCapabilities line, separated by spaces.
 #   CAP_NET_BIND_SERVICE - bind to ports < 1024 (already set)

--- a/cmd/routedns/routedns.service
+++ b/cmd/routedns/routedns.service
@@ -31,6 +31,33 @@ LogsDirectory=routedns
 #                          kernels older than 5.7. Since 5.7 it is not
 #                          needed for the initial bind to an interface.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Hardening. DynamicUser already implies ProtectSystem=strict, ProtectHome,
+# PrivateTmp and RemoveIPC; these are the additions on top of it.
+#
+# RestrictNamespaces is deliberately absent: it filters setns(), which the
+# `netns` option needs to enter a namespace. @system-service does permit
+# setns(), through @process, so the syscall filter below does not have the
+# same problem.
+#
+# AF_UNIX is kept for the `xsocket` option and syslog, AF_NETLINK because Go
+# enumerates interfaces through it, which `bind-if` relies on.
+ProtectHome=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ProtectProc=invisible
+ProcSubset=pid
+MemoryDenyWriteExecute=true
+LockPersonality=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+# The cache file records what has been looked up, so keep it to the service.
+UMask=0077
+
 ExecStart=/opt/routedns/routedns config.toml
 Restart=on-failure
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -5,6 +5,7 @@
 - [Overview](#overview)
   - [Split Configuration](#split-configuration)
   - [Validating a Configuration](#validating-a-configuration)
+  - [Writable Paths](#writable-paths)
   - [Regex Formatting](https://github.com/google/re2/wiki/Syntax)
 - [Listeners](#listeners)
   - [Plain DNS](#plain-dns)
@@ -133,6 +134,30 @@ routedns --check example-config/split-config/*.toml
 Building the configuration is what validates it, so `--check` does the same work startup does, short of binding sockets and answering queries. That means it reads certificates and cache files, loads blocklists from their sources (including over HTTP), and connects to Redis. Problems that only appear at that point, such as an unreadable certificate or a blocklist URL that no longer resolves, are reported.
 
 It does not bind any listener address and does not write the cache file, so it is safe to run against the configuration of an instance that is currently serving.
+
+### Writable Paths
+
+Three options write to disk: the cache `filename`, the blocklist `cache-dir`, and the query log `output-file`.
+
+Running RouteDNS directly, these can point anywhere the user can write. Under the systemd unit shipped with the deb, rpm and apk packages, they cannot. That unit uses `DynamicUser=true`, which implies `ProtectSystem=strict` and `PrivateTmp=true`, so the filesystem is read-only apart from a private `/tmp` that systemd discards when the service stops. A path under `/tmp` or `/var/tmp` is therefore worse than one that fails outright: writes succeed and the data is gone on the next restart, with nothing logged to say so.
+
+The unit declares two directories for this:
+
+| Path | Use |
+| --- | --- |
+| `/var/cache/routedns` | cache `filename`, blocklist `cache-dir` |
+| `/var/log/routedns` | query log `output-file` |
+
+```toml
+[groups.cached]
+type = "cache"
+resolvers = ["upstream"]
+backend = {type = "memory", filename = "/var/cache/routedns/cache.json", save-interval = 300}
+```
+
+systemd creates both on start and preserves their contents across restarts, which matters here because `DynamicUser` allocates a different UID each time.
+
+To write somewhere else, add the location to the unit with `ReadWritePaths=`, or drop `DynamicUser=true` and run as a fixed user that owns the directory.
 
 ## Listeners
 
@@ -401,7 +426,7 @@ The memory backend will keep all cache items in memory. It can be configured to 
 
 - `type="memory"`
 - `size` - Max number of responses to cache. Defaults to 0 which means no limit.
-- `filename` - File to use for persistent storage to disk. The cache will be initialized with the content from the file and it'll write the content to the same file on shutdown. Defaults to no persistence. The file is written by creating a temporary file in the same directory and renaming it into place, so the directory has to be writable, and a symlink at this path is replaced by a regular file rather than being written through. Point the option at the real location if the data needs to live elsewhere, for example on a tmpfs. A new file is created with mode `0600`, since it records what has been looked up; an existing file keeps whatever mode it already has.
+- `filename` - File to use for persistent storage to disk. The cache will be initialized with the content from the file and it'll write the content to the same file on shutdown. Defaults to no persistence. The file is written by creating a temporary file in the same directory and renaming it into place, so the directory has to be writable, and a symlink at this path is replaced by a regular file rather than being written through. Point the option at the real location if the data needs to live elsewhere, for example on a tmpfs. A new file is created with mode `0600`, since it records what has been looked up; an existing file keeps whatever mode it already has. When running under the systemd unit shipped with the packages, use a path under `/var/cache/routedns`; see [Writable Paths](#writable-paths).
 - `save-interval` - Interval (in seconds) to save the cache to file. Optional. If not set, the file is written only on shutdown.
 
 **Redis backend**
@@ -761,7 +786,7 @@ Options:
 - `allowlist-source` - An array of allowlists, each with `format`, `source`, and optionally `cache-dir` or `allow-failure`.
 - `edns0-ede` - Optional, include an extended error code in the response if it's blocked. Only used when the response is blocked, not when it's spoofed. The value is a struct with two keys, `code` (number) and `text` (string). Possible values for `code` are defined in [rfc8914](https://datatracker.ietf.org/doc/html/rfc8914) while `text` can carry additional information that is displayed by `dig` for example. The `text` value is a template that has access to a number of fields of query to allow customizing the response based on data in the query. See [Templates](#templates) for details. Simple placeholders in `text` would be `{{ .Question }}` for the question in the query or `{{ .ID }}` to be replaced with the query ID.
 
-When using the `cache-dir` option on a list that loads rules via HTTP, the results are cached into a file in the given directory. The filename is the URL of the source hashed with SHA256 so multiple blocklists can be cached in the same directory. If a cached file exists on startup, it is used instead of refreshing the list from the remote location (slowing down startup). As with the cache `filename` option, a new file is created with mode `0600` and an existing one keeps whatever mode it already has.
+When using the `cache-dir` option on a list that loads rules via HTTP, the results are cached into a file in the given directory. The filename is the URL of the source hashed with SHA256 so multiple blocklists can be cached in the same directory. If a cached file exists on startup, it is used instead of refreshing the list from the remote location (slowing down startup). As with the cache `filename` option, a new file is created with mode `0600` and an existing one keeps whatever mode it already has. When running under the systemd unit shipped with the packages, use a path under `/var/cache/routedns`; see [Writable Paths](#writable-paths).
 
 To avoid errors at startup when for example a remote blocklist isn't available, the `allow-failure` option can be used. Any errors encountered will be logged but not cause a failure to start. If a failure occurs during runtime, the previous ruleset will be reused.
 
@@ -1685,7 +1710,7 @@ To enable query-logging, add an element with `type = "query-log"` in the groups 
 
 Options:
 
-- `output-file` - Name of the file to write logs to, leave blank for STDOUT. Logs are appended to the file and there is no rotation.
+- `output-file` - Name of the file to write logs to, leave blank for STDOUT. Logs are appended to the file and there is no rotation. When running under the systemd unit shipped with the packages, use a path under `/var/log/routedns`; see [Writable Paths](#writable-paths).
 - `output-format` - Output format. Defaults to "text".
 
 Examples:

--- a/packaging/routedns.service
+++ b/packaging/routedns.service
@@ -6,6 +6,17 @@ After=network.target
 Type=simple
 DynamicUser=true
 NoNewPrivileges=true
+
+# DynamicUser implies ProtectSystem=strict and PrivateTmp, so without these the
+# service can only write to a private /tmp that is discarded when it stops, and
+# anywhere else is read-only. Options that write to disk have to point into one
+# of these directories, which systemd creates and keeps across restarts even
+# though the UID changes each time:
+#   /var/cache/routedns - cache "filename", blocklist "cache-dir"
+#   /var/log/routedns   - query-log "output-file"
+CacheDirectory=routedns
+LogsDirectory=routedns
+
 # Add capabilities below as needed by the configuration. Append them to the
 # AmbientCapabilities line, separated by spaces.
 #   CAP_NET_BIND_SERVICE - bind to ports < 1024 (already set)

--- a/packaging/routedns.service
+++ b/packaging/routedns.service
@@ -30,6 +30,33 @@ LogsDirectory=routedns
 #                          kernels older than 5.7. Since 5.7 it is not
 #                          needed for the initial bind to an interface.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Hardening. DynamicUser already implies ProtectSystem=strict, ProtectHome,
+# PrivateTmp and RemoveIPC; these are the additions on top of it.
+#
+# RestrictNamespaces is deliberately absent: it filters setns(), which the
+# `netns` option needs to enter a namespace. @system-service does permit
+# setns(), through @process, so the syscall filter below does not have the
+# same problem.
+#
+# AF_UNIX is kept for the `xsocket` option and syslog, AF_NETLINK because Go
+# enumerates interfaces through it, which `bind-if` relies on.
+ProtectHome=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ProtectProc=invisible
+ProcSubset=pid
+MemoryDenyWriteExecute=true
+LockPersonality=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+# The cache file records what has been looked up, so keep it to the service.
+UMask=0077
+
 ExecStart=/usr/bin/routedns /etc/routedns/config.toml
 Restart=on-failure
 


### PR DESCRIPTION
Two commits: a functional fix, then hardening.

## The service had nowhere to write

Both units use `DynamicUser=true`, which implies `ProtectSystem=strict` and `PrivateTmp=true`. Neither is written in the file, which is part of why this went unnoticed. The result is a read-only filesystem apart from a private `/tmp` that systemd discards when the service stops, and nothing declared a writable directory.

Three documented options write to disk: the cache `filename`, the blocklist `cache-dir`, and the query log `output-file`. On a packaged install none of them worked, in one of two ways:

- A path outside `/tmp` failed outright against the read-only hierarchy.
- A path inside `/tmp` or `/var/tmp` was worse: the write succeeded, and the data was gone on the next restart with nothing logged.

The second case is what the documentation steered people into. Every example uses `/tmp/cache.json`, `/var/tmp/cache.json`, `cache-dir = "/var/tmp"` or `/tmp/query.log`, so cache persistence and the blocklist startup cache silently did nothing for anyone following them.

Demonstrated with transient units carrying the same protections:

```
write to /var/tmp     -> "wrote ok", invisible outside the unit,
                         and GONE on the next start
write to CACHE_DIRECTORY -> SURVIVED across starts
```

`CacheDirectory=routedns` and `LogsDirectory=routedns` fix it. systemd creates both and preserves their contents across restarts, which matters here because `DynamicUser` allocates a different UID each time.

`StateDirectory` is not included. The DNS cache and the blocklist copies are both regenerable, so `/var/cache` is the right home and nothing needs `/var/lib` today.

A new "Writable Paths" section in the configuration guide explains the constraint and gives the paths, linked from each of the three options.

## Hardening

Takes the shipped unit from **8.3 EXPOSED to 4.6 OK** as scored by `systemd-analyze security`.

`UMask=0077` is worth singling out: the cache file records what has been looked up, and the analyzer flagged files as world-readable by default.

Two things are deliberately absent, since they interact with documented options:

- **`RestrictNamespaces`** filters `setns()`, which the `netns` option needs.
- **`CapabilityBoundingSet`** buys little given `NoNewPrivileges` already prevents gaining capabilities, and it would quietly invalidate the instructions directly above it, which tell users to add `CAP_SYS_ADMIN` or `CAP_NET_ADMIN` to `AmbientCapabilities` for the netns, fwmark and bind-if options.

`SystemCallFilter=@system-service` **is** included. My first pass excluded it on the assumption that it would block `setns()` too, which turned out to be wrong: `@system-service` pulls in `@process`, which contains `setns`. Confirmed by expanding the group recursively, then by running the binary under the full directive set and resolving through a DoT upstream with no seccomp kills.

`RestrictAddressFamilies` keeps `AF_UNIX` for the `xsocket` option and syslog, and `AF_NETLINK` because Go enumerates interfaces through it, which `bind-if` relies on.

Both units are updated, `packaging/routedns.service` which ships in the deb, rpm and apk packages, and `cmd/routedns/routedns.service` which the docs point at.