### PR TITLE
Describe every example config, and say where templates apply

### DIFF
--- a/cmd/routedns/example-config/block-split-cache.toml
+++ b/cmd/routedns/example-config/block-split-cache.toml
@@ -1,3 +1,7 @@
+# A blocklist in front of a router that splits the remaining queries: a couple of
+# domains go to a cached resolver, everything else goes to a second resolver
+# without a cache.
+
 title = "RouteDNS configuration for split DNS"
 
 [resolvers.cloudflare-dot]

--- a/cmd/routedns/example-config/blocklist-domain-ede.toml
+++ b/cmd/routedns/example-config/blocklist-domain-ede.toml
@@ -1,3 +1,7 @@
+# Domain blocklist that attaches an EDNS0 Extended DNS Error to blocked
+# responses, telling the client why it was blocked. The text is a template
+# populated with data from the query and the rule that matched.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/blocklist-domain.toml
+++ b/cmd/routedns/example-config/blocklist-domain.toml
@@ -1,3 +1,7 @@
+# The "domain" blocklist format. Entries match an exact name ('evil.com'), a
+# name and all of its sub-domains ('.facebook.com'), or the sub-domains only
+# ('*.twitter.com').
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/blocklist-hosts.toml
+++ b/cmd/routedns/example-config/blocklist-hosts.toml
@@ -1,3 +1,7 @@
+# The "hosts" blocklist format, which uses the syntax of /etc/hosts. Entries can
+# block a name outright or spoof it to a given address, with the IPv4 and IPv6
+# answers set independently.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/blocklist-local.toml
+++ b/cmd/routedns/example-config/blocklist-local.toml
@@ -1,3 +1,6 @@
+# Blocklist loaded from a file on disk and refreshed once a day. The source path
+# is relative to cmd/routedns, so run this example from there.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/blocklist-mac.toml
+++ b/cmd/routedns/example-config/blocklist-mac.toml
@@ -1,3 +1,6 @@
+# Blocklist matching on the client's MAC address rather than the query name.
+# Clients supply the address in EDNS0 option 65001.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/blocklist-regexp.toml
+++ b/cmd/routedns/example-config/blocklist-regexp.toml
@@ -1,3 +1,6 @@
+# The "regexp" blocklist format, which is the default. Patterns are matched
+# against the fully qualified name including the trailing dot.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/dnssec-validator.toml
+++ b/cmd/routedns/example-config/dnssec-validator.toml
@@ -1,3 +1,6 @@
+# Validates DNSSEC signatures on every response using the built-in IANA root
+# trust anchor. Responses that fail validation are rejected.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/ecs-modifier-add.toml
+++ b/cmd/routedns/example-config/ecs-modifier-add.toml
@@ -1,3 +1,6 @@
+# Adds an EDNS Client Subnet option to outgoing queries with a fixed address and
+# prefix length, so the upstream resolver returns answers for that subnet.
+
 [resolvers.google-dot]
 address = "8.8.8.8:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/ecs-modifier-delete.toml
+++ b/cmd/routedns/example-config/ecs-modifier-delete.toml
@@ -1,3 +1,6 @@
+# Strips any EDNS Client Subnet option from queries before they go upstream, so
+# the client's network is not passed on.
+
 [resolvers.google-dot]
 address = "8.8.8.8:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/ecs-modifier-privacy.toml
+++ b/cmd/routedns/example-config/ecs-modifier-privacy.toml
@@ -1,3 +1,7 @@
+# Truncates EDNS Client Subnet to a coarser prefix instead of removing it. The
+# upstream resolver keeps enough location to answer well, without seeing the
+# client's address.
+
 [resolvers.google-dot]
 address = "8.8.8.8:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/edns0-modifier.toml
+++ b/cmd/routedns/example-config/edns0-modifier.toml
@@ -1,3 +1,6 @@
+# Adds an arbitrary EDNS0 option to queries. Here that is option 65001 carrying
+# a MAC address, which OpenDNS uses to identify a device.
+
 [resolvers.opendns-udp]
 address = "208.67.222.220:53"
 protocol = "udp"

--- a/cmd/routedns/example-config/odoh-client.toml
+++ b/cmd/routedns/example-config/odoh-client.toml
@@ -1,3 +1,7 @@
+# Oblivious DoH client. Queries are encrypted for the target and sent through a
+# proxy, so neither one sees the query content and the client address at the
+# same time. Without an address set, the target is contacted directly.
+
 [resolvers.cloudflare-odoh]
 # Address of the odoh proxy server. If empty, the target is used directly.
 # address = "https://odoh-proxy.example.com/proxy"

--- a/cmd/routedns/example-config/prefetch.toml
+++ b/cmd/routedns/example-config/prefetch.toml
@@ -1,3 +1,7 @@
+# A standalone prefetch group in front of a cache. It counts how often names are
+# queried and refreshes the popular ones before they expire. It does not cache
+# anything itself and relies on the cache upstream of it.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/query-log.toml
+++ b/cmd/routedns/example-config/query-log.toml
@@ -1,3 +1,6 @@
+# Logs every query and the response it received, in text or JSON format, to
+# STDOUT or to a file.
+
 [listeners.local-udp]
 address = "127.0.0.1:53"
 protocol = "udp"

--- a/cmd/routedns/example-config/response-blocklist-asn.toml
+++ b/cmd/routedns/example-config/response-blocklist-asn.toml
@@ -1,3 +1,6 @@
+# Blocks responses whose answer IP belongs to one of the listed ASNs. Requires a
+# local MaxMind GeoLite2 ASN database.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/response-blocklist-geo.toml
+++ b/cmd/routedns/example-config/response-blocklist-geo.toml
@@ -1,3 +1,7 @@
+# Blocks responses by the geo location of the answer IP. With filter = true only
+# the matching records are removed rather than the whole response being replaced
+# with NXDOMAIN. Requires a local MaxMind GeoLite2 City database.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/response-blocklist-ip-remote.toml
+++ b/cmd/routedns/example-config/response-blocklist-ip-remote.toml
@@ -1,3 +1,6 @@
+# Response IP blocklist with the CIDR lists downloaded over HTTP and refreshed
+# once a day.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/response-blocklist-ip.toml
+++ b/cmd/routedns/example-config/response-blocklist-ip.toml
@@ -1,3 +1,7 @@
+# Blocks responses that contain an answer IP in one of the listed CIDRs. Returns
+# NXDOMAIN by default; set filter = true to strip just the matching records and
+# return the rest.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/response-blocklist-name-remote.toml
+++ b/cmd/routedns/example-config/response-blocklist-name-remote.toml
@@ -1,3 +1,6 @@
+# Response name blocklist loaded from a file on disk and refreshed once a day.
+# The source path is relative to cmd/routedns, so run this example from there.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/response-blocklist-name.toml
+++ b/cmd/routedns/example-config/response-blocklist-name.toml
@@ -1,3 +1,6 @@
+# Blocks responses that contain a name on the list anywhere in their records,
+# such as a CNAME target or an NS record, rather than matching the query name.
+
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"

--- a/cmd/routedns/example-config/restricted-listener.toml
+++ b/cmd/routedns/example-config/restricted-listener.toml
@@ -1,3 +1,6 @@
+# A listener that only answers clients in the networks given in allowed-net.
+# Queries from anywhere else are ignored.
+
 title = "RouteDNS configuration with a listener only allowing some client networks"
 
 [resolvers.cloudflare-dot]

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -899,7 +899,7 @@ Options:
 - `filter` - If set to `true` in `response-blocklist-ip`, matching records will be removed from responses rather than the whole response. If there is no answer record left after applying the filter, NXDOMAIN will be returned unless an alternative `blocklist-resolver` is defined.
 - `inverted` - Inverts the behavior of the blocklist. If set to `true`, only IPs that are on the blocklist are allowed and responses containing an IP not on the blocklist are blocked. Can be combined with `filter` to remove any IPs not on the blocklist from the response.
 - `location-db` - If location-based IP blocking is used, this specifies the GeoIP data file to load. Optional. Defaults to /usr/share/GeoIP/GeoLite2-City.mmdb
-- `edns0-ede` - Optional, include an extended error code in the response if it's blocked. Only used when the response is blocked, not when it's spoofed. The value is a struct with two keys, `code` (number) and `text` (string). Possible values for `code` are defined in [rfc8914](https://datatracker.ietf.org/doc/html/rfc8914) while `text` can carry additional information that is displayed by `dig` for example. The `text` value is a template that has access to a number of fields of query to allow customizing the response based on data in the query. See [Templates](#templates) for details. Simple placeholders in `text` would be `{{ .Question }}` for the question in the query or `{{ .ID }}` to be replaced with the query ID.
+- `edns0-ede` - Optional, include an extended error code in the response if it's blocked. Only used when the response is blocked, not when it's spoofed. The value is a struct with two keys, `code` (number) and `text` (string). Possible values for `code` are defined in [rfc8914](https://datatracker.ietf.org/doc/html/rfc8914) while `text` can carry additional information that is displayed by `dig` for example. The `text` value is a template that has access to a number of fields of query to allow customizing the response based on data in the query. See [Templates](#templates) for details. Simple placeholders in `text` would be `{{ .Question }}` for the question in the query or `{{ .ID }}` to be replaced with the query ID. Only `response-blocklist-ip` acts on this option; it is ignored by `response-blocklist-name`.
 
 Location-based blocking requires a list of GeoName IDs of geographical entities (Continent, Country, City or Subdivision) and the GeoName ID, like `2750405` for Netherlands. The GeoName ID can be looked up in [https://www.geonames.org/](https://www.geonames.org/). Locations are read from a MAXMIND GeoIP2 database that either has to be present in `/usr/share/GeoIP/GeoLite2-City.mmdb` or is configured with the `location-db` option. Similarly, using a different location database (`/usr/share/GeoIP/GeoLite2-ASN.mmdb`) it is possible to block IP responses located in specific ASNs (Autonomous System Number). `blocklist-format` should be set to `asn` in that case.
 
@@ -2405,7 +2405,16 @@ Example config files: [fwmark-bind-if.toml](../cmd/routedns/example-config/fwmar
 
 ## Templates
 
-Some groups support templates, i.e. allow placeholder in text fields that will be populated at runtime with data from a query. This can for example be used in the extended error text returned from a blocklist. In that case, the configuration would set a text with placeholders like this `"Blocked {{ .Question }} with ID {{ .ID }} because reasons"`. The placeholders in between `{{` and `}}` would then be replaced with data from the query when a query is blocked and the response returned. The template syntax is explained in more detail [here](https://pkg.go.dev/text/template).
+Some options hold templates, i.e. text with placeholders that are populated at runtime with data from the query. Placeholders between `{{` and `}}` are replaced when the response is built. The template syntax is explained in more detail [here](https://pkg.go.dev/text/template).
+
+Templates are supported in the following places:
+
+| Option | Where |
+| --- | --- |
+| `edns0-ede` `text` | [Query Blocklist](#query-blocklist), [Response Blocklist](#response-blocklist) (`response-blocklist-ip` only), [Static Responder](#static-responder), [Static Template Responder](#static-template-responder) |
+| `answer`, `ns`, `extra` | [Static Template Responder](#static-template-responder) |
+
+An extended error text on a blocklist, for example, would be configured as `"Blocked {{ .Question }} with ID {{ .ID }} because reasons"` and filled in when a query is blocked.
 
 **Data available to templates**
 


### PR DESCRIPTION
Two small gaps left over from the docs pass.

## Header comments

22 of the 109 example configs opened straight into TOML with nothing saying what they demonstrate. #624 describes them in the index, but the comment is what a reader sees on opening the file, and it is what tells them whether they have the right one. All 109 now start with a two or three line comment.

The files covered are the blocklist format examples (`domain`, `hosts`, `regexp`, `mac`, `domain-ede`), the local and remote response blocklists, the three ECS modifier variants, `edns0-modifier`, `odoh-client`, `prefetch`, `query-log`, `dnssec-validator`, `block-split-cache` and `restricted-listener`.

Each was read rather than described from its filename, which mattered in a few cases. `block-split-cache.toml` is a blocklist in front of a router that sends some domains to a cached resolver and the rest to an uncached one, not a split cache. `response-blocklist-geo.toml` sets `filter = true`, so it strips the matching records instead of replacing the response.

## Where templates apply

The Templates chapter opened with "Some groups support templates" and never said which. There are exactly two places:

- the `edns0-ede` `text` on `blocklist-v2`, `response-blocklist-ip`, `static-responder` and `static-template`
- the `answer`, `ns` and `extra` records of `static-template`

Both are now listed in a table at the top of the chapter, linked to the sections that define them.

## One thing found while checking that

The Response Blocklist section documents `edns0-ede` for the section as a whole, but only `response-blocklist-ip` acts on it. `ResponseBlocklistNameOptions` carries an `EDNS0EDETemplate` field and the `case "response-blocklist-name"` branch in `main.go` never sets it, so setting `edns0-ede` on a `response-blocklist-name` group is a silent no-op. The key decodes, so the unknown-option warning from #616 does not fire either.

This change only documents the limitation. Wiring the option up is a two-line change in `main.go` if that is the preferred fix, but it is a behaviour change rather than a docs one, so it is not in here.

## Verification

All 109 examples start with a comment. `--check` over all of them is unchanged at 102 pass, with the same 7 failing on placeholder certificate paths and a missing GeoIP database. The guide has no anchor link without a matching heading.