### PR TITLE
Index every component by its config type name

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ resolver = "dnssec-validated"
 
 ## Documentation
 
-- [Configuration Guide](doc/configuration.md) — full reference for all component types and options, split by topic
+- [Configuration Guide](doc/configuration.md) — indexed reference for every listener, resolver, group and modifier, listed by the `protocol` or `type` value that selects it
 - [Example Configs](cmd/routedns/example-config/) — 109 ready-to-use configurations, one per feature, with an index describing each
 
 ## Links

--- a/cmd/routedns/example-config/README.md
+++ b/cmd/routedns/example-config/README.md
@@ -14,54 +14,54 @@ Some of these reference supporting files by relative path (`./example-config/dom
 ./routedns --check example-config/simple-dot.toml
 ```
 
-Every option used here is described in the [Configuration Guide](../../../doc/configuration.md).
+Every option used here is described in the [Configuration Guide](../../../doc/configuration.md), which also indexes every component by the `protocol` or `type` value that selects it. The Guide column below links each example to the section describing the component it demonstrates.
 
 ## Start here
 
-| File | Description |
-| --- | --- |
-| [simple-dot.toml](simple-dot.toml) | Plain DNS on loopback, forwarded to Cloudflare over DoT. The starting point for most setups. |
-| [simple-doh.toml](simple-doh.toml) | The same, over DoH. |
-| [simple-dot-cache.toml](simple-dot-cache.toml) | DoT with a cache in front of the upstream resolver. |
-| [simple-dot-proxy.toml](simple-dot-proxy.toml) | Network-wide proxy translating plain DNS on port 53 into DoT. |
-| [use-case-1.toml](use-case-1.toml) | Local proxy with a cache, everything forwarded over DoT. |
-| [well-known.toml](well-known.toml) | Reference list of public resolvers and the protocols they support. Not meant to be run directly. |
-| [well-known-wo-ports.toml](well-known-wo-ports.toml) | The same list relying on each protocol's default port. |
-| [restricted-listener.toml](restricted-listener.toml) | Listener that only accepts queries from named client networks (`allowed-net`). |
+| File | Description | Guide |
+| --- | --- | --- |
+| [simple-dot.toml](simple-dot.toml) | Plain DNS on loopback, forwarded to Cloudflare over DoT. The starting point for most setups. | [DoT resolver](../../../doc/resolvers.md#dns-over-tls-resolver) |
+| [simple-doh.toml](simple-doh.toml) | The same, over DoH. | [DoH resolver](../../../doc/resolvers.md#dns-over-https-resolver) |
+| [simple-dot-cache.toml](simple-dot-cache.toml) | DoT with a cache in front of the upstream resolver. | [Cache](../../../doc/caching.md#cache) |
+| [simple-dot-proxy.toml](simple-dot-proxy.toml) | Network-wide proxy translating plain DNS on port 53 into DoT. | [Plain DNS listener](../../../doc/listeners.md#plain-dns) |
+| [use-case-1.toml](use-case-1.toml) | Local proxy with a cache, everything forwarded over DoT. | [Cache](../../../doc/caching.md#cache) |
+| [well-known.toml](well-known.toml) | Reference list of public resolvers and the protocols they support. Not meant to be run directly. | [Resolvers](../../../doc/resolvers.md) |
+| [well-known-wo-ports.toml](well-known-wo-ports.toml) | The same list relying on each protocol's default port. | [Resolvers](../../../doc/resolvers.md) |
+| [restricted-listener.toml](restricted-listener.toml) | Listener that only accepts queries from named client networks (`allowed-net`). | [Listener options](../../../doc/listeners.md#listeners) |
 
 ## Protocol clients (resolvers)
 
-| File | Description |
-| --- | --- |
-| [dot-client.toml](dot-client.toml) | Forward to a DoT server. |
-| [doq-client.toml](doq-client.toml) | Forward to a local DoQ server, using 0-RTT where possible. |
-| [doq-client-simple.toml](doq-client-simple.toml) | Forward to a public DoQ server. |
-| [doh-quic-client.toml](doh-quic-client.toml) | DoH over QUIC transport, with 0-RTT. |
-| [doh-quic-client-local.toml](doh-quic-client-local.toml) | DoH over QUIC against the local test server in `doh-quic-server.toml`. |
-| [dtls-client.toml](dtls-client.toml) | Forward to a DoDTLS server. |
-| [odoh-client.toml](odoh-client.toml) | Oblivious DoH client, with target and optional proxy. |
-| [bootstrap-resolver.toml](bootstrap-resolver.toml) | Resolve hostnames used elsewhere in the config (resolver endpoints, blocklist URLs) through a defined resolver. |
-| [socks5-dot.toml](socks5-dot.toml) | DoT upstream reached through a SOCKS5 proxy. |
-| [socks5-doh.toml](socks5-doh.toml) | DoH upstream reached through a SOCKS5 proxy. |
-| [socks5-udp.toml](socks5-udp.toml) | Plain DNS through a SOCKS5 proxy. |
-| [socks5-udp-resolvelocal.toml](socks5-udp-resolvelocal.toml) | The same, but resolving the server hostname locally rather than on the proxy. |
+| File | Description | Guide |
+| --- | --- | --- |
+| [dot-client.toml](dot-client.toml) | Forward to a DoT server. | [DoT resolver](../../../doc/resolvers.md#dns-over-tls-resolver) |
+| [doq-client.toml](doq-client.toml) | Forward to a local DoQ server, using 0-RTT where possible. | [DoQ resolver](../../../doc/resolvers.md#dns-over-quic-resolver) |
+| [doq-client-simple.toml](doq-client-simple.toml) | Forward to a public DoQ server. | [DoQ resolver](../../../doc/resolvers.md#dns-over-quic-resolver) |
+| [doh-quic-client.toml](doh-quic-client.toml) | DoH over QUIC transport, with 0-RTT. | [DoH resolver](../../../doc/resolvers.md#dns-over-https-resolver) |
+| [doh-quic-client-local.toml](doh-quic-client-local.toml) | DoH over QUIC against the local test server in `doh-quic-server.toml`. | [DoH resolver](../../../doc/resolvers.md#dns-over-https-resolver) |
+| [dtls-client.toml](dtls-client.toml) | Forward to a DoDTLS server. | [DTLS resolver](../../../doc/resolvers.md#dns-over-dtls-resolver) |
+| [odoh-client.toml](odoh-client.toml) | Oblivious DoH client, with target and optional proxy. | [ODoH resolver](../../../doc/resolvers.md#oblivious-dns-odoh-resolver) |
+| [bootstrap-resolver.toml](bootstrap-resolver.toml) | Resolve hostnames used elsewhere in the config (resolver endpoints, blocklist URLs) through a defined resolver. | [Bootstrap resolver](../../../doc/resolvers.md#bootstrap-resolver) |
+| [socks5-dot.toml](socks5-dot.toml) | DoT upstream reached through a SOCKS5 proxy. | [SOCKS5](../../../doc/resolvers.md#socks5-proxy-support) |
+| [socks5-doh.toml](socks5-doh.toml) | DoH upstream reached through a SOCKS5 proxy. | [SOCKS5](../../../doc/resolvers.md#socks5-proxy-support) |
+| [socks5-udp.toml](socks5-udp.toml) | Plain DNS through a SOCKS5 proxy. | [SOCKS5](../../../doc/resolvers.md#socks5-proxy-support) |
+| [socks5-udp-resolvelocal.toml](socks5-udp-resolvelocal.toml) | The same, but resolving the server hostname locally rather than on the proxy. | [SOCKS5](../../../doc/resolvers.md#socks5-proxy-support) |
 
 ## Protocol servers (listeners)
 
-| File | Description |
-| --- | --- |
-| [dot-server.toml](dot-server.toml) | DoT server. |
-| [doq-listener.toml](doq-listener.toml) | DoQ server without mutual TLS. |
-| [doh-quic-server.toml](doh-quic-server.toml) | DoH server using QUIC transport. |
-| [doh-no-tls.toml](doh-no-tls.toml) | DoH server with TLS disabled, for testing or behind a terminating proxy. |
-| [doh-behind-proxy.toml](doh-behind-proxy.toml) | DoH server taking the client address from `X-Forwarded-For` sent by a trusted reverse proxy. |
-| [dtls-server.toml](dtls-server.toml) | DoDTLS server. |
-| [odoh-listener.toml](odoh-listener.toml) | ODoH listener acting as target and proxy. |
-| [admin.toml](admin.toml) | Admin listener exposing expvar metrics over HTTPS. |
+| File | Description | Guide |
+| --- | --- | --- |
+| [dot-server.toml](dot-server.toml) | DoT server. | [DoT listener](../../../doc/listeners.md#dns-over-tls) |
+| [doq-listener.toml](doq-listener.toml) | DoQ server without mutual TLS. | [DoQ listener](../../../doc/listeners.md#dns-over-quic) |
+| [doh-quic-server.toml](doh-quic-server.toml) | DoH server using QUIC transport. | [DoH listener](../../../doc/listeners.md#dns-over-https) |
+| [doh-no-tls.toml](doh-no-tls.toml) | DoH server with TLS disabled, for testing or behind a terminating proxy. | [DoH listener](../../../doc/listeners.md#dns-over-https) |
+| [doh-behind-proxy.toml](doh-behind-proxy.toml) | DoH server taking the client address from `X-Forwarded-For` sent by a trusted reverse proxy. | [DoH listener](../../../doc/listeners.md#dns-over-https) |
+| [dtls-server.toml](dtls-server.toml) | DoDTLS server. | [DTLS listener](../../../doc/listeners.md#dns-over-dtls) |
+| [odoh-listener.toml](odoh-listener.toml) | ODoH listener acting as target and proxy. | [ODoH listener](../../../doc/listeners.md#oblivious-dns-odoh) |
+| [admin.toml](admin.toml) | Admin listener exposing expvar metrics over HTTPS. | [Admin listener](../../../doc/listeners.md#admin) |
 
 ## Mutual TLS
 
-Client and server halves of the same setup, meant to be run as a pair. They reference `/path/to/...` certificates that have to be provided.
+Client and server halves of the same setup, meant to be run as a pair. They reference `/path/to/...` certificates that have to be provided. Documented under the common options in [Listeners](../../../doc/listeners.md#listeners) (`mutual-tls`, `ca`) and [Resolvers](../../../doc/resolvers.md#resolvers) (`client-crt`, `client-key`).
 
 | File | Description |
 | --- | --- |
@@ -72,23 +72,23 @@ Client and server halves of the same setup, meant to be run as a pair. They refe
 
 ## Caching
 
-| File | Description |
-| --- | --- |
-| [cache.toml](cache.toml) | Cache with a size limit, persisted to disk on an interval. |
-| [cache-flush.toml](cache-flush.toml) | Cache that resets when a defined query name is received. |
-| [cache-rcode.toml](cache-rcode.toml) | Cache with an upper bound on the TTL of NXDOMAIN responses. |
-| [cache-redis.toml](cache-redis.toml) | Cache backed by Redis, which allows several instances to share it. |
-| [cache-with-prefetch.toml](cache-with-prefetch.toml) | Cache refreshing records itself before their TTL runs out. |
-| [prefetch.toml](prefetch.toml) | Standalone `prefetch` group that tracks frequent queries and refreshes them in a cache upstream of it. |
-| [ttl-modifier.toml](ttl-modifier.toml) | Clamp TTLs to a minimum and maximum before caching. |
-| [ttl-modifier-average.toml](ttl-modifier-average.toml) | The same using the `average` selection function. |
-| [request-dedup.toml](request-dedup.toml) | Collapse identical concurrent queries into one upstream query. |
-| [truncate-retry.toml](truncate-retry.toml) | Query over UDP, retry over TCP when the response is truncated, so only complete responses are cached. |
-| [fastest-tcp.toml](fastest-tcp.toml) | Probe the response IPs over TCP and cache only the fastest one. |
+| File | Description | Guide |
+| --- | --- | --- |
+| [cache.toml](cache.toml) | Cache with a size limit, persisted to disk on an interval. | [Cache](../../../doc/caching.md#cache) |
+| [cache-flush.toml](cache-flush.toml) | Cache that resets when a defined query name is received. | [Cache](../../../doc/caching.md#cache) |
+| [cache-rcode.toml](cache-rcode.toml) | Cache with an upper bound on the TTL of NXDOMAIN responses. | [Cache](../../../doc/caching.md#cache) |
+| [cache-redis.toml](cache-redis.toml) | Cache backed by Redis, which allows several instances to share it. | [Cache](../../../doc/caching.md#cache) |
+| [cache-with-prefetch.toml](cache-with-prefetch.toml) | Cache refreshing records itself before their TTL runs out. | [Cache](../../../doc/caching.md#cache) |
+| [prefetch.toml](prefetch.toml) | Standalone `prefetch` group that tracks frequent queries and refreshes them in a cache upstream of it. | [Prefetch](../../../doc/caching.md#prefetch) |
+| [ttl-modifier.toml](ttl-modifier.toml) | Clamp TTLs to a minimum and maximum before caching. | [TTL modifier](../../../doc/caching.md#ttl-modifier) |
+| [ttl-modifier-average.toml](ttl-modifier-average.toml) | The same using the `average` selection function. | [TTL modifier](../../../doc/caching.md#ttl-modifier) |
+| [request-dedup.toml](request-dedup.toml) | Collapse identical concurrent queries into one upstream query. | [Request dedup](../../../doc/caching.md#request-deduplication) |
+| [truncate-retry.toml](truncate-retry.toml) | Query over UDP, retry over TCP when the response is truncated, so only complete responses are cached. | [Truncate-retry](../../../doc/caching.md#retrying-truncated-responses) |
+| [fastest-tcp.toml](fastest-tcp.toml) | Probe the response IPs over TCP and cache only the fastest one. | [Fastest TCP](../../../doc/caching.md#fastest-tcp-probe) |
 
 ## Blocklists
 
-Query blocklists, matched against the name being asked for.
+Query blocklists, matched against the name being asked for. See [Query Blocklist](../../../doc/blocklists.md#query-blocklist).
 
 | File | Description |
 | --- | --- |
@@ -105,7 +105,7 @@ Query blocklists, matched against the name being asked for.
 | [blocklist-resolver.toml](blocklist-resolver.toml) | Send matching queries to a different resolver instead of answering NXDOMAIN. |
 | [block-split-cache.toml](block-split-cache.toml) | Blocklist in front of a router that splits traffic between a cached and an uncached resolver. |
 
-Response blocklists, matched against what came back.
+Response blocklists, matched against what came back. See [Response Blocklist](../../../doc/blocklists.md#response-blocklist).
 
 | File | Description |
 | --- | --- |
@@ -118,7 +118,7 @@ Response blocklists, matched against what came back.
 | [response-blocklist-name-remote.toml](response-blocklist-name-remote.toml) | The same with the list loaded from a file. |
 | [response-blocklist-name-resolver.toml](response-blocklist-name-resolver.toml) | Re-send matching queries to an alternative resolver. |
 
-Client blocklists, matched against who asked.
+Client blocklists, matched against who asked. See [Client Blocklist](../../../doc/blocklists.md#client-blocklist).
 
 | File | Description |
 | --- | --- |
@@ -129,43 +129,45 @@ Client blocklists, matched against who asked.
 
 ## Failover and load balancing
 
-| File | Description |
-| --- | --- |
-| [load-balance.toml](load-balance.toml) | Prefer resolvers with lower average response time, retrying elsewhere after a failure. |
-| [random-resolver.toml](random-resolver.toml) | Pick a resolver at random, taking failing ones out of rotation for a while. |
-| [fastest.toml](fastest.toml) | Query every resolver at once and use the first good answer. |
+| File | Description | Guide |
+| --- | --- | --- |
+| [load-balance.toml](load-balance.toml) | Prefer resolvers with lower average response time, retrying elsewhere after a failure. | [Load-balance](../../../doc/groups.md#load-balance-group) |
+| [random-resolver.toml](random-resolver.toml) | Pick a resolver at random, taking failing ones out of rotation for a while. | [Random](../../../doc/groups.md#random-group) |
+| [fastest.toml](fastest.toml) | Query every resolver at once and use the first good answer. | [Fastest](../../../doc/groups.md#fastest-group) |
 
 ## Routing
 
-| File | Description |
-| --- | --- |
-| [router.toml](router.toml) | Routes by query type and name, including an inverted route. |
-| [router-time.toml](router-time.toml) | Routes by time of day and weekday. |
-| [split-dns.toml](split-dns.toml) | Internal names to internal servers, everything else over DoT. |
-| [family-browsing.toml](family-browsing.toml) | Per-device filtering by source IP, with a filtered upstream for those devices. |
-| [use-case-2.toml](use-case-2.toml) | Corporate split DNS, company servers grouped with fail-rotate, everything else over DoH. |
-| [use-case-4.toml](use-case-4.toml) | Multiple VPNs each with their own DNS, rewriting short hostnames to the right domain. |
-| [use-case-7.toml](use-case-7.toml) | Per-client policy driven by EDNS Client Subnet when RouteDNS sits behind another resolver. |
-| [walled-garden.toml](walled-garden.toml) | Route by query type to static responders, so every query gets a canned answer and nothing reaches an upstream resolver. |
+| File | Description | Guide |
+| --- | --- | --- |
+| [router.toml](router.toml) | Routes by query type and name, including an inverted route. | [Router](../../../doc/routing.md#router) |
+| [router-time.toml](router-time.toml) | Routes by time of day and weekday. | [Router](../../../doc/routing.md#router) |
+| [split-dns.toml](split-dns.toml) | Internal names to internal servers, everything else over DoT. | [Router](../../../doc/routing.md#router) |
+| [family-browsing.toml](family-browsing.toml) | Per-device filtering by source IP, with a filtered upstream for those devices. | [Router](../../../doc/routing.md#router) |
+| [use-case-2.toml](use-case-2.toml) | Corporate split DNS, company servers grouped with fail-rotate, everything else over DoH. | [Router](../../../doc/routing.md#router) |
+| [use-case-4.toml](use-case-4.toml) | Multiple VPNs each with their own DNS, rewriting short hostnames to the right domain. | [Router](../../../doc/routing.md#router), [Replace](../../../doc/modifiers.md#replace) |
+| [use-case-7.toml](use-case-7.toml) | Per-client policy driven by EDNS Client Subnet when RouteDNS sits behind another resolver. | [ECS source routing](../../../doc/routing.md#ecs-source-routing) |
+| [walled-garden.toml](walled-garden.toml) | Route by query type to static responders, so every query gets a canned answer and nothing reaches an upstream resolver. | [Static responder](../../../doc/responders.md#static-responder) |
 
 ## Modifiers and responders
 
-| File | Description |
-| --- | --- |
-| [ecs-modifier-add.toml](ecs-modifier-add.toml) | Add an EDNS Client Subnet option to outgoing queries. |
-| [ecs-modifier-delete.toml](ecs-modifier-delete.toml) | Strip ECS from outgoing queries. |
-| [ecs-modifier-privacy.toml](ecs-modifier-privacy.toml) | Truncate ECS to a coarser prefix instead of removing it. |
-| [edns0-modifier.toml](edns0-modifier.toml) | Add an arbitrary EDNS0 option, here a MAC address for OpenDNS. |
-| [response-minimize.toml](response-minimize.toml) | Strip Extra and NS records from responses. |
-| [response-collapse.toml](response-collapse.toml) | Collapse CNAME chains in the answer. |
-| [static-extended-error.toml](static-extended-error.toml) | Static response carrying an Extended DNS Error explaining the block. |
-| [static-template.toml](static-template.toml) | Build the response from the query with a Go template. |
-| [static-template-error.toml](static-template-error.toml) | The same, returning an error response. |
-| [rfc8482.toml](rfc8482.toml) | Answer ANY queries with an HINFO record as per RFC 8482. |
-| [truncate.toml](truncate.toml) | Set the TC bit on UDP responses to push clients onto TCP. |
-| [rate-limiter.toml](rate-limiter.toml) | Limit the query rate per client subnet. |
+| File | Description | Guide |
+| --- | --- | --- |
+| [ecs-modifier-add.toml](ecs-modifier-add.toml) | Add an EDNS Client Subnet option to outgoing queries. | [ECS modifier](../../../doc/modifiers.md#edns0-client-subnet-modifier) |
+| [ecs-modifier-delete.toml](ecs-modifier-delete.toml) | Strip ECS from outgoing queries. | [ECS modifier](../../../doc/modifiers.md#edns0-client-subnet-modifier) |
+| [ecs-modifier-privacy.toml](ecs-modifier-privacy.toml) | Truncate ECS to a coarser prefix instead of removing it. | [ECS modifier](../../../doc/modifiers.md#edns0-client-subnet-modifier) |
+| [edns0-modifier.toml](edns0-modifier.toml) | Add an arbitrary EDNS0 option, here a MAC address for OpenDNS. | [EDNS0 modifier](../../../doc/modifiers.md#edns0-modifier) |
+| [response-minimize.toml](response-minimize.toml) | Strip Extra and NS records from responses. | [Response minimizer](../../../doc/modifiers.md#response-minimizer) |
+| [response-collapse.toml](response-collapse.toml) | Collapse CNAME chains in the answer. | [Response collapse](../../../doc/modifiers.md#response-collapse) |
+| [static-extended-error.toml](static-extended-error.toml) | Static response carrying an Extended DNS Error explaining the block. | [Static responder](../../../doc/responders.md#static-responder) |
+| [static-template.toml](static-template.toml) | Build the response from the query with a Go template. | [Static template](../../../doc/responders.md#static-template-responder) |
+| [static-template-error.toml](static-template-error.toml) | The same, returning an error response. | [Static template](../../../doc/responders.md#static-template-responder) |
+| [rfc8482.toml](rfc8482.toml) | Answer ANY queries with an HINFO record as per RFC 8482. | [Static responder](../../../doc/responders.md#static-responder) |
+| [truncate.toml](truncate.toml) | Set the TC bit on UDP responses to push clients onto TCP. | [Static responder](../../../doc/responders.md#static-responder) |
+| [rate-limiter.toml](rate-limiter.toml) | Limit the query rate per client subnet. | [Rate limiter](../../../doc/security.md#rate-limiter) |
 
 ## DNSSEC
+
+See [DNSSEC Validator](../../../doc/security.md#dnssec-validator).
 
 | File | Description |
 | --- | --- |
@@ -174,6 +176,8 @@ Client blocklists, matched against who asked.
 | [dnssec-validator-trust-anchors.toml](dnssec-validator-trust-anchors.toml) | Explicit trust anchors, with log-only mode. |
 
 ## Lua
+
+See [Lua Scripting](../../../doc/scripting.md#lua) and the [Lua API](../../../doc/scripting.md#lua-api).
 
 | File | Description |
 | --- | --- |
@@ -186,34 +190,34 @@ Client blocklists, matched against who asked.
 
 ## Logging and metrics
 
-| File | Description |
-| --- | --- |
-| [query-log.toml](query-log.toml) | Log queries and responses in text or JSON. |
-| [syslog.toml](syslog.toml) | Send query logs to syslog. |
-| [admin.toml](admin.toml) | expvar metrics over HTTPS. |
-| [prometheus-exporter/](prometheus-exporter/) | The admin listener paired with prometheus-expvar-exporter. |
+| File | Description | Guide |
+| --- | --- | --- |
+| [query-log.toml](query-log.toml) | Log queries and responses in text or JSON. | [Query log](../../../doc/observability.md#query-log) |
+| [syslog.toml](syslog.toml) | Send query logs to syslog. | [Syslog](../../../doc/observability.md#syslog) |
+| [admin.toml](admin.toml) | expvar metrics over HTTPS. | [Admin listener](../../../doc/listeners.md#admin) |
+| [prometheus-exporter/](prometheus-exporter/) | The admin listener paired with prometheus-expvar-exporter. | [Admin listener](../../../doc/listeners.md#admin) |
 
 ## Linux networking
 
-| File | Description |
-| --- | --- |
-| [netns.toml](netns.toml) | Listen in one network namespace and resolve in another. Needs `CAP_SYS_ADMIN`. |
-| [xsocket.toml](xsocket.toml) | The same through an xsocket server, without `CAP_SYS_ADMIN`. |
-| [fwmark-bind-if.toml](fwmark-bind-if.toml) | `SO_MARK` and `SO_BINDTODEVICE` for policy routing and multi-WAN. |
+| File | Description | Guide |
+| --- | --- | --- |
+| [netns.toml](netns.toml) | Listen in one network namespace and resolve in another. Needs `CAP_SYS_ADMIN`. | [Network namespaces](../../../doc/resolvers.md#network-namespace-support) |
+| [xsocket.toml](xsocket.toml) | The same through an xsocket server, without `CAP_SYS_ADMIN`. | [xsocket](../../../doc/resolvers.md#without-elevated-privileges-xsocket) |
+| [fwmark-bind-if.toml](fwmark-bind-if.toml) | `SO_MARK` and `SO_BINDTODEVICE` for policy routing and multi-WAN. | [fwmark, bind-if](../../../doc/resolvers.md#firewall-mark-and-interface-binding) |
 
 ## Whole-network setups
 
-| File | Description |
-| --- | --- |
-| [use-case-6.toml](use-case-6.toml) | Home network resolver: caching, TTL clamping, and query, response-name and response-IP blocklists refreshed daily. |
-| [split-config/](split-config/) | One configuration broken across several files, loaded together. |
+| File | Description | Guide |
+| --- | --- | --- |
+| [use-case-6.toml](use-case-6.toml) | Home network resolver: caching, TTL clamping, and query, response-name and response-IP blocklists refreshed daily. | [Blocklists](../../../doc/blocklists.md) |
+| [split-config/](split-config/) | One configuration broken across several files, loaded together. | [Split configuration](../../../doc/overview.md#split-configuration) |
 
 ## Supporting files
 
-| File | Description |
-| --- | --- |
-| [domains.txt](domains.txt) | Domain blocklist used by the file-based examples. |
-| [cidr.txt](cidr.txt) | CIDR list for response IP blocklists. |
-| [location.txt](location.txt) | GeoIP location list, with the ID format the geo blocklists expect. |
-| `server.crt`, `server.key` | Self-signed certificate for the TLS listener examples. |
-| `server-ec.crt`, `server-ec.key` | The same with an EC key. |
+| File | Description | Guide |
+| --- | --- | --- |
+| [domains.txt](domains.txt) | Domain blocklist used by the file-based examples. | [Query blocklist](../../../doc/blocklists.md#query-blocklist) |
+| [cidr.txt](cidr.txt) | CIDR list for response IP blocklists. | [Response blocklist](../../../doc/blocklists.md#response-blocklist) |
+| [location.txt](location.txt) | GeoIP location list, with the ID format the geo blocklists expect. | [Response blocklist](../../../doc/blocklists.md#response-blocklist) |
+| `server.crt`, `server.key` | Self-signed certificate for the TLS listener examples. | [Listener TLS options](../../../doc/listeners.md#listeners) |
+| `server-ec.crt`, `server-ec.key` | The same with an EC key. | [Listener TLS options](../../../doc/listeners.md#listeners) |

--- a/doc/blocklists.md
+++ b/doc/blocklists.md
@@ -1,8 +1,12 @@
 # Blocklists
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | **Blocklists** | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | [Resolvers](resolvers.md) | [Templates](templates.md)
+
+**On this page:** [Query Blocklist](#query-blocklist) | [Response Blocklist](#response-blocklist) | [Client Blocklist](#client-blocklist)
 
 ## Query Blocklist
+
+`type = "blocklist-v2"`
 
 Query blocklists can be added to resolver-chains to prevent further processing of queries (return NXDOMAIN or spoofed IP) or to send queries to different resolvers if the query name matches a rule on the blocklist. A blocklist can have multiple rule-sets, with different formats. In its simplest form, the blocklist has just one upstream resolver and forwards anything that does not match its rules. If a query matches, it'll be answered with NXDOMAIN or a spoofed IP, depending on what blocklist format is used.
 
@@ -146,6 +150,8 @@ Example config files: [blocklist-regexp.toml](../cmd/routedns/example-config/blo
 
 ## Response Blocklist
 
+`type = "response-blocklist-ip"` or `type = "response-blocklist-name"`
+
 Rather than filtering queries, response blocklists evaluate the response to a query and block anything that matches a filter-rule. There are two kinds of response blocklists: `response-blocklist-ip` and `response-blocklist-name`.
 
 - `response-blocklist-ip` blocks based on IP addresses in the response, by network IP (in CIDR notation) or geographical location.
@@ -262,6 +268,8 @@ blocklist           = [
 Example config files: [response-blocklist-ip.toml](../cmd/routedns/example-config/response-blocklist-ip.toml), [response-blocklist-name.toml](../cmd/routedns/example-config/response-blocklist-name.toml), [response-blocklist-ip-remote.toml](../cmd/routedns/example-config/response-blocklist-ip-remote.toml), [response-blocklist-name-remote.toml](../cmd/routedns/example-config/response-blocklist-name-remote.toml), [response-blocklist-ip-resolver.toml](../cmd/routedns/example-config/response-blocklist-ip-resolver.toml), [response-blocklist-name-resolver.toml](../cmd/routedns/example-config/response-blocklist-name-resolver.toml), [response-blocklist-geo.toml](../cmd/routedns/example-config/response-blocklist-geo.toml), [response-blocklist-asn.toml](../cmd/routedns/example-config/response-blocklist-asn.toml)
 
 ## Client Blocklist
+
+`type = "client-blocklist"`
 
 Client blocklists match the IP of the client instead of responses. By default, a client on the blocklist will receive a REFUSED, though other responses can be configured by combining it with a `static-responder`. The same options as with [response-blocklist-ip](#response-blocklist) are supported. This includes CIDR lists, static in configuration, on local disk or remote via HTTP. Also, geo location based blocklists are supported.
 

--- a/doc/caching.md
+++ b/doc/caching.md
@@ -1,8 +1,12 @@
 # Caching and Performance
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | **Caching and Performance** | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | [Resolvers](resolvers.md) | [Templates](templates.md)
+
+**On this page:** [Cache](#cache) | [Prefetch](#prefetch) | [TTL modifier](#ttl-modifier) | [Fastest TCP Probe](#fastest-tcp-probe) | [Retrying Truncated Responses](#retrying-truncated-responses) | [Request Deduplication](#request-deduplication)
 
 ## Cache
+
+`type = "cache"`
 
 A cache will store the responses to queries in memory and respond to further identical queries with the same response. To determine how long an item is kept in memory, the cache uses the lowest TTL of the RRs in the response. Responses served from the cache have their TTL updated according to the time the records spent in memory. If a query has an [ECS Subnet](https://tools.ietf.org/html/rfc7871) option, the subnet address forms part of the key to support subnet-specific answers.
 
@@ -109,6 +113,8 @@ Example config files: [cache.toml](../cmd/routedns/example-config/cache.toml), [
 
 ## Prefetch
 
+`type = "prefetch"`
+
 While [Cache](#cache) has built-in prefetch capabilities, the dedicated `prefetch` group may be more appropriate for some use cases. It tracks the number of queries made within a time window and actively prefetches frequently requested records. While it actively sends queries in order to refresh a cache, it does not cache responses itself and relies on a cache upstream from it.
 
 On multi-core systems the internal tracking caches are automatically sharded (based on `GOMAXPROCS`) to reduce lock contention under concurrent query load. This is an internal optimization only; it does not change behavior or measurably affect end-to-end query latency.
@@ -146,6 +152,8 @@ prefetch-max-items = 50
 Example config files: [prefetch.toml](../cmd/routedns/example-config/prefetch.toml)
 
 ## TTL modifier
+
+`type = "ttl-modifier"`
 
 A TTL modifier is used to adjust the time-to-live (TTL) of DNS responses. This is used to avoid frequently making the same queries to upstream because many responses have a value that is unreasonably low as outlined in this [blog](https://blog.apnic.net/2019/11/12/stop-using-ridiculously-low-dns-ttls). It's also possible to restrict very high TTL values that might be used in DNS poisoning attacks.
 
@@ -196,6 +204,8 @@ Example config files: [ttl-modifier.toml](../cmd/routedns/example-config/ttl-mod
 
 ## Fastest TCP Probe
 
+`type = "fastest-tcp"`
+
 The `fastest-tcp` element will first perform a lookup, then send TCP probes to all A or AAAA records in the response. It can then either return just the A/AAAA record for the fastest response, or all A/AAAA sorted by response time (fastest first). Since probing multiple servers can be slow, it is typically used behind a [cache](#cache) to avoid making too many probes repeatedly. Each instance can only probe one port and if different ports are to be probed depending on the query name, a router should be used in front of it as well.
 
 ### Configuration
@@ -228,6 +238,8 @@ resolvers = ["cloudflare-dot"]
 Example config files: [fastest-tcp.toml](../cmd/routedns/example-config/fastest-tcp.toml)
 
 ## Retrying Truncated Responses
+
+`type = "truncate-retry"`
 
 The `truncated-retry` element will first perform a lookup using its primary resolver. If the response from the primary is truncated, the same query is retried with the secondary `retry-resolver`. This element is only useful if the primary resolver uses either plain UDP or DTLS as those apply limits to the size of the response. In addition, it is typically used behind a [cache](#cache) which can then store the full response and respond faster to clients which too may have to retry the query if using a UDP or DTLS listener.
 
@@ -280,6 +292,8 @@ resolver = "cache"
 Example config files: [truncate-retry.toml](../cmd/routedns/example-config/truncate-retry.toml)
 
 ## Request Deduplication
+
+`type = "request-dedup"`
 
 The `request-dedup` element passes individual queries to its upstream resolver. While the first query is being processed, further queries for the same name will be blocked. Once the first query has been answered, all waiting queries are completed with the same answer. This element can be used to reduce load on upstream servers when queried by clients sending the same query multiple times.
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,353 +1,124 @@
 # RouteDNS Configuration Guide
 
-The guide is split by topic. Every section below links to the page that now holds it; the anchors on this page are unchanged, so existing links into the guide still work.
+An index of everything that can appear in a configuration file. Each component is listed under the value used to select it in TOML, `protocol` for listeners and resolvers, `type` for everything in between.
+
+New to RouteDNS? Start with the [Overview](overview.md), then look up the pieces here. Every component also has a working example under [example-config](../cmd/routedns/example-config/).
 
 [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | [Resolvers](resolvers.md) | [Templates](templates.md)
 
-## Overview
+## How a configuration is structured
 
-RouteDNS uses a config file in [TOML](https://github.com/toml-lang/toml) format which is passed to the tool as argument on the command line. See **[Overview](overview.md)**.
+A configuration is a [TOML](https://github.com/toml-lang/toml) file with four kinds of sections. Each element gets a unique name, and elements reference each other by name to form a pipeline that runs from a listener, through any number of routers, groups and modifiers, to a resolver.
 
-### Split Configuration
+```toml
+[listeners.NAME]   # receives queries from clients      -> protocol = "udp" | "dot" | ...
+[routers.NAME]     # splits the pipeline by query       -> routes = [...]
+[groups.NAME]      # everything in between              -> type = "cache" | "blocklist-v2" | ...
+[resolvers.NAME]   # sends queries upstream             -> protocol = "udp" | "doh" | ...
+```
 
-Configuration can be broken up into individual files to support large or generated configurations.
-
--> [Overview](overview.md#split-configuration)
-
-### Validating a Configuration
-
-The `--check` option loads a configuration, builds everything it defines, and exits without serving any queries.
-
--> [Overview](overview.md#validating-a-configuration)
-
-### Writable Paths
-
-Three options write to disk: the cache `filename`, the blocklist `cache-dir`, and the query log `output-file`.
-
--> [Overview](overview.md#writable-paths)
+Sections can appear in any order, and a single file can hold several independent pipelines. See the [Overview](overview.md) for a complete example, [split configurations](overview.md#split-configuration), and [validating a config](overview.md#validating-a-configuration) with `--check`.
 
 ## Listeners
 
-Listeners are query receivers that form the start of a query pipeline. See **[Listeners](listeners.md)**.
-
-### Plain DNS
-
-Regular (insecure) DNS protocol over port 53, UDP and TCP.
-
--> [Listeners](listeners.md#plain-dns)
-
-### DNS-over-TLS
-
-DNS protocol using a TLS connection (DoT) as per [RFC7858](https://tools.ietf.org/html/rfc7858).
-
--> [Listeners](listeners.md#dns-over-tls)
-
-### DNS-over-HTTPS
-
-DNS using the HTTPS protocol as per [RFC8484](https://tools.ietf.org/html/rfc8484).
-
--> [Listeners](listeners.md#dns-over-https)
-
-### Oblivious DNS (ODoH)
-
-ODoH ([RFC9230](https://datatracker.ietf.org/doc/rfc9230/)) improves the privacy of **clients** by encrypting queries for a **target** DNS server and sending them through a **proxy**, so that neither the target nor the proxy sees the query content and the source IP of the client at the same time.
-
--> [Listeners](listeners.md#oblivious-dns-odoh)
-
-### DNS-over-DTLS
-
-Similar to DoT, but uses a DTLS (UDP) connection as transport as per [RFC8094](https://tools.ietf.org/html/rfc8094).
-
--> [Listeners](listeners.md#dns-over-dtls)
-
-### DNS-over-QUIC
-
-Similar to DoT, but uses a QUIC connection as transport as per [RFC9250](https://datatracker.ietf.org/doc/rfc9250/).
-
--> [Listeners](listeners.md#dns-over-quic)
-
-### Admin
-
-The Admin listener provides metrics on RouteDNS usage and performance at https://{address}/routedns/vars/ in [expvar](https://pkg.go.dev/expvar) format.
-
--> [Listeners](listeners.md#admin)
-
-## Modifiers, Groups and Routers
-
-The processing pipeline: everything between a listener and a resolver. Split across several pages by what the component does.
-
-### Cache
-
-A cache will store the responses to queries in memory and respond to further identical queries with the same response.
-
--> [Caching and Performance](caching.md#cache)
-
-### Prefetch
-
-While [Cache](#cache) has built-in prefetch capabilities, the dedicated `prefetch` group may be more appropriate for some use cases.
-
--> [Caching and Performance](caching.md#prefetch)
-
-### TTL modifier
-
-A TTL modifier is used to adjust the time-to-live (TTL) of DNS responses.
-
--> [Caching and Performance](caching.md#ttl-modifier)
-
-### Round-Robin group
-
-A Round-Robin balancer groups multiple upstream resolvers and sends every received query to the next resolver.
-
--> [Failover and Load Balancing](groups.md#round-robin-group)
-
-### Fail-Rotate group
-
-In a Fail-Rotate group, one of the upstream resolvers or modifiers is active and receives all queries.
-
--> [Failover and Load Balancing](groups.md#fail-rotate-group)
-
-### Fail-Back group
-
-Similar to [fail-rotate](#fail-rotate-group) but will attempt to fall back to the original order (prioritizing the first) if there are no failures for a minute.
-
--> [Failover and Load Balancing](groups.md#fail-back-group)
-
-### Random group
-
-This group will pick a resolver from its list of upstream resolvers at random.
-
--> [Failover and Load Balancing](groups.md#random-group)
-
-### Load-Balance group
-
-This group distributes queries across all configured resolvers using weighted random selection based on measured response times.
-
--> [Failover and Load Balancing](groups.md#load-balance-group)
-
-### Fastest group
-
-This group will send every query to all configured resolvers but only use the fastest (successful) response.
-
--> [Failover and Load Balancing](groups.md#fastest-group)
-
-### Replace
-
-The replace modifier applies regular expressions to query strings and replaces them before forwarding the query to the upstream resolver or modifier.
-
--> [Modifiers](modifiers.md#replace)
-
-### Query Blocklist
-
-Query blocklists can be added to resolver-chains to prevent further processing of queries (return NXDOMAIN or spoofed IP) or to send queries to different resolvers if the query name matches a rule on the blocklist.
-
--> [Blocklists](blocklists.md#query-blocklist)
-
-### Response Blocklist
-
-Rather than filtering queries, response blocklists evaluate the response to a query and block anything that matches a filter-rule.
-
--> [Blocklists](blocklists.md#response-blocklist)
-
-### Client Blocklist
-
-Client blocklists match the IP of the client instead of responses.
-
--> [Blocklists](blocklists.md#client-blocklist)
-
-### EDNS0 Client Subnet Modifier
-
-A client subnet modifier is used to either remove ECS options from a query, replace/add one, or improve privacy by hiding more bits of the address.
-
--> [Modifiers](modifiers.md#edns0-client-subnet-modifier)
-
-### EDNS0 Modifier
-
-EDNS0 Modifier allows low-level operations on the EDNS0 option records in queries.
-
--> [Modifiers](modifiers.md#edns0-modifier)
-
-### Static responder
-
-A static responder can be used to terminate every query made to it with a fixed answer.
-
--> [Responders](responders.md#static-responder)
-
-### Static Template Responder
-
-A static template responder operates similarly to a [Static Responder](#static-responder) with the main difference being that the records configured are templates, meaning they can contain placeholders which can refer to data in the query, such as the question.
-
--> [Responders](responders.md#static-template-responder)
-
-### Drop
-
-Terminates a pipeline by dropping the request.
-
--> [Responders](responders.md#drop)
-
-### Response Minimizer
-
-This element passes all queries to its upstream resolver and strips all Extra and NS records from the response, making responses smaller.
-
--> [Modifiers](modifiers.md#response-minimizer)
-
-### Response Collapse
-
-This element passes all queries to its upstream resolver and collapses response chains in the answer records to just the query name and the queried type.
-
--> [Modifiers](modifiers.md#response-collapse)
-
-### Router
-
-Routers are used to direct queries to specific upstream resolvers, modifiers, or to other routers based on the query type, name, time of day, or client information.
-
--> [Routing](routing.md#router)
-
-### ECS Source Routing
-
-The `ecs-source` field allows routing based on the IP address provided in the EDNS Client Subnet (ECS) option ([RFC 7871](https://tools.ietf.org/html/rfc7871)).
-
--> [Routing](routing.md#ecs-source-routing)
-
-#### Route Evaluation Order
-
--> [Routing](routing.md#route-evaluation-order)
-
-### Rate Limiter
-
-This element is used to limit the number of queries a client or network is allowed to make in a given time period.
-
--> [DNSSEC and Rate Limiting](security.md#rate-limiter)
-
-### Fastest TCP Probe
-
-The `fastest-tcp` element will first perform a lookup, then send TCP probes to all A or AAAA records in the response.
-
--> [Caching and Performance](caching.md#fastest-tcp-probe)
-
-### Retrying Truncated Responses
-
-The `truncated-retry` element will first perform a lookup using its primary resolver.
-
--> [Caching and Performance](caching.md#retrying-truncated-responses)
-
-### Request Deduplication
-
-The `request-dedup` element passes individual queries to its upstream resolver.
-
--> [Caching and Performance](caching.md#request-deduplication)
-
-### Syslog
-
-The `syslog` element can be used to log requests and/or responses to local or remote syslog servers.
-
--> [Logging](observability.md#syslog)
-
-### Query Log
-
-The `query-log` element logs all DNS query details, including time, client IP, DNS question name, class and type.
-
--> [Logging](observability.md#query-log)
-
-### Lua
-
-Lua groups allow writing custom query handling logic using Lua scripts.
-
--> [Lua Scripting](scripting.md#lua)
-
-#### Sandbox
-
--> [Lua Scripting](scripting.md#sandbox)
-
-#### Lua API
-
--> [Lua Scripting](scripting.md#lua-api)
-
-### DNSSEC Validator
-
-Validates DNSSEC signatures on responses from upstream resolvers.
-
--> [DNSSEC and Rate Limiting](security.md#dnssec-validator)
-
-### DNS64
-
-Synthesizes AAAA records from A records for IPv6-only clients using NAT64 ([RFC 6147](https://datatracker.ietf.org/doc/html/rfc6147)).
-
--> [Modifiers](modifiers.md#dns64)
+Query receivers, the start of a pipeline. Defined as `[listeners.NAME]` and selected with `protocol`. Options common to all listeners, including TLS, `allowed-net` and the Linux socket options, are described at the top of the [Listeners](listeners.md) page.
+
+| `protocol` | Listener | Description |
+| --- | --- | --- |
+| `udp` | [Plain DNS](listeners.md#plain-dns) | Un-encrypted DNS over UDP. |
+| `tcp` | [Plain DNS](listeners.md#plain-dns) | Un-encrypted DNS over TCP. |
+| `dot` | [DNS-over-TLS](listeners.md#dns-over-tls) | DoT server, [RFC 7858](https://tools.ietf.org/html/rfc7858). |
+| `doh` | [DNS-over-HTTPS](listeners.md#dns-over-https) | DoH server, [RFC 8484](https://tools.ietf.org/html/rfc8484), over HTTP/2 or QUIC. |
+| `doq` | [DNS-over-QUIC](listeners.md#dns-over-quic) | DoQ server, [RFC 9250](https://datatracker.ietf.org/doc/rfc9250/). |
+| `dtls` | [DNS-over-DTLS](listeners.md#dns-over-dtls) | DTLS server, [RFC 8094](https://tools.ietf.org/html/rfc8094). |
+| `odoh` | [Oblivious DNS](listeners.md#oblivious-dns-odoh) | ODoH target and/or proxy, [RFC 9230](https://datatracker.ietf.org/doc/rfc9230/). |
+| `admin` | [Admin](listeners.md#admin) | Metrics endpoint in [expvar](https://pkg.go.dev/expvar) format, not a DNS listener. |
+
+## Routers
+
+Routers split a pipeline into multiple paths. Defined as `[routers.NAME]` with a list of routes, they have no `type`.
+
+| Component | Description |
+| --- | --- |
+| [Router](routing.md#router) | Direct queries to different elements by query name, type, class, client IP, ECS subnet or time of day. Routes are evaluated [in order](routing.md#route-evaluation-order), first match wins. |
+| [ECS source routing](routing.md#ecs-source-routing) | Route on the address in the EDNS0 Client Subnet option rather than the connection source. |
+
+## Groups, modifiers and responders
+
+Everything between a listener and a resolver. All are defined as `[groups.NAME]` and selected with `type`, regardless of what they do.
+
+| `type` | Description | Documented in |
+| --- | --- | --- |
+| `blocklist-v2` | Block or reroute queries by name, using domain, regexp, hosts-file or MAC rules from config, disk or HTTP. | [Blocklists](blocklists.md#query-blocklist) |
+| `cache` | Cache responses in memory or Redis, with optional prefetch and persistence across restarts. | [Caching](caching.md#cache) |
+| `client-blocklist` | Block or reroute queries by client IP, CIDR or geographical location. | [Blocklists](blocklists.md#client-blocklist) |
+| `dns64` | Synthesize AAAA records from A records for IPv6-only clients behind NAT64. | [Modifiers](modifiers.md#dns64) |
+| `dnssec-validator` | Validate DNSSEC signatures against root trust anchors, SERVFAIL on failure. | [Security](security.md#dnssec-validator) |
+| `drop` | Terminate a pipeline by dropping the query without replying. | [Responders](responders.md#drop) |
+| `ecs-modifier` | Add, replace, delete or truncate the EDNS0 Client Subnet option. | [Modifiers](modifiers.md#edns0-client-subnet-modifier) |
+| `edns0-modifier` | Add or remove arbitrary EDNS0 options in queries. | [Modifiers](modifiers.md#edns0-modifier) |
+| `fail-back` | Failover that returns to the preferred resolver once it recovers. | [Failover](groups.md#fail-back-group) |
+| `fail-rotate` | Failover to the next resolver on error, staying there until it too fails. | [Failover](groups.md#fail-rotate-group) |
+| `fastest` | Send every query to all resolvers, use the fastest successful response. | [Failover](groups.md#fastest-group) |
+| `fastest-tcp` | TCP-probe the A/AAAA records in a response and answer with the fastest address. | [Caching](caching.md#fastest-tcp-probe) |
+| `load-balance` | Weighted random distribution across all resolvers, based on measured response time. | [Failover](groups.md#load-balance-group) |
+| `lua` | Custom query handling logic in a sandboxed Lua script. | [Scripting](scripting.md#lua) |
+| `prefetch` | Track frequently queried records and refresh them before they expire. | [Caching](caching.md#prefetch) |
+| `query-log` | Log query details to a file or STDOUT. | [Logging](observability.md#query-log) |
+| `random` | Pick a resolver at random, deactivating failed ones for a time. | [Failover](groups.md#random-group) |
+| `rate-limiter` | Limit how many queries a client or network can make per time window. | [Security](security.md#rate-limiter) |
+| `replace` | Rewrite query names with regular expressions, mapping responses back. | [Modifiers](modifiers.md#replace) |
+| `request-dedup` | Collapse identical concurrent queries into a single upstream query. | [Caching](caching.md#request-deduplication) |
+| `response-blocklist-ip` | Block responses by IP, CIDR, geographical location or ASN. | [Blocklists](blocklists.md#response-blocklist) |
+| `response-blocklist-name` | Block responses by name in CNAME, MX, NS, PTR and SRV records. | [Blocklists](blocklists.md#response-blocklist) |
+| `response-collapse` | Collapse CNAME chains in the answer to the queried name and type. | [Modifiers](modifiers.md#response-collapse) |
+| `response-minimize` | Strip Extra and NS records from responses. | [Modifiers](modifiers.md#response-minimizer) |
+| `round-robin` | Send each query to the next resolver in the list. | [Failover](groups.md#round-robin-group) |
+| `static-responder` | Answer every query with a fixed set of records and RCode. | [Responders](responders.md#static-responder) |
+| `static-template` | Answer with records built from [templates](templates.md) using data from the query. | [Responders](responders.md#static-template-responder) |
+| `syslog` | Log queries and responses to a local or remote syslog server. | [Logging](observability.md#syslog) |
+| `truncate-retry` | Retry truncated responses with a second resolver, typically over TCP. | [Caching](caching.md#retrying-truncated-responses) |
+| `ttl-modifier` | Clamp response TTLs to a minimum and maximum. | [Caching](caching.md#ttl-modifier) |
+
+Two older names still work but should not be used in new configurations: `response-blocklist-cidr` is the former name of `response-blocklist-ip`, and `blocklist` is the first-generation query blocklist superseded by `blocklist-v2`.
 
 ## Resolvers
 
-Resolvers forward queries to other DNS servers over the network and typically represent the end of one or many processing pipelines. See **[Resolvers](resolvers.md)**.
+Query senders, the end of a pipeline. Defined as `[resolvers.NAME]` and selected with `protocol`. Options common to all resolvers, including TLS, local addresses and the Linux socket options, are described at the top of the [Resolvers](resolvers.md) page.
 
-### Bootstrapping
+| `protocol` | Resolver | Description |
+| --- | --- | --- |
+| `udp` | [Plain DNS](resolvers.md#plain-dns-resolver) | Un-encrypted DNS over UDP. |
+| `tcp` | [Plain DNS](resolvers.md#plain-dns-resolver) | Un-encrypted DNS over TCP. |
+| `dot` | [DNS-over-TLS](resolvers.md#dns-over-tls-resolver) | DoT client, [RFC 7858](https://tools.ietf.org/html/rfc7858). |
+| `doh` | [DNS-over-HTTPS](resolvers.md#dns-over-https-resolver) | DoH client, [RFC 8484](https://tools.ietf.org/html/rfc8484), over HTTP/2 or QUIC. |
+| `doq` | [DNS-over-QUIC](resolvers.md#dns-over-quic-resolver) | DoQ client, [RFC 9250](https://datatracker.ietf.org/doc/rfc9250/). |
+| `dtls` | [DNS-over-DTLS](resolvers.md#dns-over-dtls-resolver) | DTLS client, [RFC 8094](https://tools.ietf.org/html/rfc8094). |
+| `odoh` | [Oblivious DNS](resolvers.md#oblivious-dns-odoh-resolver) | ODoH client, [RFC 9230](https://datatracker.ietf.org/doc/rfc9230/). |
 
-When upstream services are configured using their hostnames, RouteDNS will first have to resolve the hostname of the service before establishing a secure connection with it.
+Resolver behaviour that is not a protocol of its own:
 
--> [Resolvers](resolvers.md#bootstrapping)
+| Topic | Description |
+| --- | --- |
+| [Bootstrapping](resolvers.md#bootstrapping) | Reach a service by IP while keeping its hostname for the TLS handshake, with `bootstrap-address` or a [bootstrap resolver](resolvers.md#bootstrap-resolver). |
+| [SOCKS5 proxy](resolvers.md#socks5-proxy-support) | Send upstream connections through a SOCKS5 proxy. |
+| [Network namespaces](resolvers.md#network-namespace-support) | Listen in one Linux netns and resolve in another, with `netns` or [xsocket](resolvers.md#without-elevated-privileges-xsocket). |
+| [fwmark and interface binding](resolvers.md#firewall-mark-and-interface-binding) | `SO_MARK` and `SO_BINDTODEVICE` for policy routing and VRFs. |
 
-### Plain DNS Resolver
+## Pages
 
-Plain, un-encrypted DNS protocol clients for UDP or TCP.
-
--> [Resolvers](resolvers.md#plain-dns-resolver)
-
-### DNS-over-TLS Resolver
-
-DNS protocol using a TLS connection (DoT) as per [RFC7858](https://tools.ietf.org/html/rfc7858).
-
--> [Resolvers](resolvers.md#dns-over-tls-resolver)
-
-### DNS-over-HTTPS Resolver
-
-DNS resolvers using the HTTPS protocol are configured with `protocol = "doh"`.
-
--> [Resolvers](resolvers.md#dns-over-https-resolver)
-
-### Oblivious DNS (ODoH) Resolver
-
-ODoH ([RFC9230](https://datatracker.ietf.org/doc/rfc9230/)) is intended to improve privacy of **clients** by encrypting queries for a **target** DNS server while sending the query through a **proxy**.
-
--> [Resolvers](resolvers.md#oblivious-dns-odoh-resolver)
-
-### DNS-over-DTLS Resolver
-
-Similar to DoT, but uses a DTLS (UDP) connection as transport as per [RFC8094](https://tools.ietf.org/html/rfc8094).
-
--> [Resolvers](resolvers.md#dns-over-dtls-resolver)
-
-### DNS-over-QUIC Resolver
-
-Similar to DoT, but uses a QUIC connection as transport as per [RFC9250](https://datatracker.ietf.org/doc/rfc9250/).
-
--> [Resolvers](resolvers.md#dns-over-quic-resolver)
-
-### Bootstrap Resolver
-
-Some configurations contain references to external resources by hostname.
-
--> [Resolvers](resolvers.md#bootstrap-resolver)
-
-### SOCKS5 Proxy Support
-
-Several resolver types support connecting to upstream servers through a SOCKS5 proxy.
-
--> [Resolvers](resolvers.md#socks5-proxy-support)
-
-### Network Namespace Support
-
-On Linux, listeners and resolvers can be assigned to different network namespaces using the `netns` option.
-
--> [Resolvers](resolvers.md#network-namespace-support)
-
-#### Without elevated privileges: xsocket
-
--> [Resolvers](resolvers.md#without-elevated-privileges-xsocket)
-
-### Firewall Mark and Interface Binding
-
-On Linux, listeners and resolvers support two socket-level options for advanced routing.
-
--> [Resolvers](resolvers.md#firewall-mark-and-interface-binding)
-
-## Templates
-
-Some options hold text with placeholders that are filled in from the query at runtime. See **[Templates](templates.md)**.
+| Page | Covers |
+| --- | --- |
+| [Overview](overview.md) | File format, pipeline model, split configurations, `--check`, writable paths. |
+| [Listeners](listeners.md) | All listener protocols and the options common to them. |
+| [Routing](routing.md) | Routers, route matching and evaluation order, ECS source routing. |
+| [Blocklists](blocklists.md) | Query, response and client blocklists, rule formats and sources. |
+| [Caching and Performance](caching.md) | Cache, prefetch, TTL modifier, TCP probing, truncate-retry, deduplication. |
+| [Failover and Load Balancing](groups.md) | Round-robin, fail-rotate, fail-back, random, load-balance, fastest. |
+| [Modifiers](modifiers.md) | Name replacement, EDNS0 and ECS manipulation, response trimming, DNS64. |
+| [Responders](responders.md) | Static and templated answers, dropping queries. |
+| [Lua Scripting](scripting.md) | Lua groups, the sandbox, and the exposed API. |
+| [DNSSEC and Rate Limiting](security.md) | DNSSEC validation and per-client rate limits. |
+| [Logging](observability.md) | Syslog and query logging. |
+| [Resolvers](resolvers.md) | All resolver protocols, bootstrapping, proxies and Linux socket options. |
+| [Templates](templates.md) | Placeholder syntax for options that take templated text. |

--- a/doc/groups.md
+++ b/doc/groups.md
@@ -1,8 +1,10 @@
 # Failover and Load Balancing
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | **Failover and Load Balancing** | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | [Resolvers](resolvers.md) | [Templates](templates.md)
 
 ## Round-Robin group
+
+`type = "round-robin"`
 
 A Round-Robin balancer groups multiple upstream resolvers and sends every received query to the next resolver. It effectively balances the query load evenly over a number of upstream resolvers or modifiers.
 
@@ -23,6 +25,8 @@ type = "round-robin"
 ```
 
 ## Fail-Rotate group
+
+`type = "fail-rotate"`
 
 In a Fail-Rotate group, one of the upstream resolvers or modifiers is active and receives all queries. If the active resolver fails, i.e. no response or returns SERVFAIL, the next becomes active and the request is retried. If the last resolver fails the first becomes the active again. There's no time-based automatic fail-back.
 
@@ -46,6 +50,8 @@ type = "fail-rotate"
 
 ## Fail-Back group
 
+`type = "fail-back"`
+
 Similar to [fail-rotate](#fail-rotate-group) but will attempt to fall back to the original order (prioritizing the first) if there are no failures for a minute. Failure means either no response or it returns SERVFAIL.
 
 ### Configuration
@@ -68,6 +74,8 @@ type = "fail-back"
 ```
 
 ## Random group
+
+`type = "random"`
 
 This group will pick a resolver from its list of upstream resolvers at random. Resolvers that fail will be deactivated for an amount of time before being re-tried.
 
@@ -93,6 +101,8 @@ resolvers = ["cloudflare-dot-1", "cloudflare-dot-2", "google-dot"]
 Example config files: [random-resolver.toml](../cmd/routedns/example-config/random-resolver.toml)
 
 ## Load-Balance group
+
+`type = "load-balance"`
 
 This group distributes queries across all configured resolvers using weighted random selection based on measured response times. Resolvers with lower average response times receive proportionally more traffic. If the selected resolver fails, the query is retried with another resolver until one succeeds or all have been tried.
 
@@ -125,6 +135,8 @@ failure-penalty = 5
 Example config files: [load-balance.toml](../cmd/routedns/example-config/load-balance.toml)
 
 ## Fastest group
+
+`type = "fastest"`
 
 This group will send every query to all configured resolvers but only use the fastest (successful) response. Slower responses are discarded. Use sparingly as this increases the overall query load on upstream resolvers.
 

--- a/doc/listeners.md
+++ b/doc/listeners.md
@@ -1,6 +1,8 @@
 # Listeners
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | **Listeners** | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | [Resolvers](resolvers.md) | [Templates](templates.md)
+
+**On this page:** [Plain DNS](#plain-dns) | [DNS-over-TLS](#dns-over-tls) | [DNS-over-HTTPS](#dns-over-https) | [Oblivious DNS (ODoH)](#oblivious-dns-odoh) | [DNS-over-DTLS](#dns-over-dtls) | [DNS-over-QUIC](#dns-over-quic) | [Admin](#admin)
 
 Listeners are query receivers that form the start of a query pipeline. Queries received by a listener are then forwarded to routers, groups, or to resolvers directly. Several DNS protocols are supported.
 
@@ -31,6 +33,8 @@ The DNS-over-HTTPS listener also accepts the client IP address from trusted reve
 
 ## Plain DNS
 
+`protocol = "udp"` or `protocol = "tcp"`
+
 Regular (insecure) DNS protocol over port 53, UDP and TCP. Setting `protocol` to `udp` will start a UDP listener, and `tcp` starts a TCP listener. In many cases both are present in a configuration if RouteDNS is used to provide DNS to local services over the loopback device.
 
 ### Configuration
@@ -59,6 +63,8 @@ resolver = "router1"
 ```
 
 ## DNS-over-TLS
+
+`protocol = "dot"`
 
 DNS protocol using a TLS connection (DoT) as per [RFC7858](https://tools.ietf.org/html/rfc7858).
 
@@ -101,6 +107,8 @@ mutual-tls = true
 Example config files: [mutual-tls-dot-server.toml](../cmd/routedns/example-config/mutual-tls-dot-server.toml)
 
 ## DNS-over-HTTPS
+
+`protocol = "doh"`
 
 DNS using the HTTPS protocol as per [RFC8484](https://tools.ietf.org/html/rfc8484).
 
@@ -159,6 +167,8 @@ Example config files: [mutual-tls-doh-server.toml](../cmd/routedns/example-confi
 
 ## Oblivious DNS (ODoH)
 
+`protocol = "odoh"`
+
 ODoH ([RFC9230](https://datatracker.ietf.org/doc/rfc9230/)) improves the privacy of **clients** by encrypting queries for a **target** DNS server and sending them through a **proxy**, so that neither the target nor the proxy sees the query content and the source IP of the client at the same time. Listeners are configured with `protocol = "odoh"` and can act as the target, the proxy, or both. See the [ODoH resolver](resolvers.md#oblivious-dns-odoh-resolver) for the client side.
 
 By default the ODoH listener listens on `/proxy` and `/dns-query`. Additionally, it will host its HPKE config under `/.well-known/odohconfigs`. If `odoh-mode = "proxy"` is set, it will only listen and handle ODoH proxy requests on `/proxy`. If set to target the listener will only handle the ODoH queries on `/dns-query`.
@@ -202,6 +212,8 @@ Example config files: [odoh-listener.toml](../cmd/routedns/example-config/odoh-l
 
 ## DNS-over-DTLS
 
+`protocol = "dtls"`
+
 Similar to DoT, but uses a DTLS (UDP) connection as transport as per [RFC8094](https://tools.ietf.org/html/rfc8094).
 
 ### Configuration
@@ -231,6 +243,8 @@ server-key = "example-config/server-ec.key"
 Example config files: [dtls-server.toml](../cmd/routedns/example-config/dtls-server.toml)
 
 ## DNS-over-QUIC
+
+`protocol = "doq"`
 
 Similar to DoT, but uses a QUIC connection as transport as per [RFC9250](https://datatracker.ietf.org/doc/rfc9250/). Configured with `protocol = "doq"`. Note that this is different from DoH over QUIC. See [DNS-over-HTTPS](#dns-over-https) for how to configure this.
 
@@ -263,6 +277,8 @@ server-key = "example-config/server.key"
 Example config files: [doq-listener.toml](../cmd/routedns/example-config/doq-listener.toml)
 
 ## Admin
+
+`protocol = "admin"`
 
 The Admin listener provides metrics on RouteDNS usage and performance at https://{address}/routedns/vars/ in [expvar](https://pkg.go.dev/expvar) format. These metrics can be exported to be usable by Prometheus using [prometheus-expvar-exporter](https://github.com/albertito/prometheus-expvar-exporter).
 

--- a/doc/modifiers.md
+++ b/doc/modifiers.md
@@ -1,8 +1,10 @@
 # Modifiers
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | **Modifiers** | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | [Resolvers](resolvers.md) | [Templates](templates.md)
 
 ## Replace
+
+`type = "replace"`
 
 The replace modifier applies regular expressions to query strings and replaces them before forwarding the query to the upstream resolver or modifier. The response is then mapped back to the original query, similar to NAT in a network. This can be useful to map hostnames to different domains on-the-fly or to append domain names to short hostname queries. In lab environments, one can replace a query for a production host with the equivalent lab host.
 
@@ -33,6 +35,8 @@ This replacer could be used where the company has multiple environment behind VP
 ```
 
 ## EDNS0 Client Subnet Modifier
+
+`type = "ecs-modifier"`
 
 A client subnet modifier is used to either remove ECS options from a query, replace/add one, or improve privacy by hiding more bits of the address. The following operation are supported by the subnet modifier:
 
@@ -91,6 +95,8 @@ Example config files: [ecs-modifier-add.toml](../cmd/routedns/example-config/ecs
 
 ## EDNS0 Modifier
 
+`type = "edns0-modifier"`
+
 EDNS0 Modifier allows low-level operations on the EDNS0 option records in queries. It can be used to add or remove custom option codes with arbitrary data.
 
 - `add` - Add an EDNS0 option to a query. If there is one already it is replaced.
@@ -124,6 +130,8 @@ Example config files: [edns0-modifier.toml](../cmd/routedns/example-config/edns0
 
 ## Response Minimizer
 
+`type = "response-minimize"`
+
 This element passes all queries to its upstream resolver and strips all Extra and NS records from the response, making responses smaller.
 
 ### Configuration
@@ -145,6 +153,8 @@ resolvers = ["google-dot"]
 Example config files: [response-minimize.toml](../cmd/routedns/example-config/response-minimize.toml)
 
 ## Response Collapse
+
+`type = "response-collapse"`
 
 This element passes all queries to its upstream resolver and collapses response chains in the answer records to just the query name and the queried type.
 
@@ -182,6 +192,8 @@ resolvers = ["google-dot"]
 Example config files: [response-collapse.toml](../cmd/routedns/example-config/response-collapse.toml)
 
 ## DNS64
+
+`type = "dns64"`
 
 Synthesizes AAAA records from A records for IPv6-only clients using NAT64 ([RFC 6147](https://datatracker.ietf.org/doc/html/rfc6147)). When an AAAA query returns no AAAA answers from upstream, DNS64 falls back to an A query and embeds the IPv4 addresses into configurable IPv6 prefixes per [RFC 6052](https://datatracker.ietf.org/doc/html/rfc6052). Queries for non-AAAA types and responses that already contain AAAA records pass through unchanged.
 

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -1,8 +1,10 @@
 # Logging
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | **Logging** | [Resolvers](resolvers.md) | [Templates](templates.md)
 
 ## Syslog
+
+`type = "syslog"`
 
 The `syslog` element can be used to log requests and/or responses to local or remote syslog servers. It forwards queries un-modified to the configured resolver. It is possible to configure multiple syslog loggers in different places. For example a logger could be configured to log and forward queries for domains on a blocklist, or behind a router.
 
@@ -38,6 +40,8 @@ log-response = true
 Example config files: [syslog.toml](../cmd/routedns/example-config/syslog.toml)
 
 ## Query Log
+
+`type = "query-log"`
 
 The `query-log` element logs all DNS query details, including time, client IP, DNS question name, class and type. Logs can be written to a file or STDOUT.
 

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | **Overview** | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | [Resolvers](resolvers.md) | [Templates](templates.md)
 
 RouteDNS uses a config file in [TOML](https://github.com/toml-lang/toml) format which is passed to the tool as argument on the command line. The configuration is broken up into sections, each of which can contain objects. Each element has a unique identifier (name) which is used to reference it from other objects in order to build a processing pipeline. A configuration can define elements in the following sections, in any order.
 

--- a/doc/resolvers.md
+++ b/doc/resolvers.md
@@ -1,6 +1,8 @@
 # Resolvers
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | **Resolvers** | [Templates](templates.md)
+
+**On this page:** [Bootstrapping](#bootstrapping) | [Plain DNS Resolver](#plain-dns-resolver) | [DNS-over-TLS Resolver](#dns-over-tls-resolver) | [DNS-over-HTTPS Resolver](#dns-over-https-resolver) | [Oblivious DNS (ODoH) Resolver](#oblivious-dns-odoh-resolver) | [DNS-over-DTLS Resolver](#dns-over-dtls-resolver) | [DNS-over-QUIC Resolver](#dns-over-quic-resolver) | [Bootstrap Resolver](#bootstrap-resolver) | [SOCKS5 Proxy Support](#socks5-proxy-support) | [Network Namespace Support](#network-namespace-support) | [Firewall Mark and Interface Binding](#firewall-mark-and-interface-binding)
 
 Resolvers forward queries to other DNS servers over the network and typically represent the end of one or many processing pipelines. Resolvers encode every query that is passed from listeners, modifiers, routers etc and send them to a DNS server without further processing. Like with other elements in the pipeline, resolvers require a unique identifier to reference them from other elements. The following protocols are supported:
 
@@ -85,6 +87,8 @@ bootstrap-address = "8.8.8.8"
 
 ## Plain DNS Resolver
 
+`protocol = "udp"` or `protocol = "tcp"`
+
 Plain, un-encrypted DNS protocol clients for UDP or TCP. Note that UDP responses can be truncated so it is common to use it in combination with a [truncate-retry](caching.md#retrying-truncated-responses) group to define a fallback.
 
 ### Configuration
@@ -114,6 +118,8 @@ protocol = "tcp"
 Example config files: [well-known.toml](../cmd/routedns/example-config/well-known.toml), [truncate-retry.toml](../cmd/routedns/example-config/truncate-retry.toml)
 
 ## DNS-over-TLS Resolver
+
+`protocol = "dot"`
 
 DNS protocol using a TLS connection (DoT) as per [RFC7858](https://tools.ietf.org/html/rfc7858).
 
@@ -162,6 +168,8 @@ client-crt = "/path/to/my-crt.pem"
 Example config files: [well-known.toml](../cmd/routedns/example-config/well-known.toml), [family-browsing.toml](../cmd/routedns/example-config/family-browsing.toml), [simple-dot-cache.toml](../cmd/routedns/example-config/simple-dot-cache.toml)
 
 ## DNS-over-HTTPS Resolver
+
+`protocol = "doh"`
 
 DNS resolvers using the HTTPS protocol are configured with `protocol = "doh"`. By default, DoH uses TCP as transport, but it can also be run over QUIC (UDP) by providing the option `transport = "quic"`. DoH supports two HTTP methods, GET and POST. By default RouteDNS uses the POST method, but can be configured to use GET as well using the option `doh = { method = "GET" }`.
 DoH with QUIC supports 0-RTT. The DoH resolver will try to use 0-RTT connection establishment if `transport = "quic"` and `enable-0rtt = true` are configured. Only GET requests can be sent as 0-RTT data, so with `enable-0rtt = true` the method defaults to GET when none is configured, and the address has to be a URL template containing the `{?dns}` parameter. RouteDNS fails to start if 0-RTT is enabled on a configuration that can't use it: with `transport` other than `"quic"`, with `doh = { method = "POST" }`, or with an address that isn't a URL template. Since 0-RTT data is replayable, only the opcodes RFC 9250 allows there (QUERY and NOTIFY) are sent as early data; queries with any other opcode wait for the handshake to complete.
@@ -224,6 +232,8 @@ Example config files: [well-known.toml](../cmd/routedns/example-config/well-know
 
 ## Oblivious DNS (ODoH) Resolver
 
+`protocol = "odoh"`
+
 ODoH ([RFC9230](https://datatracker.ietf.org/doc/rfc9230/)) is intended to improve privacy of **clients** by encrypting queries for a **target** DNS server while sending the query through a **proxy**. In this configuration, neither the target nor the proxy can see the query content and the source IP of the client at the same time. A client query is resolved as follows:
 
 - If the clients target-config = "" parameter is not set, the client will automatically query the public key of the target resolver directly from the target. This is bad for the anonymity of the client and should be avoided by pre-configuring the config beforehand.
@@ -272,6 +282,8 @@ Example config files: [odoh-client.toml](../cmd/routedns/example-config/odoh-cli
 
 ## DNS-over-DTLS Resolver
 
+`protocol = "dtls"`
+
 Similar to DoT, but uses a DTLS (UDP) connection as transport as per [RFC8094](https://tools.ietf.org/html/rfc8094).
 
 ### Configuration
@@ -302,6 +314,8 @@ Example config files: [dtls-client.toml](../cmd/routedns/example-config/dtls-cli
 
 ## DNS-over-QUIC Resolver
 
+`protocol = "doq"`
+
 Similar to DoT, but uses a QUIC connection as transport as per [RFC9250](https://datatracker.ietf.org/doc/rfc9250/). Configured with `protocol = "doq"`. Note that this is different from DoH over QUIC. See [DNS-over-HTTPS](#dns-over-https-resolver) for how to configure this.
 The DoQ resolver will try to use 0-RTT connection establishment if `enable-0rtt = true` is configured. Since 0-RTT data is replayable, only the opcodes RFC 9250 allows there (QUERY and NOTIFY) are sent as early data; queries with any other opcode wait for the handshake to complete.
 
@@ -331,6 +345,8 @@ enable-0rtt = true
 Example config files: [doq-client.toml](../cmd/routedns/example-config/doq-client.toml)
 
 ## Bootstrap Resolver
+
+`[bootstrap-resolver]`
 
 Some configurations contain references to external resources by hostname. For example remote blocklists or resolvers. For those configurations to be valid, RouteDNS needs to be able to resolve those names at startup. If RouteDNS is the only service providing name resolution, this would fail. A bootstrap resolver allows the config to provide a resolver that is used to lookup such hostnames from the RouteDNS process itself. Bootstrap resolvers support the same protocols and options as regular resolvers.
 Note: Resolvers (including the bootstrap resolver itself) also support a `bootstrap-address` property that sets the IP directly and bypasses the bootstrap resolver.

--- a/doc/responders.md
+++ b/doc/responders.md
@@ -1,8 +1,10 @@
 # Responders
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | **Responders** | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | [Resolvers](resolvers.md) | [Templates](templates.md)
 
 ## Static responder
+
+`type = "static-responder"`
 
 A static responder can be used to terminate every query made to it with a fixed answer. The answer can contain Answer, NS, and Extra records with a configurable RCode. Static responders are useful in combination with routers to build walled-gardens or blocklists providing more control over the response. The individual records in the response are defined in zone-file format. The default TTL is 1h unless given in the record.
 
@@ -86,6 +88,8 @@ Example config files: [walled-garden.toml](../cmd/routedns/example-config/walled
 
 ## Static Template Responder
 
+`type = "static-template"`
+
 A static template responder operates similarly to a [Static Responder](#static-responder) with the main difference being that the records configured are templates, meaning they can contain placeholders which can refer to data in the query, such as the question. Based on the values in the question, the template can manipulate the response. Templates can contain more complex operations such as string splitting, replacing etc.
 
 ### Configuration
@@ -129,6 +133,8 @@ edns0-ede = {code = 15, text = '{{ .Question }} is banned!'}
 Example config files: [static-template.toml](../cmd/routedns/example-config/static-template.toml), [static-template-error.toml](../cmd/routedns/example-config/static-template-error.toml)
 
 ## Drop
+
+`type = "drop"`
 
 Terminates a pipeline by dropping the request. Typically used with blocklists to abort queries that match block rules. UDP and TCP listeners close the connection without replying, while HTTP listeners will reply with an HTTP error.
 

--- a/doc/routing.md
+++ b/doc/routing.md
@@ -1,8 +1,10 @@
 # Routing
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | **Routing** | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | [Resolvers](resolvers.md) | [Templates](templates.md)
 
 ## Router
+
+`[routers.NAME]`
 
 Routers are used to direct queries to specific upstream resolvers, modifiers, or to other routers based on the query type, name, time of day, or client information. Each router contains at least one route. Routes are evaluated in the order they are defined and the first match will be used. Routes that match on the query name are regular expressions. Typically the last route should not have a class, type or name, making it the default route.
 

--- a/doc/scripting.md
+++ b/doc/scripting.md
@@ -1,8 +1,10 @@
 # Lua Scripting
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | **Lua Scripting** | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | [Resolvers](resolvers.md) | [Templates](templates.md)
 
 ## Lua
+
+`type = "lua"`
 
 Lua groups allow writing custom query handling logic using Lua scripts. The script must define a `Resolve(msg, ci)` function that receives the DNS message and client info, and returns a response message and error. Scripts run in a sandboxed environment by default with access to DNS types, message construction, and upstream resolvers.
 

--- a/doc/security.md
+++ b/doc/security.md
@@ -1,8 +1,10 @@
 # DNSSEC and Rate Limiting
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | **DNSSEC and Rate Limiting** | [Logging](observability.md) | [Resolvers](resolvers.md) | [Templates](templates.md)
 
 ## Rate Limiter
+
+`type = "rate-limiter"`
 
 This element is used to limit the number of queries a client or network is allowed to make in a given time period. It uses a fixed window algorithm and by default drops any queries that exceed the configured maximum. Alternatively, a `limit-resolver` can be configured to route such queries to other elements such as [static responders](responders.md#static-responder) or other resolvers.
 
@@ -50,6 +52,8 @@ rcode = 5 # REFUSED
 Example config files: [rate-limiter.toml](../cmd/routedns/example-config/rate-limiter.toml)
 
 ## DNSSEC Validator
+
+`type = "dnssec-validator"`
 
 Validates DNSSEC signatures on responses from upstream resolvers. The validator builds a chain of trust from configured root trust anchors down through DS and DNSKEY records to verify RRSIG signatures on the response. If validation fails, a SERVFAIL is returned to the client. Unsigned zones (insecure delegations) pass through without error. Only NOERROR and NXDOMAIN responses are validated.
 

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -1,6 +1,6 @@
 # Templates
 
-Part of the [RouteDNS Configuration Guide](configuration.md).
+[Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | [Resolvers](resolvers.md) | **Templates**
 
 Some options hold templates, i.e. text with placeholders that are populated at runtime with data from the query. Placeholders between `{{` and `}}` are replaced when the response is built. The template syntax is explained in more detail [here](https://pkg.go.dev/text/template).
 


### PR DESCRIPTION
Finding a component in the configuration guide required knowing which topic page held it. The landing page listed sections by prose title, and nothing was keyed by the string that actually selects a component in TOML, so looking up `fastest-tcp` meant guessing it lived under caching.

`doc/configuration.md` becomes the index rather than a set of forwarding stubs:

- Listeners, by `protocol` value
- Routers, which have no type of their own
- All 30 group, modifier and responder types, alphabetically, with the page acting as the category column
- Resolvers, by `protocol` value, plus a second table for bootstrapping, SOCKS5, network namespaces and the socket options, which are resolver behaviour rather than protocols
- A short section on how a configuration is structured, and a directory of what each page covers

Each entry says what the component does in one line and links to the section describing it. A footnote records the two legacy names, `response-blocklist-cidr` and the first-generation `blocklist`, so an old config can still be read.

Every component section now carries its type or protocol line under the heading:

```
## Fastest TCP Probe

`type = "fastest-tcp"`
```

That makes the section findable by searching for the string seen in a config. Headings themselves are unchanged, so existing anchors still resolve.

The 13 topic pages get a shared nav bar with the current page marked, replacing the single line that pointed back at the guide. The four longest pages, resolvers, listeners, caching and blocklists, also list their sections at the top.

The example config index gains a Guide column linking each example to the component it demonstrates, with section-level links where a whole table lands on one section. The mapping was checked against the TOML: `rfc8482.toml` and `truncate.toml` are static responders behind a router, and `block-split-cache.toml` is a blocklist in front of one.

The type list was verified against the switch in `cmd/routedns/main.go`, and `.github/scripts/check-docs.sh` passes.
