### PR TITLE
Allow the bootstrap-resolver to be referenced as a resolver

### DIFF
--- a/cmd/routedns/check_test.go
+++ b/cmd/routedns/check_test.go
@@ -9,9 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// check runs the config through --check.
+// check runs the config through --check. A config with a [bootstrap-resolver]
+// makes run() replace the process-wide net.DefaultResolver, which would
+// otherwise outlive the test and point every later lookup in the package at
+// whatever address that config used.
 func check(t *testing.T, content string) error {
 	t.Helper()
+	defaultResolver := net.DefaultResolver
+	t.Cleanup(func() { net.DefaultResolver = defaultResolver })
 	name := filepath.Join(t.TempDir(), "config.toml")
 	require.NoError(t, os.WriteFile(name, []byte(content), 0600))
 	return run(options{check: true}, []string{name})

--- a/cmd/routedns/check_test.go
+++ b/cmd/routedns/check_test.go
@@ -113,3 +113,96 @@ resolver = "cached"
 	require.NoError(t, err)
 	require.Equal(t, content, after, "--check overwrote the cache file")
 }
+
+// The bootstrap-resolver is built before the dependency graph, so referencing
+// it by ID has to be wired up separately from the other elements.
+func TestCheckBootstrapResolverAsResolver(t *testing.T) {
+	require.NoError(t, check(t, `
+[bootstrap-resolver]
+address = "127.0.0.1:5399"
+protocol = "udp"
+
+[resolvers.upstream]
+address = "127.0.0.1:5398"
+protocol = "udp"
+
+[groups.cached]
+type = "cache"
+resolvers = ["bootstrap-resolver"]
+
+[routers.router]
+routes = [
+  {name = '\.com\.$', resolver = "bootstrap-resolver"},
+  {type = "A", resolver = "cached"},
+  {resolver = "upstream"},
+]
+
+[listeners.local-udp]
+address = "127.0.0.1:5399"
+protocol = "udp"
+resolver = "router"
+
+[listeners.direct]
+address = "127.0.0.1:5398"
+protocol = "udp"
+resolver = "bootstrap-resolver"
+`))
+}
+
+// Defining an element with the reserved ID would build a second resolver and
+// replace the bootstrap one in the map, so it has to be rejected.
+func TestCheckBootstrapResolverIDReserved(t *testing.T) {
+	for _, tc := range []struct{ name, section string }{
+		{"resolver", `
+[resolvers.bootstrap-resolver]
+address = "127.0.0.1:5398"
+protocol = "udp"`},
+		{"group", `
+[groups.bootstrap-resolver]
+type = "cache"
+resolvers = ["upstream"]`},
+		{"router", `
+[routers.bootstrap-resolver]
+routes = [{resolver = "upstream"}]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := check(t, `
+[bootstrap-resolver]
+address = "127.0.0.1:5399"
+protocol = "udp"
+
+[resolvers.upstream]
+address = "127.0.0.1:5398"
+protocol = "udp"
+`+tc.section+`
+
+[listeners.local-udp]
+address = "127.0.0.1:5399"
+protocol = "udp"
+resolver = "upstream"
+`)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "is reserved")
+		})
+	}
+}
+
+// Without a [bootstrap-resolver] section the ID is not special and a reference
+// to it is a typo like any other.
+func TestCheckBootstrapResolverNotDefined(t *testing.T) {
+	err := check(t, `
+[resolvers.upstream]
+address = "127.0.0.1:5398"
+protocol = "udp"
+
+[routers.router]
+routes = [{resolver = "bootstrap-resolver"}]
+
+[listeners.local-udp]
+address = "127.0.0.1:5399"
+protocol = "udp"
+resolver = "router"
+`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "'bootstrap-resolver' is unknown")
+}

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -171,6 +171,10 @@ type Node struct {
 	value any
 }
 
+// bootstrapResolverID is the reserved ID of the resolver defined in the
+// [bootstrap-resolver] section. It can be referenced like any other resolver.
+const bootstrapResolverID = "bootstrap-resolver"
+
 var _ dag.IDInterface = Node{}
 
 func (n Node) ID() string {
@@ -190,6 +194,11 @@ func uniqueIDs(ids []string) []string {
 	ids = slices.DeleteFunc(slices.Clone(ids), func(id string) bool { return id == "" })
 	slices.Sort(ids)
 	return slices.Compact(ids)
+}
+
+func hasKey[V any](m map[string]V, key string) bool {
+	_, ok := m[key]
+	return ok
 }
 
 type pendingListener struct {
@@ -254,11 +263,22 @@ func run(opt options, args []string) error {
 	// See if a bootstrap-resolver was defined in the config. If so, instantiate it,
 	// wrap it in a net.Resolver wrapper and replace the net.DefaultResolver with it
 	// for all other entities to use.
+	var hasBootstrapResolver bool
 	if config.BootstrapResolver.Address != "" {
-		if err := instantiateResolver("bootstrap-resolver", config.BootstrapResolver, resolvers); err != nil {
+		// The ID is reserved while a bootstrap-resolver is defined. Without this
+		// an element of the same name would be built again by the loop below and
+		// replace it in the map, leaving net.DefaultResolver pointing at one
+		// resolver while everything referencing the ID by name got the other.
+		if hasKey(config.Resolvers, bootstrapResolverID) ||
+			hasKey(config.Groups, bootstrapResolverID) ||
+			hasKey(config.Routers, bootstrapResolverID) {
+			return fmt.Errorf("'%s' is reserved when a [bootstrap-resolver] is defined", bootstrapResolverID)
+		}
+		if err := instantiateResolver(bootstrapResolverID, config.BootstrapResolver, resolvers); err != nil {
 			return fmt.Errorf("failed to instantiate bootstrap-resolver: %w", err)
 		}
-		net.DefaultResolver = rdns.NewNetResolver(resolvers["bootstrap-resolver"])
+		net.DefaultResolver = rdns.NewNetResolver(resolvers[bootstrapResolverID])
+		hasBootstrapResolver = true
 	}
 	// Add all types of nodes to a DAG, this is to find duplicates. Then populate the edges (dependencies).
 	graph := dag.NewDAG()
@@ -295,6 +315,14 @@ func run(opt options, args []string) error {
 	// Add the edges to the DAG. This will fail if there is recursion or missing nodes.
 	for id, es := range edges {
 		for _, e := range es {
+			// The bootstrap-resolver is built before the graph, since
+			// net.DefaultResolver has to be replaced before anything that may
+			// perform a lookup is instantiated. It has no vertex to point at and
+			// nothing needs to wait for it, so references to it carry no
+			// ordering constraint.
+			if hasBootstrapResolver && e == bootstrapResolverID {
+				continue
+			}
 			if err := graph.AddEdge(id, e); err != nil {
 				return err
 			}

--- a/doc/resolvers.md
+++ b/doc/resolvers.md
@@ -353,7 +353,7 @@ Note: Resolvers (including the bootstrap resolver itself) also support a `bootst
 
 ### Configuration
 
-The bootstrap resolver is defined in a top-level `[bootstrap-resolver]` table rather than under `resolvers`, since nothing references it by name. There can be only one.
+The bootstrap resolver is defined in a top-level `[bootstrap-resolver]` table rather than under `resolvers`. There can be only one.
 
 Options:
 
@@ -367,6 +367,20 @@ Use Cloudflare DoT to resolve all hostnames in the configuration.
 [bootstrap-resolver]
 address = "1.1.1.1:853"
 protocol = "dot"
+```
+
+The bootstrap resolver can also be used to answer queries, by referencing it as `bootstrap-resolver` from a group, router or listener. This avoids having to define the same server twice when it should serve queries as well as resolve the names in the config. Since the ID is used for this, it can't also be given to a resolver, group or router while a `[bootstrap-resolver]` is defined.
+
+```toml
+[bootstrap-resolver]
+address = "1.1.1.1:853"
+protocol = "dot"
+
+[routers.router]
+routes = [
+  { name = '\.internal\.$', resolver = "bootstrap-resolver" },
+  { resolver = "upstream" },
+]
 ```
 
 Example config files: [bootstrap-resolver.toml](../cmd/routedns/example-config/bootstrap-resolver.toml), [use-case-6.toml](../cmd/routedns/example-config/use-case-6.toml)


### PR DESCRIPTION
Lets a `[bootstrap-resolver]` be referenced by ID from groups, routers and listeners, so a server that resolves the hostnames in the config can also answer queries without being defined twice.

## The problem

The bootstrap-resolver is instantiated before the dependency graph is built, because `net.DefaultResolver` has to be replaced before anything that may perform a lookup is constructed. It was placed in the resolver map but never added as a vertex, so `graph.AddEdge` rejected any reference to it:

```
Error: 'bootstrap-resolver' is unknown
```

## The change

Edges pointing at the bootstrap-resolver are skipped rather than added. It is already built and has no dependencies of its own, so a reference to it carries no ordering constraint. References to any other unknown ID still fail as before.

The ID is reserved while a `[bootstrap-resolver]` section is defined. An element of the same name would otherwise be built a second time and replace the entry in the map, leaving `net.DefaultResolver` pointing at one resolver while everything referencing the ID by name got the other. That split is silent, so it is rejected at startup:

```
Error: 'bootstrap-resolver' is reserved when a [bootstrap-resolver] is defined
```

## Usage

```toml
[bootstrap-resolver]
address  = "1.1.1.1:853"
protocol = "dot"

[routers.router]
routes = [
  { name = '\.internal\.$', resolver = "bootstrap-resolver" },
  { resolver = "upstream" },
]
```

## Verification

`--check` covers the config from the issue, a typo'd resolver ID, the reserved-ID collision for all three element types, and a reference made without any `[bootstrap-resolver]` defined. A live run confirmed queries routed to the bootstrap resolver and to a separate upstream are both answered.

`doc/resolvers.md` previously stated the section is top-level "since nothing references it by name", which no longer holds, and now documents referencing it.

Fixes #365
