### PR TITLE
Tag the commit that was built, not master's head

### DIFF
--- a/.github/workflows/version-bump-release.yaml
+++ b/.github/workflows/version-bump-release.yaml
@@ -2,7 +2,9 @@ name: Tag and Release
 
 # Runs after the "build" workflow (which builds, lints and runs the race-enabled
 # tests) completes on master. Tagging and release only proceed if that run
-# succeeded, so a red test or lint gates the release.
+# succeeded, so a red test or lint gates the release. Everything below works on
+# the commit that build ran against, not on master's head, which is a different
+# commit whenever another PR merges while the first build is still going.
 on:
   workflow_run:
     workflows: ["build"]
@@ -27,6 +29,11 @@ jobs:
       ${{ github.event_name == 'workflow_dispatch' ||
           (github.event.workflow_run.conclusion == 'success' &&
            github.event.workflow_run.event == 'push') }}
+    # Serialise close merges so the second run sees the first one's tag. Only
+    # tagging; the releases that follow can overlap.
+    concurrency:
+      group: tag
+      cancel-in-progress: false
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     permissions:
@@ -39,9 +46,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
         with:
-          ref: master
-          # Tags are the source of truth for the version, so the full history
-          # is needed for git describe to find the most recent one.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # Tags are the source of truth for the version, so full history.
           fetch-depth: 0
 
       - name: Tag the next version
@@ -52,11 +58,23 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          # The most recent release tag is the source of truth for the version.
-          # Nothing in the tree records it: the binaries get their version
-          # stamped in at link time from the tag, by goreleaser and by the
-          # Docker build.
-          CURRENT=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || echo "v0.0.0")
+          SHA=$(git rev-parse HEAD)
+
+          # Already shipped, either tagged by a re-run or carried along by a
+          # later release that went out first. Tagging again would put a higher
+          # version on an older commit.
+          EXISTING=$(git tag --contains "$SHA" --list 'v[0-9]*' --sort=v:refname | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "$SHA already released in $EXISTING, nothing to do"
+            exit 0
+          fi
+
+          # The highest tag in the repo is the source of truth for the version;
+          # nothing in the tree records it. Every tag, not `git describe`: HEAD
+          # may be behind master's tip, and a version that went backwards there
+          # would collide with a tag that already exists.
+          CURRENT=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1)
+          CURRENT=${CURRENT:-v0.0.0}
           MAJOR_MINOR=$(echo "$CURRENT" | cut -d. -f1,2)
           PATCH=$(echo "$CURRENT" | cut -d. -f3)
           if ! [ "$PATCH" -eq "$PATCH" ] 2>/dev/null; then
@@ -66,10 +84,9 @@ jobs:
           NEXT="$MAJOR_MINOR.$((PATCH + 1))"
           echo "latest tag $CURRENT, releasing $NEXT from $(git rev-parse --short HEAD)"
 
-          # Tag the commit that is already on master, which the build workflow
-          # has built, tested and linted. Tagging rather than committing means
-          # the released commit is one CI has actually run against.
-          git tag -a "$NEXT" -m "Automatic release $NEXT"
+          # Tagging rather than committing keeps the released commit one that
+          # CI has actually run against.
+          git tag -a "$NEXT" "$SHA" -m "Automatic release $NEXT"
           git push origin "$NEXT"
 
           # Output tag for release workflow
@@ -77,6 +94,8 @@ jobs:
 
   release:
     needs: tag
+    # Empty when the tag job skipped an already-released commit.
+    if: needs.tag.outputs.tag != ''
     uses: ./.github/workflows/release.yaml
     with:
       tag: ${{ needs.tag.outputs.tag }}


### PR DESCRIPTION
The tag job checked out `ref: master`. On a `workflow_run` trigger that means master as it stands when the job starts, which is not the commit the upstream build ran against whenever another PR merges in between.

## What happened

#623 and #624 merged 36 seconds apart on 2026-08-30. Both Tag and Release runs report `head_sha 7197825`:

```
v0.1.243 -> 35e7e6f  (#622)
v0.1.244 -> 7197825  (#624)
v0.1.245 -> 7197825  (#624)   <- same commit
865d4b1  (#623)               <- never tagged
```

No content was lost, since 865d4b1 is an ancestor of 7197825, so both changes ship in either release. But two releases now hold identical code and one merge produced no release of its own. The worse form of the same bug is a run tagging a head whose own build is still running or has failed, which defeats the gate this workflow exists to provide.

## The fix

- Check out `github.event.workflow_run.head_sha` and tag that commit explicitly, falling back to `github.sha` for `workflow_dispatch`.
- Take the version from the highest tag in the repository rather than from `git describe`, which only sees tags reachable from HEAD. This matters *because* of the first change: from 865d4b1, `git describe` reports v0.1.243 and would try to create v0.1.244, which already exists on another commit.
- Skip when `git tag --contains` shows the commit has already shipped, either tagged directly by a re-run of this workflow or carried along by a later release that went out first. The `release` job is conditional on the tag output so it skips too.
- `concurrency: {group: tag}` on the job serialises close merges, so the second run reads the tag the first one pushed. Only tagging is serialised; the releases that follow can overlap.

`release.yaml` already checks out `inputs.tag`, so it needs no change: once the tag is on the right commit, the release builds the right code.

## Verification

Replayed against the three real commits (865d4b1, 7197825, 91ca0c0) in a clone with the tags rolled back to v0.1.243, in all three completion orders.

In trigger order, each commit gets its own sequential tag:

```
v0.1.244 -> 865d4b1 (#623)
v0.1.245 -> 7197825 (#624)
v0.1.246 -> 91ca0c0 (#625)
```

Out of order, the superseded commit is skipped rather than taking a version number higher than the commit that contains it:

```
tagged v0.1.244 on 7197825 (#624)
865d4b1 already released in v0.1.244, nothing to do
tagged v0.1.245 on 91ca0c0 (#625)
```

Fully reversed, only the newest is tagged and both ancestors are recognised as already shipped. Re-running against an already-tagged commit is a no-op.

All four workflow files parse, the embedded shell passes `bash -n`, and no `ref: master` remains under `.github/workflows/`.

Worth noting: this cannot be fully exercised until it is on master, since `workflow_run` uses the workflow definition from the default branch. The first merge after this lands is the real test, and the first pair of close merges is the test that matters.