### PR TITLE
Make idle-timeout a resolver-level option for all protocols

### DIFF
--- a/cmd/routedns/check_test.go
+++ b/cmd/routedns/check_test.go
@@ -211,3 +211,69 @@ resolver = "router"
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "'bootstrap-resolver' is unknown")
 }
+
+// idle-timeout moved from the doh sub-table to the resolver level. Both forms
+// have to keep working, but not together, since zero is indistinguishable from
+// unset and a silent winner would ignore what the user wrote.
+func TestCheckIdleTimeout(t *testing.T) {
+	config := func(resolverOpt, dohOpt string) string {
+		return `
+[resolvers.upstream]
+address = "https://dns.google/dns-query"
+protocol = "doh"
+` + resolverOpt + `
+` + dohOpt + `
+
+[listeners.local-udp]
+address = "127.0.0.1:5399"
+protocol = "udp"
+resolver = "upstream"
+`
+	}
+
+	t.Run("resolver level", func(t *testing.T) {
+		require.NoError(t, check(t, config(`idle-timeout = 60`, ``)))
+	})
+	t.Run("deprecated doh form", func(t *testing.T) {
+		require.NoError(t, check(t, config(``, `doh = { idle-timeout = 60 }`)))
+	})
+	t.Run("neither", func(t *testing.T) {
+		require.NoError(t, check(t, config(``, ``)))
+	})
+	t.Run("both is an error", func(t *testing.T) {
+		err := check(t, config(`idle-timeout = 60`, `doh = { idle-timeout = 30 }`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "both at the resolver level and under doh")
+	})
+	t.Run("negative is an error", func(t *testing.T) {
+		err := check(t, config(`idle-timeout = -1`, ``))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must not be negative")
+	})
+}
+
+// The option applies to every protocol, not just the two it started on.
+func TestCheckIdleTimeoutAllProtocols(t *testing.T) {
+	for _, tc := range []struct{ protocol, address string }{
+		{"udp", "8.8.8.8:53"},
+		{"tcp", "8.8.8.8:53"},
+		{"dot", "dns.google:853"},
+		{"dtls", "8.8.8.8:853"},
+		{"doq", "dns.adguard.com:8853"},
+		{"doh", "https://dns.google/dns-query"},
+	} {
+		t.Run(tc.protocol, func(t *testing.T) {
+			require.NoError(t, check(t, `
+[resolvers.upstream]
+address = "`+tc.address+`"
+protocol = "`+tc.protocol+`"
+idle-timeout = 45
+
+[listeners.local-udp]
+address = "127.0.0.1:5399"
+protocol = "udp"
+resolver = "upstream"
+`))
+		})
+	}
+}

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -62,6 +62,7 @@ type resolver struct {
 	LocalAddrV6   string `toml:"local-address-v6"`
 	EDNS0UDPSize  uint16 `toml:"edns0-udp-size"` // UDP resolver option
 	QueryTimeout  int    `toml:"query-timeout"`  // Query timeout in seconds
+	IdleTimeout   int    `toml:"idle-timeout"`   // Idle connection timeout in seconds. 0 uses the protocol default.
 	NetNS         string `toml:"netns"`          // Linux network namespace name or absolute path
 	XSocket       string `toml:"xsocket"`        // xsocket-server Unix socket path; alternative to netns that avoids CAP_SYS_ADMIN
 	FWMark        uint32 `toml:"fwmark"`         // Linux firewall mark (SO_MARK) for outbound connections
@@ -83,8 +84,10 @@ type resolver struct {
 
 // DoH-specific resolver options
 type doh struct {
-	Method      string
-	IdleTimeout int `toml:"idle-timeout"` // Idle connection timeout in seconds. TCP default: 30s. QUIC: uses library default if not set.
+	Method string
+	// Deprecated: use the resolver-level idle-timeout, which applies to every
+	// protocol. Still honoured on its own; setting both is an error.
+	IdleTimeout int `toml:"idle-timeout"`
 }
 
 // Cache backend options

--- a/cmd/routedns/resolver.go
+++ b/cmd/routedns/resolver.go
@@ -8,6 +8,25 @@ import (
 	rdns "github.com/folbricht/routedns"
 )
 
+// idleTimeout returns the idle connection timeout for a resolver, reconciling
+// the resolver-level option with the deprecated DoH-specific one. A zero value
+// means the protocol applies its own default. Since zero is indistinguishable
+// from unset, setting both is an error rather than picking a winner silently.
+func idleTimeout(id string, r resolver) (time.Duration, error) {
+	if r.IdleTimeout != 0 && r.DoH.IdleTimeout != 0 {
+		return 0, fmt.Errorf("resolver '%s': idle-timeout is set both at the resolver level and under doh, use only the resolver-level option", id)
+	}
+	seconds := r.IdleTimeout
+	if r.DoH.IdleTimeout != 0 {
+		rdns.Log.Warn("doh = { idle-timeout } is deprecated, use the resolver-level idle-timeout", "id", id)
+		seconds = r.DoH.IdleTimeout
+	}
+	if seconds < 0 {
+		return 0, fmt.Errorf("resolver '%s': idle-timeout must not be negative", id)
+	}
+	return time.Duration(seconds) * time.Second, nil
+}
+
 // Instantiates an rdns.Resolver from a resolver config
 func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolver) error {
 	var err error
@@ -15,6 +34,11 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 	netns, err := buildNetNS(r.NetNS, r.XSocket)
 	if err != nil {
 		return fmt.Errorf("resolver '%s': %w", id, err)
+	}
+
+	idle, err := idleTimeout(id, r)
+	if err != nil {
+		return err
 	}
 
 	sockOpts := rdns.SocketOptions{
@@ -38,6 +62,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			LocalAddrV6:   net.ParseIP(r.LocalAddrV6),
 			TLSConfig:     tlsConfig,
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
+			IdleTimeout:   idle,
 			Use0RTT:       r.Use0RTT,
 			NetNS:         netns,
 			SocketOptions: sockOpts,
@@ -60,6 +85,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			LocalAddrV6:   net.ParseIP(r.LocalAddrV6),
 			TLSConfig:     tlsConfig,
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
+			IdleTimeout:   idle,
 			Dialer:        socks5DialerFromConfig(r, netns, sockOpts),
 			NetNS:         netns,
 			SocketOptions: sockOpts,
@@ -83,6 +109,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			DTLSConfig:    dtlsConfig,
 			UDPSize:       r.EDNS0UDPSize,
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
+			IdleTimeout:   idle,
 			NetNS:         netns,
 			SocketOptions: sockOpts,
 		}
@@ -106,7 +133,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			LocalAddrV4:   net.ParseIP(r.LocalAddrV4),
 			LocalAddrV6:   net.ParseIP(r.LocalAddrV6),
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
-			IdleTimeout:   time.Duration(r.DoH.IdleTimeout) * time.Second,
+			IdleTimeout:   idle,
 			Dialer:        socks5DialerFromConfig(r, netns, sockOpts),
 			Use0RTT:       r.Use0RTT,
 			NetNS:         netns,
@@ -130,7 +157,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			LocalAddrV4:   net.ParseIP(r.LocalAddrV4),
 			LocalAddrV6:   net.ParseIP(r.LocalAddrV6),
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
-			IdleTimeout:   time.Duration(r.DoH.IdleTimeout) * time.Second,
+			IdleTimeout:   idle,
 			NetNS:         netns,
 			SocketOptions: sockOpts,
 		}
@@ -147,6 +174,7 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 			LocalAddrV6:   net.ParseIP(r.LocalAddrV6),
 			UDPSize:       r.EDNS0UDPSize,
 			QueryTimeout:  time.Duration(r.QueryTimeout) * time.Second,
+			IdleTimeout:   idle,
 			Dialer:        socks5DialerFromConfig(r, netns, sockOpts),
 			NetNS:         netns,
 			SocketOptions: sockOpts,

--- a/dnsclient.go
+++ b/dnsclient.go
@@ -36,6 +36,10 @@ type DNSClientOptions struct {
 
 	QueryTimeout time.Duration
 
+	// IdleTimeout is how long an upstream connection is kept without any
+	// traffic before it is torn down. Zero applies the default.
+	IdleTimeout time.Duration
+
 	// Optional dialer, e.g. proxy
 	Dialer Dialer
 
@@ -69,7 +73,7 @@ func NewDNSClient(id, endpoint, network string, opt DNSClientOptions) (*DNSClien
 		id:       id,
 		net:      network,
 		endpoint: endpoint,
-		pipeline: NewPipeline(id, endpoint, client, opt.QueryTimeout),
+		pipeline: NewPipeline(id, endpoint, client, opt.QueryTimeout, opt.IdleTimeout),
 		opt:      opt,
 	}, nil
 }

--- a/doc/resolvers.md
+++ b/doc/resolvers.md
@@ -2,7 +2,7 @@
 
 [Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | **Resolvers** | [Templates](templates.md)
 
-**On this page:** [Bootstrapping](#bootstrapping) | [Plain DNS Resolver](#plain-dns-resolver) | [DNS-over-TLS Resolver](#dns-over-tls-resolver) | [DNS-over-HTTPS Resolver](#dns-over-https-resolver) | [Oblivious DNS (ODoH) Resolver](#oblivious-dns-odoh-resolver) | [DNS-over-DTLS Resolver](#dns-over-dtls-resolver) | [DNS-over-QUIC Resolver](#dns-over-quic-resolver) | [Bootstrap Resolver](#bootstrap-resolver) | [SOCKS5 Proxy Support](#socks5-proxy-support) | [Network Namespace Support](#network-namespace-support) | [Firewall Mark and Interface Binding](#firewall-mark-and-interface-binding)
+**On this page:** [Bootstrapping](#bootstrapping) | [Plain DNS Resolver](#plain-dns-resolver) | [DNS-over-TLS Resolver](#dns-over-tls-resolver) | [DNS-over-HTTPS Resolver](#dns-over-https-resolver) | [Oblivious DNS (ODoH) Resolver](#oblivious-dns-odoh-resolver) | [DNS-over-DTLS Resolver](#dns-over-dtls-resolver) | [DNS-over-QUIC Resolver](#dns-over-quic-resolver) | [Idle Connection Timeout](#idle-connection-timeout) | [Bootstrap Resolver](#bootstrap-resolver) | [SOCKS5 Proxy Support](#socks5-proxy-support) | [Network Namespace Support](#network-namespace-support) | [Firewall Mark and Interface Binding](#firewall-mark-and-interface-binding)
 
 Resolvers forward queries to other DNS servers over the network and typically represent the end of one or many processing pipelines. Resolvers encode every query that is passed from listeners, modifiers, routers etc and send them to a DNS server without further processing. Like with other elements in the pipeline, resolvers require a unique identifier to reference them from other elements. The following protocols are supported:
 
@@ -24,6 +24,7 @@ Resolvers are defined in the configuration like so `[resolvers.NAME]` and have t
 - `local-address-v6` - IPv6 address of the local interface to use when connecting to IPv6 targets. Takes priority over `local-address` for IPv6 connections. The address must be unbracketed (e.g. `fd00::1`, not `[fd00::1]`).
 - `edns0-udp-size` - If set, modifies the EDNS0 UDP size option in all queries sent upstream. Only meaningful when using UDP or DTLS resolvers. Upstream resolvers may not respect this value and apply their own limits.
 - `query-timeout` - Sets the query timeout to allow. In seconds.
+- `idle-timeout` - How long an idle upstream connection is kept open before being torn down, in seconds. Applies to all protocols. If not set, each protocol uses its own default, see [Idle Connection Timeout](#idle-connection-timeout).
 - `netns` - Linux network namespace for outbound connections. Can be a name (looked up in `/var/run/netns/`) or an absolute path (e.g. `/proc/PID/ns/net`). Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
 - `xsocket` - Path to an `xsocket-server` Unix socket. Outbound connections are made through a socket created in that server's network namespace without requiring `CAP_SYS_ADMIN`. Mutually exclusive with `netns`. For SOCKS5-proxied resolvers it is the connection to the proxy that is made in the target namespace. Optional, Linux only. See [Network Namespace Support](#network-namespace-support).
 - `fwmark` - Linux firewall mark (`SO_MARK`) to set on outbound connections. Used for netfilter matching and policy routing. Optional, Linux only, integer. See [Firewall Mark and Interface Binding](#firewall-mark-and-interface-binding).
@@ -173,7 +174,7 @@ Example config files: [well-known.toml](../cmd/routedns/example-config/well-know
 
 DNS resolvers using the HTTPS protocol are configured with `protocol = "doh"`. By default, DoH uses TCP as transport, but it can also be run over QUIC (UDP) by providing the option `transport = "quic"`. DoH supports two HTTP methods, GET and POST. By default RouteDNS uses the POST method, but can be configured to use GET as well using the option `doh = { method = "GET" }`.
 DoH with QUIC supports 0-RTT. The DoH resolver will try to use 0-RTT connection establishment if `transport = "quic"` and `enable-0rtt = true` are configured. Only GET requests can be sent as 0-RTT data, so with `enable-0rtt = true` the method defaults to GET when none is configured, and the address has to be a URL template containing the `{?dns}` parameter. RouteDNS fails to start if 0-RTT is enabled on a configuration that can't use it: with `transport` other than `"quic"`, with `doh = { method = "POST" }`, or with an address that isn't a URL template. Since 0-RTT data is replayable, only the opcodes RFC 9250 allows there (QUERY and NOTIFY) are sent as early data; queries with any other opcode wait for the handshake to complete.
-The idle connection timeout can be configured with `doh = { idle-timeout = 60 }` (in seconds). This controls how long idle HTTP connections are kept open before being closed. For TCP transport, the default is 30 seconds. For QUIC transport, the default is determined by the quic-go library. Note that for QUIC, the actual idle timeout is the minimum of the client and server values.
+The idle connection timeout is set with the resolver-level `idle-timeout` option, see [Idle Connection Timeout](#idle-connection-timeout). For DoH it controls how long idle HTTP connections are kept open, defaulting to 30 seconds over TCP and to the quic-go library value over QUIC. The older `doh = { idle-timeout = 60 }` form still works but is deprecated.
 
 ### Configuration
 
@@ -184,7 +185,7 @@ Options:
 - All [common resolver options](#resolvers).
 - `ca`, `client-crt`, `client-key`, `server-name` - [TLS options](#resolvers) for validating the server and presenting a client certificate.
 - `transport` - `"tcp"` (default) for HTTP/2 over TCP, or `"quic"` to run DoH over QUIC.
-- `doh` - Table of DoH-specific settings: `method` (`"POST"` default, or `"GET"`) and `idle-timeout` in seconds.
+- `doh` - Table of DoH-specific settings: `method` (`"POST"` default, or `"GET"`). It also accepts a deprecated `idle-timeout`, superseded by the resolver-level [`idle-timeout`](#idle-connection-timeout).
 - `enable-0rtt` - Use 0-RTT connection establishment. Requires `transport = "quic"`, the GET method, and a URL template address. Optional, defaults to false.
 - `socks5-address`, `socks5-username`, `socks5-password`, `socks5-resolve-local` - Connect through a [SOCKS5 proxy](#socks5-proxy-support). Optional.
 
@@ -225,7 +226,7 @@ DoH resolver with extended idle timeout.
 [resolvers.cloudflare-doh-long-idle]
 address = "https://1.1.1.1/dns-query"
 protocol = "doh"
-doh = { idle-timeout = 60 }
+idle-timeout = 60
 ```
 
 Example config files: [well-known.toml](../cmd/routedns/example-config/well-known.toml), [simple-doh.toml](../cmd/routedns/example-config/simple-doh.toml), [mutual-tls-doh-client.toml](../cmd/routedns/example-config/mutual-tls-doh-client.toml)
@@ -253,7 +254,7 @@ Options:
 - `target` - URL of the ODoH target. Required.
 - `target-config` - The target's ODoH config, as hex. Fetched from the target automatically when not set, which costs the client's anonymity for that one request, so prefer configuring it. Running with debug logging prints the fetched value so it can be copied here.
 - `transport` - `"tcp"` (default) or `"quic"` for the proxy connection.
-- `doh` - Table of DoH-specific settings for the proxy connection: `method` and `idle-timeout`.
+- `doh` - Table of DoH-specific settings for the proxy connection: `method`. It also accepts a deprecated `idle-timeout`, superseded by the resolver-level [`idle-timeout`](#idle-connection-timeout).
 
 `edns0-udp-size`, `enable-0rtt` and the SOCKS5 options do not apply to this protocol.
 
@@ -343,6 +344,35 @@ enable-0rtt = true
 ```
 
 Example config files: [doq-client.toml](../cmd/routedns/example-config/doq-client.toml)
+
+## Idle Connection Timeout
+
+`idle-timeout`
+
+RouteDNS keeps upstream connections open between queries rather than reconnecting each time. The `idle-timeout` option controls how long a connection with no traffic on it is kept before being torn down, in seconds. It is available on every resolver protocol. Lowering it releases connections sooner, which can matter on devices with few resources or behind stateful firewalls that track idle flows. Raising it keeps connections warm for longer, avoiding repeated handshakes on a busy resolver.
+
+If the option is not set, each protocol applies its own default:
+
+| Protocol | Default idle timeout |
+| --- | --- |
+| `udp`, `tcp`, `dot`, `dtls` | 10 seconds |
+| `doh` over TCP | 30 seconds |
+| `doh` over QUIC, `doq` | Determined by the quic-go library |
+
+Notes:
+
+- For the QUIC-based protocols (`doq` and `doh` with `transport = "quic"`) the value maps to the QUIC `MaxIdleTimeout`, which is negotiated as the lower of the client and server values. Raising it beyond what the server allows has no effect.
+- Many public resolvers close idle connections after a couple of seconds regardless of what the client asks for, so a high value is not a guarantee that the connection survives.
+- A negative value is rejected at startup.
+
+```toml
+[resolvers.cloudflare-dot]
+address      = "1.1.1.1:853"
+protocol     = "dot"
+idle-timeout = 60
+```
+
+The DoH resolver previously carried this setting as `doh = { idle-timeout = 60 }`. That form is deprecated and logs a warning, but continues to work. Setting both it and the resolver-level option is an error, since a zero value cannot be told apart from an unset one and silently picking a winner would ignore what was configured.
 
 ## Bootstrap Resolver
 

--- a/doqclient.go
+++ b/doqclient.go
@@ -47,7 +47,11 @@ type DoQClientOptions struct {
 
 	TLSConfig    *tls.Config
 	QueryTimeout time.Duration
-	Use0RTT      bool
+
+	// IdleTimeout sets the QUIC MaxIdleTimeout. Zero uses the library default.
+	// The effective value is the lower of this and the server's.
+	IdleTimeout time.Duration
+	Use0RTT     bool
 
 	// Linux network namespace for outbound connections.
 	NetNS *NetNS
@@ -100,6 +104,9 @@ func NewDoQClient(id, endpoint string, opt DoQClientOptions) (*DoQClient, error)
 	config := &quic.Config{
 		TokenStore:           quic.NewLRUTokenStore(10, 10),
 		HandshakeIdleTimeout: opt.QueryTimeout,
+	}
+	if opt.IdleTimeout > 0 {
+		config.MaxIdleTimeout = opt.IdleTimeout
 	}
 
 	client := &DoQClient{

--- a/doqclient_test.go
+++ b/doqclient_test.go
@@ -241,3 +241,22 @@ func (r *doqEarlyRecorder) last(t *testing.T) doqRecordedQuery {
 	require.NotEmpty(t, r.seen, "server received no queries")
 	return r.seen[len(r.seen)-1]
 }
+
+// idle-timeout has to reach the QUIC config as MaxIdleTimeout. Zero leaves it
+// unset so quic-go applies its own default.
+func TestDoQClientIdleTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opt  time.Duration
+		want time.Duration
+	}{
+		{"set", 45 * time.Second, 45 * time.Second},
+		{"unset keeps the library default", 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewDoQClient("test-doq", "127.0.0.1:8853", DoQClientOptions{IdleTimeout: tc.opt})
+			require.NoError(t, err)
+			require.Equal(t, tc.want, c.connection.config.MaxIdleTimeout)
+		})
+	}
+}

--- a/dotclient.go
+++ b/dotclient.go
@@ -32,6 +32,10 @@ type DoTClientOptions struct {
 
 	QueryTimeout time.Duration
 
+	// IdleTimeout is how long an upstream connection is kept without any
+	// traffic before it is torn down. Zero applies the default.
+	IdleTimeout time.Duration
+
 	// Optional dialer, e.g. proxy
 	Dialer Dialer
 
@@ -75,7 +79,7 @@ func NewDoTClient(id, endpoint string, opt DoTClientOptions) (*DoTClient, error)
 	return &DoTClient{
 		id:       id,
 		endpoint: endpoint,
-		pipeline: NewPipeline(id, endpoint, client, opt.QueryTimeout),
+		pipeline: NewPipeline(id, endpoint, client, opt.QueryTimeout, opt.IdleTimeout),
 	}, nil
 }
 

--- a/dtlsclient.go
+++ b/dtlsclient.go
@@ -38,6 +38,10 @@ type DTLSClientOptions struct {
 
 	QueryTimeout time.Duration
 
+	// IdleTimeout is how long an upstream connection is kept without any
+	// traffic before it is torn down. Zero applies the default.
+	IdleTimeout time.Duration
+
 	// Linux network namespace for outbound connections.
 	NetNS *NetNS
 
@@ -103,7 +107,7 @@ func NewDTLSClient(id, endpoint string, opt DTLSClientOptions) (*DTLSClient, err
 	return &DTLSClient{
 		id:       id,
 		endpoint: endpoint,
-		pipeline: NewPipeline(id, endpoint, client, opt.QueryTimeout),
+		pipeline: NewPipeline(id, endpoint, client, opt.QueryTimeout, opt.IdleTimeout),
 		opt:      opt,
 	}, nil
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -14,8 +14,9 @@ import (
 // Defines how long to wait for a response from the resolver if no other timeout is given.
 const defaultQueryTimeout = 2 * time.Second
 
-// Tear down an upstream connection if nothing has been received for this long.
-const idleTimeout = 10 * time.Second
+// Tear down an upstream connection if nothing has been received for this long,
+// unless the resolver configures its own.
+const defaultIdleTimeout = 10 * time.Second
 
 // Pipeline is a DNS client that is able to use pipelining for multiple requests over
 // one connection, handle out-of-order responses and deals with disconnects
@@ -28,6 +29,7 @@ type Pipeline struct {
 	inFlight inFlightQueue
 	metrics  *ListenerMetrics
 	timeout  time.Duration
+	idle     time.Duration
 }
 
 // DNSDialer is an abstraction for a dns.Client that returns a *dns.Conn.
@@ -36,9 +38,13 @@ type DNSDialer interface {
 }
 
 // NewPipeline returns an initialized (and running) DNS connection manager.
-func NewPipeline(id string, addr string, client DNSDialer, timeout time.Duration) *Pipeline {
+// A zero timeout or idle timeout applies the package defaults.
+func NewPipeline(id string, addr string, client DNSDialer, timeout, idle time.Duration) *Pipeline {
 	if timeout == 0 {
 		timeout = defaultQueryTimeout
+	}
+	if idle == 0 {
+		idle = defaultIdleTimeout
 	}
 	c := &Pipeline{
 		addr:     addr,
@@ -46,6 +52,7 @@ func NewPipeline(id string, addr string, client DNSDialer, timeout time.Duration
 		requests: make(chan *request),
 		metrics:  NewListenerMetrics("client", id),
 		timeout:  timeout,
+		idle:     idle,
 	}
 	go c.start()
 	return c
@@ -139,7 +146,7 @@ func (c *Pipeline) start() {
 				// a network topology change wouldn't be noticed. Putting the idle timeout here ensures
 				// a reconnect in that case as well. This does create a very slight race however if the
 				// sender is using the connection right at the time of the timeout in the receiver.
-				_ = conn.SetReadDeadline(time.Now().Add(idleTimeout))
+				_ = conn.SetReadDeadline(time.Now().Add(c.idle))
 				a, err := conn.ReadMsg()
 				if err != nil {
 					switch e := err.(type) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ func TestPipelineQueryTimeout(t *testing.T) {
 		time.Sleep(2 * time.Second)
 		return nil, errors.New("failed")
 	}
-	p := NewPipeline("test", "localhost:53", testDialer(df), time.Second)
+	p := NewPipeline("test", "localhost:53", testDialer(df), time.Second, 0)
 
 	q := new(dns.Msg)
 	q.SetQuestion("example.com.", dns.TypeA)
@@ -56,7 +57,7 @@ func TestPipelineInFlightCleanup(t *testing.T) {
 	df := func(address string) (*dns.Conn, error) {
 		return &dns.Conn{Conn: client}, nil
 	}
-	p := NewPipeline("test", "localhost:53", testDialer(df), 50*time.Millisecond)
+	p := NewPipeline("test", "localhost:53", testDialer(df), 50*time.Millisecond, 0)
 
 	q := new(dns.Msg)
 	q.SetQuestion("example.com.", dns.TypeA)
@@ -100,7 +101,7 @@ func TestPipelineQuestionMatch(t *testing.T) {
 	df := func(address string) (*dns.Conn, error) {
 		return &dns.Conn{Conn: client}, nil
 	}
-	p := NewPipeline("test", "localhost:53", testDialer(df), time.Second)
+	p := NewPipeline("test", "localhost:53", testDialer(df), time.Second, 0)
 
 	q := new(dns.Msg)
 	q.SetQuestion("example.com.", dns.TypeA)
@@ -136,11 +137,69 @@ func TestPipelineRejectEmptyQuestion(t *testing.T) {
 	df := func(address string) (*dns.Conn, error) {
 		return &dns.Conn{Conn: client}, nil
 	}
-	p := NewPipeline("test", "localhost:53", testDialer(df), time.Second)
+	p := NewPipeline("test", "localhost:53", testDialer(df), time.Second, 0)
 
 	q := new(dns.Msg)
 	q.SetQuestion("example.com.", dns.TypeA)
 
 	_, err := p.Resolve(q)
 	require.Error(t, err, "response with empty question section must be rejected")
+}
+
+// The idle timeout tears down a connection that has gone quiet, so the next
+// query has to dial again. Without a configurable value this could only be
+// exercised by waiting out the 10s default.
+func TestPipelineIdleTimeout(t *testing.T) {
+	var dials atomic.Int64
+	var mu sync.Mutex
+	var servers []net.Conn
+	t.Cleanup(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, c := range servers {
+			c.Close()
+		}
+	})
+
+	df := func(address string) (*dns.Conn, error) {
+		dials.Add(1)
+		server, client := net.Pipe()
+		mu.Lock()
+		servers = append(servers, server)
+		mu.Unlock()
+		go func() { // upstream that reads queries but never answers
+			buf := make([]byte, 4096)
+			for {
+				if _, err := server.Read(buf); err != nil {
+					return
+				}
+			}
+		}()
+		return &dns.Conn{Conn: client}, nil
+	}
+	p := NewPipeline("test", "localhost:53", testDialer(df), 20*time.Millisecond, 10*time.Millisecond)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	_, err := p.Resolve(q)
+	require.Error(t, err, "upstream never answers")
+	require.Equal(t, int64(1), dials.Load())
+
+	// Wait out the idle timeout, which closes the connection. The next query
+	// has to establish a new one.
+	require.Eventually(t, func() bool {
+		_, _ = p.Resolve(q)
+		return dials.Load() > 1
+	}, time.Second, 10*time.Millisecond, "idle connection was not torn down")
+}
+
+// A zero idle timeout keeps the package default rather than expiring
+// connections immediately.
+func TestPipelineIdleTimeoutDefault(t *testing.T) {
+	p := NewPipeline("test", "localhost:53", testDialer(func(string) (*dns.Conn, error) {
+		return nil, errors.New("not dialed")
+	}), 0, 0)
+	require.Equal(t, defaultIdleTimeout, p.idle)
+	require.Equal(t, defaultQueryTimeout, p.timeout)
 }


### PR DESCRIPTION
Promotes `idle-timeout` from a DoH-only sub-option to a resolver-level option that applies to every protocol.

## Background

Idle connection lifetime was only configurable for DoH. Everything else used a fixed value:

| Protocol | Before | Configurable |
| --- | --- | --- |
| `udp`, `tcp`, `dot`, `dtls` | 10s, a constant in `pipeline.go` | No |
| `doh` over TCP | 30s | Yes, via `doh = { idle-timeout }` |
| `doh` over QUIC | quic-go default | Yes, same option |
| `doq` | quic-go default | No |

The pipeline constant governs UDP, TCP, DoT and DTLS together, so none of those had any control over how long a connection stayed open.

## Changes

`idle-timeout` is now a resolver-level option. The pipeline takes its value from the resolver options rather than a constant, and DoQ sets the QUIC `MaxIdleTimeout` when one is configured, matching what DoH over QUIC already did.

Zero keeps meaning "use the protocol default", so no existing configuration changes behaviour, and each protocol's default is unchanged.

```toml
[resolvers.cloudflare-dot]
address      = "1.1.1.1:853"
protocol     = "dot"
idle-timeout = 60
```

## Compatibility

`doh = { idle-timeout = 60 }` still works and logs a deprecation warning. Setting both forms is rejected at startup:

```
Error: resolver 'upstream': idle-timeout is set both at the resolver level and under doh, use only the resolver-level option
```

Erroring rather than picking a winner is deliberate. Zero is indistinguishable from unset, so a precedence rule would silently ignore whichever value lost. The softer alternative, letting the resolver-level option win with a warning, never blocks startup but can discard what someone wrote.

Negative values are now rejected for every protocol, which previously only happened for DoH.

## Verification

Unit tests cover the config merge (both forms, the conflict, negatives), the option reaching `quic.Config` as `MaxIdleTimeout` for DoQ, and the pipeline tearing down an idle connection. The pipeline test was confirmed to fail when the plumbing is reverted, so it exercises the behaviour rather than passing vacuously.

A live DoT resolver with `idle-timeout = 2` and two queries three seconds apart logs the connection teardown between them, which the previous hardcoded 10s made impossible to reach.

## Scope

`KeepAlivePeriod` is deliberately not part of this. It is a behaviour addition rather than exposing an existing setting, and to beat the couple of seconds after which many public resolvers close an idle connection it would have to send near-constantly to every configured upstream. That tradeoff is worth settling separately, so #382 stays open for it while this closes #220.

Fixes #220
