### PR TITLE
Check docs consistency and example configs in CI

### DIFF
--- a/.github/scripts/check-docs.sh
+++ b/.github/scripts/check-docs.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Consistency checks for the documentation. Run from the repository root:
+#
+#   .github/scripts/check-docs.sh
+#
+# Every check here has caught a real defect at least once. See #623 for the
+# anchor and link problems, #624 and #625 for the example config coverage.
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+
+GUIDE=doc/configuration.md
+EXAMPLES=cmd/routedns/example-config
+DOCS=(README.md "$GUIDE" "$EXAMPLES/README.md")
+
+fail=0
+report() {
+	echo "FAIL: $1"
+	fail=1
+}
+
+# GitHub derives a heading id by lowercasing, dropping anything that is not a
+# letter, digit, space or dash, and turning spaces into dashes.
+anchors_of() {
+	grep '^#\{2,4\} ' "$1" |
+		sed 's/^#* //' |
+		tr 'A-Z' 'a-z' |
+		sed 's/[^a-z0-9 -]//g' |
+		tr ' ' '-'
+}
+
+echo "==> relative links resolve"
+for f in "${DOCS[@]}"; do
+	dir=$(dirname "$f")
+	grep -o '](\([a-zA-Z0-9._/-]\+\))' "$f" |
+		sed 's/](//; s/)$//' |
+		sort -u |
+		while read -r link; do
+			[ -e "$dir/$link" ] || echo "  $f -> $link"
+		done
+done | grep . && report "links above point at files that do not exist"
+
+echo "==> in-document anchors resolve"
+for f in "${DOCS[@]}"; do
+	anchors_of "$f" | sort -u >/tmp/rdns-anchors.$$
+	grep -o '](#[^)]*)' "$f" |
+		sed 's/](#//; s/)//' |
+		sort -u |
+		while read -r a; do
+			grep -qx "$a" /tmp/rdns-anchors.$$ || echo "  $f -> #$a"
+		done
+	rm -f /tmp/rdns-anchors.$$
+done | grep . && report "anchors above match no heading"
+
+# Two sections rendering to the same id makes GitHub append -1 to the second,
+# so links to either one land in the wrong place. Repeated #### headings
+# (Configuration, Examples) are expected and nothing links to them.
+echo "==> no duplicate section anchors"
+for f in "${DOCS[@]}"; do
+	grep '^#\{2,3\} ' "$f" |
+		sed 's/^#* //' |
+		tr 'A-Z' 'a-z' |
+		sed 's/[^a-z0-9 -]//g' |
+		tr ' ' '-' |
+		sort | uniq -d |
+		sed "s|^|  $f -> |"
+done | grep . && report "headings above render to the same anchor"
+
+echo "==> every config option is documented"
+grep -oE 'toml:"[a-z0-9-]+"' cmd/routedns/config.go |
+	sed 's/toml:"//; s/"//' |
+	sort -u |
+	while read -r opt; do
+		grep -q "\b$opt\b" "$GUIDE" || echo "  $opt"
+	done | grep . && report "options above appear in config.go but not in $GUIDE"
+
+echo "==> every example is indexed and described"
+for f in "$EXAMPLES"/*.toml; do
+	base=$(basename "$f")
+	head -1 "$f" | grep -q '^#' || echo "  $base has no header comment"
+	grep -q "($base)" "$EXAMPLES/README.md" || echo "  $base is missing from the index"
+done | grep . && report "examples above are undocumented"
+
+if [ "$fail" -eq 0 ]; then
+	echo "docs are consistent"
+fi
+exit "$fail"

--- a/.github/scripts/check-examples.sh
+++ b/.github/scripts/check-examples.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Loads every example configuration with "routedns --check". Run from the
+# repository root:
+#
+#   .github/scripts/check-examples.sh
+#
+# --check builds everything a config defines without binding a port, which
+# means it reads certificates, loads blocklists from their sources including
+# over HTTP, and connects to Redis. Reaching the network is the point: #619
+# found every cbuijs blocklist URL returning 404 after that repo moved to
+# "main". It also means a third-party outage shows up here as a failure.
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+
+BIN=$(mktemp -d)/routedns
+go build -o "$BIN" ./cmd/routedns || exit 1
+
+# Configurations that cannot load without something the checkout does not
+# carry. Two groups, because they behave differently by environment.
+#
+# The placeholder group is unconditional: these reference
+# /path/to/{ca,client,server}.{crt,key}, which a reader is meant to replace.
+PLACEHOLDER_CERTS=(
+	mutual-tls-doh-client.toml
+	mutual-tls-doh-server.toml
+	mutual-tls-dot-client.toml
+	mutual-tls-dot-server.toml
+	use-case-5-client.toml
+	use-case-5-server.toml
+)
+
+# The geo group depends on MaxMind databases that are not redistributable and
+# so are not in the repo. They are absent on CI runners and may be installed on
+# a developer machine, so whether these are expected to fail is decided by
+# looking for the file rather than hard-coded.
+#
+# These are the paths the blocklists default to, from geoip-db.go and
+# asn-db.go. They are not configurable here on purpose: the check has to ask
+# the same question routedns will, or the two disagree and every run reports a
+# file that is fine.
+GEO_CITY_DB=/usr/share/GeoIP/GeoLite2-City.mmdb
+GEO_ASN_DB=/usr/share/GeoIP/GeoLite2-ASN.mmdb
+
+EXPECTED_FAIL=("${PLACEHOLDER_CERTS[@]}")
+[ -f "$GEO_CITY_DB" ] || EXPECTED_FAIL+=(client-blocklist-geo.toml response-blocklist-geo.toml)
+[ -f "$GEO_ASN_DB" ] || EXPECTED_FAIL+=(response-blocklist-asn.toml)
+
+is_expected_fail() {
+	local name=$1
+	for e in "${EXPECTED_FAIL[@]}"; do
+		[ "$e" = "$name" ] && return 0
+	done
+	return 1
+}
+
+cd cmd/routedns
+
+pass=0 skip=0
+unexpected_fail=() unexpected_pass=()
+
+for f in example-config/*.toml; do
+	name=$(basename "$f")
+	if timeout 60 "$BIN" --check "$f" >/dev/null 2>&1; then
+		if is_expected_fail "$name"; then
+			unexpected_pass+=("$name")
+		else
+			pass=$((pass + 1))
+		fi
+	else
+		if is_expected_fail "$name"; then
+			skip=$((skip + 1))
+		else
+			unexpected_fail+=("$name")
+		fi
+	fi
+done
+
+echo "$pass validated, $skip expected to fail"
+
+status=0
+
+if [ ${#unexpected_fail[@]} -gt 0 ]; then
+	echo
+	echo "FAIL: these configurations no longer load:"
+	for name in "${unexpected_fail[@]}"; do
+		echo "  $name"
+		"$BIN" --check "example-config/$name" 2>&1 | tail -3 | sed 's/^/      /'
+	done
+	status=1
+fi
+
+if [ ${#unexpected_pass[@]} -gt 0 ]; then
+	echo
+	echo "FAIL: these are listed in EXPECTED_FAIL but load fine now."
+	echo "Remove them from the list in $0:"
+	printf '  %s\n' "${unexpected_pass[@]}"
+	status=1
+fi
+
+exit "$status"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,40 @@ jobs:
     - name: Test
       run: go test -race ./...
 
+  # Consistency checks on the docs: links and anchors resolve, no two sections
+  # render to the same anchor, every toml option in config.go is mentioned in
+  # the guide, and every example config is described and indexed. Each of these
+  # has caught a real defect, see #623 and #624.
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Check docs
+      run: .github/scripts/check-docs.sh
+
+  # Loads every example config with --check. This reaches the network, since
+  # --check loads remote blocklists, which is what caught the dead cbuijs URLs
+  # in #619. A third-party outage will therefore show up as a failure here.
+  examples:
+    name: Examples
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Check example configs
+      run: .github/scripts/check-examples.sh
+
   # golangci-lint's standard linter set plus gofmt, configured in
   # .golangci.yml. "run" reports formatting problems too, so this is the
   # gofmt gate as well; nothing caught them before.


### PR DESCRIPTION
Two jobs covering checks that have each caught a real defect this month but were only ever run by hand.

## `Docs`

`.github/scripts/check-docs.sh` verifies that:

- relative links resolve to a file that exists
- in-document `](#anchor)` links match a heading
- no two sections render to the same anchor
- every `toml:` option in `cmd/routedns/config.go` is mentioned in the guide
- every example config has a header comment and appears in the index

#623 fixed a link to `simpel-dot-cache.toml`, 20 mixed-case anchors such as `#TTL-Modifier` that never resolved because GitHub lowercases heading ids, and two ODoH headings colliding on one anchor so a table of contents entry landed in the wrong chapter. I reintroduced each of those defects against this script and confirmed it reports them and exits non-zero. The option check catches the `gc-period` gap #623 closed; the example checks catch what #624 and #625 added.

Repeated `####` headings (`Configuration`, `Examples`) are expected and nothing links to them, so the duplicate-anchor check looks at `##` and `###` only.

Runs in about 5 seconds and needs no toolchain.

## `Examples`

`.github/scripts/check-examples.sh` loads all 109 example configs with `--check`. The ones that cannot load in a clean checkout are listed as expected failures, and the list is checked **both ways**: an entry that starts passing is reported as a failure too, so it cannot outlive its reason.

| Files | Why | Expected to fail |
| --- | --- | --- |
| four `mutual-tls-*`, two `use-case-5-*` | reference `/path/to/{ca,client,server}.{crt,key}`, placeholders a reader replaces | always |
| `client-blocklist-geo`, `response-blocklist-geo` | need `GeoLite2-City.mmdb` | when the file is absent |
| `response-blocklist-asn` | needs `GeoLite2-ASN.mmdb` | when the file is absent |

The MaxMind databases are not redistributable, so they are not in the repo. They are absent on a CI runner and may be installed on a developer machine, so the script decides by looking for the file rather than hard-coding a list. It reads the same default paths as `geoip-db.go` and `asn-db.go`, so the check and the binary cannot disagree about which configs should load.

That distinction is not hypothetical. The first version of this hard-coded the list from a run on a machine that happens to have `GeoLite2-City.mmdb` installed, so it passed locally and failed on CI with two configs the list did not account for.

Runtime is about 35 seconds on CI.

## The tradeoff worth deciding

`--check` reaches the network, because it loads remote blocklists. That is the point — it is how #619 found every `cbuijs/accomplist` URL returning 404 after that repo moved to `main` — but it does mean a third-party outage shows up here as a red check on unrelated PRs.

I have it running on every PR because catching a dead documentation link early is worth more than the occasional false red, and because that failure mode is itself information. If it turns out disruptive, moving the `Examples` job to a schedule while leaving `Docs` on PRs is a one-line change.

## Alternative considered for the six placeholder configs

Generating a test CA and client certificate in the repo would let those validate too, and there is precedent since `server.crt` and `server.key` are already committed. I did not do it here: it would mean editing six documentation files to point at real paths, and `/path/to/ca.crt` tells a reader "your path here" better than `example-config/ca.crt` does. Worth doing separately if those six rotting silently turns out to matter.