### PR TITLE
Write the shared cache record format in the redis backend

### DIFF
--- a/cache-age_test.go
+++ b/cache-age_test.go
@@ -51,10 +51,13 @@ func TestBackendsAgeIdentically(t *testing.T) {
 	require.NotNil(t, fromMemory.IsEdns0(), "the OPT record must survive")
 
 	// Redis has no test server, so go through its codec and age the result the
-	// way redisBackend.Lookup does.
-	encoded, err := encodeCacheAnswer(make([]byte, 0, 2048), item)
+	// way redisBackend.Lookup does. Both backends now encode the same way, so
+	// this is the record the memory path just served, which is the point: they
+	// must not disagree about how old an entry is. They used to, by up to a
+	// second, because the redis format truncated its timestamp.
+	encoded, err := newCacheBlob(lruKey{}, item)
 	require.NoError(t, err)
-	decoded, err := decodeCacheAnswer(encoded)
+	decoded, err := decodeRecord(encoded)
 	require.NoError(t, err)
 	require.True(t, ageCachedAnswer(decoded.Msg, q,
 		cacheAge(time.Now().UnixNano(), decoded.Timestamp.UnixNano())))

--- a/cache-redis.go
+++ b/cache-redis.go
@@ -34,81 +34,33 @@ type RedisBackendOptions struct {
 
 var _ CacheBackend = (*redisBackend)(nil)
 
-// The record format this backend writes. Version 2, the layout it shares with
-// the memory backend, is read but not yet written; see decodeRecord.
+// The record format this backend wrote before it shared a layout with the
+// memory backend. Still read, no longer written; see decodeRecord.
 const (
 	binaryFormatVersion = 1
 	headerSize          = 10
 	flagPrefetchBit     = 1 << 0
 )
 
-// decodeRecord decodes a stored record, whichever format it is in. Version 1
-// is the format above, which this backend still writes. Version 2 is the blob
-// layout shared with the memory backend, which a later release will write.
+// decodeRecord decodes a stored record, whichever format it is in. Version 2
+// is the blob layout shared with the memory backend, which this backend now
+// writes. Version 1 is the format above, which it wrote until this release.
 //
-// Reading it first is deliberate. A redis cache is shared between instances,
-// so a record written in a format an instance does not know is a miss and an
-// error log line on every lookup that finds it. Shipping the reader a release
-// ahead of the writer means that by the time anything emits version 2, the
-// instances sharing the database can already read it, and a rollback lands on
-// a build that can too.
+// Reading version 1 keeps a shared cache usable while instances are on either
+// side of the upgrade. It does not have to stay: every record is stored with a
+// TTL, so version 1 drains within one DNS TTL of the last instance writing it
+// stopping, and reading it can go then.
 func decodeRecord(b []byte) (*cacheAnswer, error) {
 	if len(b) == 0 {
 		return nil, errors.New("empty cache record")
 	}
 	switch b[0] {
-	case binaryFormatVersion:
-		return decodeCacheAnswer(b)
 	case blobVersion:
 		return cacheBlob(b).cacheAnswer()
+	case binaryFormatVersion:
+		return decodeCacheAnswer(b)
 	}
 	return nil, fmt.Errorf("unsupported cache record version: %d", b[0])
-}
-
-// encodeCacheAnswer encodes a cacheAnswer into a compact binary format:
-// - byte 0: version (1)
-// - byte 1: flags (bit0: prefetchEligible)
-// - bytes 2..9: timestamp (uint64 seconds from Unix epoch, big endian)
-// - bytes 10..N: dns.Msg wire bytes
-//
-// The message is packed into buf when it fits, so the returned slice
-// typically aliases buf. The caller owns buf and must not reuse it while
-// the result is in use.
-func encodeCacheAnswer(buf []byte, item *cacheAnswer) ([]byte, error) {
-	if cap(buf) < headerSize {
-		buf = make([]byte, headerSize+2048)
-	}
-	buf = buf[:cap(buf)]
-
-	// Pack the DNS message directly after the header. PackBuffer packs
-	// in place and only allocates a new buffer if the message doesn't fit.
-	dnsWire, err := item.Msg.PackBuffer(buf[headerSize:])
-	if err != nil {
-		return nil, fmt.Errorf("failed to pack DNS message: %w", err)
-	}
-
-	var result []byte
-	if &dnsWire[0] == &buf[headerSize] {
-		// Packed in place, header and wire bytes are contiguous in buf
-		result = buf[:headerSize+len(dnsWire)]
-	} else {
-		// The message didn't fit and PackBuffer allocated a new buffer
-		result = make([]byte, headerSize+len(dnsWire))
-		copy(result[headerSize:], dnsWire)
-	}
-
-	// Write header
-	result[0] = binaryFormatVersion
-
-	var flags byte
-	if item.PrefetchEligible {
-		flags |= flagPrefetchBit
-	}
-	result[1] = flags
-
-	binary.BigEndian.PutUint64(result[2:10], uint64(item.Timestamp.Unix()))
-
-	return result, nil
 }
 
 // decodeCacheAnswer decodes a binary-encoded cacheAnswer.
@@ -166,35 +118,30 @@ func (b *redisBackend) Store(query *dns.Msg, item *cacheAnswer) {
 	// they can't be touched from a background goroutine.
 	key := b.keyFromQuery(query)
 
-	bufPtr := packBufPool.Get().(*[]byte)
-	value, err := encodeCacheAnswer(*bufPtr, item)
+	// The redis key already encodes the question, so the record is stored
+	// under the empty key: the region costs its ten header bytes and nothing
+	// would read it back. newCacheBlob returns its own allocation, so the
+	// value can be handed to a background write as it is.
+	value, err := newCacheBlob(lruKey{}, item)
 	if err != nil {
-		putPackBuf(bufPtr)
 		Log.Error("failed to encode cache record", "error", err)
 		return
 	}
-	adoptPackBuf(bufPtr, value)
 
 	if b.opt.SyncSet {
 		b.set(key, value, ttl)
-		putPackBuf(bufPtr)
 		return
 	}
 
-	// Non-blocking semaphore acquire. The value buffer is handed to the
-	// goroutine and returned to the pool once the write completes.
+	// Non-blocking semaphore acquire.
 	select {
 	case b.asyncWriteSem <- struct{}{}:
 		go func() {
-			defer func() {
-				putPackBuf(bufPtr)
-				<-b.asyncWriteSem
-			}()
+			defer func() { <-b.asyncWriteSem }()
 			b.set(key, value, ttl)
 		}()
 	default:
 		// Semaphore full, skip async store (best-effort caching)
-		putPackBuf(bufPtr)
 		b.asyncSkipped.Add(1)
 	}
 }

--- a/cache-redis_test.go
+++ b/cache-redis_test.go
@@ -1,9 +1,9 @@
 package rdns
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
@@ -44,81 +44,6 @@ func TestRedisKeyFromQuery(t *testing.T) {
 	require.Equal(t, "example.com.:IN:A::false:192.0.2.0/24", b.keyFromQuery(queryECS(24)))
 }
 
-func TestEncodeDecode(t *testing.T) {
-	// Create a test DNS message
-	msg := new(dns.Msg)
-	msg.SetQuestion("example.com.", dns.TypeA)
-	msg.Response = true
-	msg.Rcode = dns.RcodeSuccess
-
-	// Add an answer
-	rr, err := dns.NewRR("example.com. 300 IN A 192.0.2.1")
-	require.NoError(t, err)
-	msg.Answer = append(msg.Answer, rr)
-
-	// Create a cacheAnswer
-	now := time.Now()
-	original := &cacheAnswer{
-		Timestamp:        now,
-		PrefetchEligible: true,
-		Msg:              msg,
-	}
-
-	// Encode
-	encoded, err := encodeCacheAnswer(nil, original)
-	require.NoError(t, err)
-
-	// Verify format
-	require.GreaterOrEqual(t, len(encoded), headerSize, "encoded data too short")
-
-	// Check version byte
-	require.Equal(t, byte(binaryFormatVersion), encoded[0], "version byte")
-
-	// Check flags byte
-	expectedFlags := byte(flagPrefetchBit)
-	require.Equal(t, expectedFlags, encoded[1], "flags byte")
-
-	// Decode
-	decoded, err := decodeCacheAnswer(encoded)
-	require.NoError(t, err)
-
-	// Verify fields
-	require.Equal(t, original.Timestamp.Unix(), decoded.Timestamp.Unix())
-	require.Equal(t, original.PrefetchEligible, decoded.PrefetchEligible)
-
-	// Verify DNS message
-	require.Len(t, decoded.Msg.Answer, len(original.Msg.Answer))
-	require.Equal(t, original.Msg.Question[0].Name, decoded.Msg.Question[0].Name)
-	require.Equal(t, original.Msg.Question[0].Qtype, decoded.Msg.Question[0].Qtype)
-}
-
-func TestEncodeDecodeNoPrefetch(t *testing.T) {
-	// Create a test DNS message
-	msg := new(dns.Msg)
-	msg.SetQuestion("test.example.", dns.TypeAAAA)
-	msg.Response = true
-
-	// Create a cacheAnswer with prefetch disabled
-	original := &cacheAnswer{
-		Timestamp:        time.Unix(1234567890, 0),
-		PrefetchEligible: false,
-		Msg:              msg,
-	}
-
-	// Encode
-	encoded, err := encodeCacheAnswer(nil, original)
-	require.NoError(t, err)
-
-	// Check flags byte (should be 0)
-	require.Equal(t, byte(0), encoded[1], "flags byte")
-
-	// Decode
-	decoded, err := decodeCacheAnswer(encoded)
-	require.NoError(t, err)
-
-	require.False(t, decoded.PrefetchEligible)
-}
-
 func TestDecodeInvalidData(t *testing.T) {
 	tests := []struct {
 		name string
@@ -137,133 +62,7 @@ func TestDecodeInvalidData(t *testing.T) {
 	}
 }
 
-func TestEncodeAliasesBuffer(t *testing.T) {
-	msg := new(dns.Msg)
-	msg.SetQuestion("alias.test.", dns.TypeA)
-	msg.Response = true
-
-	item := &cacheAnswer{
-		Timestamp:        time.Unix(1234567890, 0),
-		PrefetchEligible: true,
-		Msg:              msg,
-	}
-
-	// A buffer with enough capacity is used for the result
-	buf := make([]byte, 0, 2048)
-	encoded, err := encodeCacheAnswer(buf, item)
-	require.NoError(t, err)
-	require.Same(t, &buf[:1][0], &encoded[0], "expected result to alias the provided buffer")
-
-	// A buffer that's too small for the message is not used; the result
-	// must still be complete and decode correctly
-	small := make([]byte, 0, headerSize+4)
-	encodedSmall, err := encodeCacheAnswer(small, item)
-	require.NoError(t, err)
-	require.NotSame(t, &small[:1][0], &encodedSmall[0], "expected result not to alias the undersized buffer")
-	require.Equal(t, encoded, encodedSmall)
-
-	decoded, err := decodeCacheAnswer(encodedSmall)
-	require.NoError(t, err)
-	require.Equal(t, "alias.test.", decoded.Msg.Question[0].Name)
-
-	// A nil buffer works too
-	encodedNil, err := encodeCacheAnswer(nil, item)
-	require.NoError(t, err)
-	require.Equal(t, encoded, encodedNil)
-}
-
-func TestEncodeBufferReuse(t *testing.T) {
-	// Encode repeatedly into the same buffer, the way Store does with
-	// pooled buffers, and verify each result round-trips
-	msg := new(dns.Msg)
-	msg.SetQuestion("pool.test.", dns.TypeA)
-	msg.Response = true
-
-	item := &cacheAnswer{
-		Timestamp:        time.Now(),
-		PrefetchEligible: true,
-		Msg:              msg,
-	}
-
-	buf := make([]byte, 0, 2048)
-	for i := range 100 {
-		encoded, err := encodeCacheAnswer(buf, item)
-		require.NoError(t, err, "iteration %d", i)
-
-		// Verify first byte is always version
-		require.Equal(t, byte(binaryFormatVersion), encoded[0], "iteration %d: version byte", i)
-
-		// Decode to verify correctness
-		decoded, err := decodeCacheAnswer(encoded)
-		require.NoError(t, err, "iteration %d", i)
-
-		require.Equal(t, "pool.test.", decoded.Msg.Question[0].Name, "iteration %d: corrupted data", i)
-	}
-}
-
-func TestEncodeConcurrent(t *testing.T) {
-	// Test concurrent encoding, each goroutine reusing its own buffer.
-	// Each goroutine gets its own dns.Msg to avoid racing on shared message internals
-	const numGoroutines = 50
-	const numIterations = 100
-
-	errs := make(chan error, numGoroutines)
-	var wg sync.WaitGroup
-	wg.Add(numGoroutines)
-
-	for g := range numGoroutines {
-		go func(gid int) {
-			defer wg.Done()
-
-			msg := new(dns.Msg)
-			msg.SetQuestion("concurrent.test.", dns.TypeA)
-			msg.Response = true
-			rr, err := dns.NewRR("concurrent.test. 300 IN A 192.0.2.1")
-			if err != nil {
-				errs <- err
-				return
-			}
-			msg.Answer = append(msg.Answer, rr)
-
-			item := &cacheAnswer{
-				Timestamp:        time.Now(),
-				PrefetchEligible: true,
-				Msg:              msg,
-			}
-
-			buf := make([]byte, 0, 2048)
-			for i := range numIterations {
-				encoded, err := encodeCacheAnswer(buf, item)
-				if err != nil {
-					errs <- err
-					return
-				}
-				if encoded[0] != binaryFormatVersion {
-					errs <- fmt.Errorf("goroutine %d iteration %d: invalid version byte %d", gid, i, encoded[0])
-					return
-				}
-				decoded, err := decodeCacheAnswer(encoded)
-				if err != nil {
-					errs <- err
-					return
-				}
-				if decoded.Msg.Question[0].Name != "concurrent.test." {
-					errs <- fmt.Errorf("goroutine %d iteration %d: corrupted data, got name %s", gid, i, decoded.Msg.Question[0].Name)
-					return
-				}
-			}
-		}(g)
-	}
-
-	wg.Wait()
-	close(errs)
-
-	for err := range errs {
-		require.NoError(t, err, "concurrent encode/decode failed")
-	}
-}
-
-func BenchmarkEncodeCacheAnswer(b *testing.B) {
+func BenchmarkEncodeCacheRecord(b *testing.B) {
 	msg := new(dns.Msg)
 	msg.SetQuestion("bench.example.com.", dns.TypeA)
 	msg.Response = true
@@ -279,10 +78,9 @@ func BenchmarkEncodeCacheAnswer(b *testing.B) {
 		Msg:              msg,
 	}
 
-	buf := make([]byte, 0, 2048)
 	b.ReportAllocs()
 	for b.Loop() {
-		if _, err := encodeCacheAnswer(buf, item); err != nil {
+		if _, err := newCacheBlob(lruKey{}, item); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -339,18 +137,34 @@ func TestRedisReadsVersion1Records(t *testing.T) {
 	msg.SetQuestion("legacy.example.", dns.TypeA)
 	msg.Response = true
 
-	encoded, err := encodeCacheAnswer(nil, &cacheAnswer{
+	encoded := encodeVersion1(t, &cacheAnswer{
 		Timestamp:        time.Unix(1234567890, 0),
 		PrefetchEligible: true,
 		Msg:              msg,
 	})
-	require.NoError(t, err)
 	require.Equal(t, byte(binaryFormatVersion), encoded[0])
 
 	decoded, err := decodeRecord(encoded)
 	require.NoError(t, err)
 	require.True(t, decoded.PrefetchEligible)
 	require.Equal(t, "legacy.example.", decoded.Msg.Question[0].Name)
+}
+
+// encodeVersion1 writes the format this backend used before it shared a layout
+// with the memory backend. The production encoder is gone, so the compatibility
+// path needs a fixture of its own; this goes when reading version 1 does.
+func encodeVersion1(t *testing.T, item *cacheAnswer) []byte {
+	t.Helper()
+	wire, err := item.Msg.Pack()
+	require.NoError(t, err)
+	record := make([]byte, headerSize+len(wire))
+	record[0] = binaryFormatVersion
+	if item.PrefetchEligible {
+		record[1] = flagPrefetchBit
+	}
+	binary.BigEndian.PutUint64(record[2:10], uint64(item.Timestamp.Unix()))
+	copy(record[headerSize:], wire)
+	return record
 }
 
 func TestDecodeRecordRejectsUnknownVersion(t *testing.T) {

--- a/doc/caching.md
+++ b/doc/caching.md
@@ -45,7 +45,11 @@ The memory backend will keep all cache items in memory. It can be configured to 
 
 **Redis backend**
 
-The `redis` backend stores cached items in a Redis database. This allows multiple instances of routedns to share a common cache backend. The following options are supported:
+The `redis` backend stores cached items in a Redis database. This allows multiple instances of routedns to share a common cache backend.
+
+Note that the format of a stored record changes between releases from time to time. A newer instance reads what an older one wrote, but not the other way around: while instances sharing one database are on different versions, those still running the older build see a cache miss and log an error for every record the upgraded ones have written. Nothing is lost but the warm cache, and it clears without intervention, since every record is stored with a TTL and so ages out within one DNS TTL of the upgrade finishing. Upgrading all instances close together keeps the window short.
+
+The following options are supported:
 
 - `type="redis"`
 - `redis-network` - The network type, either `tcp` or `unix`. Defaults to `tcp`.


### PR DESCRIPTION
Follows #631, which taught the Redis backend to read the shared record layout. This switches the writer over to it.

Hold this until #631 has shipped in a release. The point of the split is that every instance can read the format before anything writes it, which only holds once the reader is actually deployed and running.

## What changes

`Store` builds a blob under the empty key. The Redis key already encodes the question, so repeating it in the value would only cost bytes, and the accessors need no change to read one: `message()` offsets by the key lengths, which are zero.

That leaves 18 bytes per record over the old format, 8 for an expiry Redis does not need since it has its own TTL, and 10 for the zeroed key region. On the 124 B/record measured in #614 that is about 15%.

`encodeCacheAnswer` goes, and with it the pooled buffer handling in `Store`, since `newCacheBlob` returns its own allocation and can be handed to a background write as it is.

## The drift this removes

Not only cosmetic. The old format kept its timestamp in whole seconds, and `Unix()` truncates, so a Redis-cached record was aged up to a second harder than the same entry in memory, and the two backends did not return the same TTL for one answer.

`TestBackendsAgeIdentically` now runs both sides through one layout, which is what turns it from a description into a regression test.

## Not a performance change

Worth saying plainly so it is not read as one. Measured at 300k iterations, 3 runs, single A answer:

| path | ns/op | B/op | allocs/op |
|---|---|---|---|
| `encodeCacheAnswer`, removed | ~250 | 0 | 0 |
| `newCacheBlob`, its replacement | ~430 | 96 | 1 |
| decode, either layout | ~680 | 384 | 9 |

Building a blob is about 180ns slower, because it also writes the key region. The read side does not move: both layouts store the message as packed wire, so both have to unpack it, and those 9 allocs are `dns.Msg.Unpack` either way.

Both are noise next to the round trip every lookup already pays. A localhost Redis GET is tens of microseconds, so the codec is a low single-digit percentage of the operation and less over a real network. The justification is consistency, not speed.

## Compatibility

Reading version 1 stays, so a shared cache keeps working while instances are on either side of the upgrade. It does not have to stay for long: every record is stored with a TTL, since `Store` derives one from `Expiry` and returns early if it has already passed, so version 1 records drain within one DNS TTL of the last instance writing them stopping. Dropping the version 1 decoder is a later change.

## Tests

Three came out with the encoder. Two covered `encodeCacheAnswer`'s buffer aliasing, semantics that no longer exist now that the encoder returns its own allocation. The third encoded concurrently to show the shared buffer pool is safe, which `TestMemoryBackendConcurrentStoreAndLookup` covers: every `Store` builds a blob, so it drives the same pool from eight goroutines under `-race`.

Reading version 1 keeps an `encodeVersion1` fixture, since nothing in the package writes that format any more. It goes when the decoder does.

