### PR TITLE
Support DTLS pre-shared keys on resolvers and listeners

### DIFF
--- a/cmd/routedns/check_test.go
+++ b/cmd/routedns/check_test.go
@@ -341,3 +341,64 @@ server-key = "../../testdata/server.key"`))
 		require.Contains(t, err.Error(), "cannot be combined with a certificate")
 	})
 }
+
+// The psk options sit on the shared listener and resolver structs, so they
+// would otherwise be accepted and ignored on protocols that cannot use them.
+func TestCheckPSKOnlyForDTLS(t *testing.T) {
+	for _, protocol := range []string{"dot", "doh", "doq", "udp", "tcp"} {
+		t.Run("listener "+protocol, func(t *testing.T) {
+			err := check(t, `
+[resolvers.upstream]
+address = "8.8.8.8:53"
+protocol = "udp"
+
+[listeners.local]
+address = "127.0.0.1:5399"
+protocol = "`+protocol+`"
+resolver = "upstream"
+server-crt = "../../testdata/server.crt"
+server-key = "../../testdata/server.key"
+psk = "0102030405060708090a0b0c0d0e0f10"
+`)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "only supported by the dtls protocol")
+		})
+	}
+	for _, protocol := range []string{"dot", "doq", "udp", "tcp"} {
+		t.Run("resolver "+protocol, func(t *testing.T) {
+			err := check(t, `
+[resolvers.upstream]
+address = "dns.google:853"
+protocol = "`+protocol+`"
+psk = "0102030405060708090a0b0c0d0e0f10"
+psk-identity = "client"
+
+[listeners.local-udp]
+address = "127.0.0.1:5399"
+protocol = "udp"
+resolver = "upstream"
+`)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "only supported by the dtls protocol")
+		})
+	}
+}
+
+// A listener that asks for both a key and client certificates cannot work.
+func TestCheckPSKWithMutualTLS(t *testing.T) {
+	err := check(t, `
+[resolvers.upstream]
+address = "8.8.8.8:53"
+protocol = "udp"
+
+[listeners.local-dtls]
+address = "127.0.0.1:5399"
+protocol = "dtls"
+resolver = "upstream"
+ca = "../../testdata/ca.crt"
+mutual-tls = true
+psk = "0102030405060708090a0b0c0d0e0f10"
+`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot be combined with mutual-tls")
+}

--- a/cmd/routedns/check_test.go
+++ b/cmd/routedns/check_test.go
@@ -277,3 +277,67 @@ resolver = "upstream"
 		})
 	}
 }
+
+// DTLS pre-shared keys, on both resolvers and listeners.
+func TestCheckDTLSPSK(t *testing.T) {
+	listener := func(opts string) string {
+		return `
+[listeners.local-dtls]
+address = "127.0.0.1:5399"
+protocol = "dtls"
+resolver = "upstream"
+` + opts + `
+
+[resolvers.upstream]
+address = "8.8.8.8:53"
+protocol = "udp"
+`
+	}
+	resolver := func(opts string) string {
+		return `
+[resolvers.upstream]
+address = "8.8.8.8:853"
+protocol = "dtls"
+` + opts + `
+
+[listeners.local-udp]
+address = "127.0.0.1:5399"
+protocol = "udp"
+resolver = "upstream"
+`
+	}
+
+	t.Run("listener psk", func(t *testing.T) {
+		require.NoError(t, check(t, listener(`psk = "0102030405060708"`)))
+	})
+	t.Run("listener psk with identity", func(t *testing.T) {
+		require.NoError(t, check(t, listener(`psk = "0102030405060708"
+psk-identity = "server"`)))
+	})
+	t.Run("resolver psk with identity", func(t *testing.T) {
+		require.NoError(t, check(t, resolver(`psk = "0102030405060708"
+psk-identity = "client"`)))
+	})
+	t.Run("resolver psk without identity", func(t *testing.T) {
+		err := check(t, resolver(`psk = "0102030405060708"`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "psk-identity is required")
+	})
+	t.Run("identity without a key", func(t *testing.T) {
+		err := check(t, listener(`psk-identity = "server"`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "psk-identity requires psk")
+	})
+	t.Run("key is not hex", func(t *testing.T) {
+		err := check(t, listener(`psk = "not-hex"`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "hex-encoded")
+	})
+	t.Run("psk with a certificate", func(t *testing.T) {
+		err := check(t, listener(`psk = "0102030405060708"
+server-crt = "../../testdata/server.crt"
+server-key = "../../testdata/server.key"`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot be combined with a certificate")
+	})
+}

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -30,7 +30,9 @@ type listener struct {
 	ServerKey     string   `toml:"server-key"`
 	ServerCrt     string   `toml:"server-crt"`
 	MutualTLS     bool     `toml:"mutual-tls"`
-	NoTLS         bool     `toml:"no-tls"` // Disable TLS in DoH servers
+	PSK           string   `toml:"psk"`          // DTLS pre-shared key, hex-encoded. Alternative to a certificate.
+	PSKIdentity   string   `toml:"psk-identity"` // Identity hint offered with the PSK. Optional for listeners.
+	NoTLS         bool     `toml:"no-tls"`       // Disable TLS in DoH servers
 	AllowedNet    []string `toml:"allowed-net"`
 	KeySeed       string   `toml:"key-seed"`  // ODoH HPKE key seed, 16 byte hex key. Generate for example with: "openssl rand -hex 16"
 	OdohMode      string   `toml:"odoh-mode"` // ODoH mode - accepts "proxy", "target" or "dual", default is target mode
@@ -55,7 +57,9 @@ type resolver struct {
 	CA            string
 	ClientKey     string `toml:"client-key"`
 	ClientCrt     string `toml:"client-crt"`
-	ServerName    string `toml:"server-name"` // TLS server name presented in the server certificate
+	PSK           string `toml:"psk"`          // DTLS pre-shared key, hex-encoded. Alternative to a certificate.
+	PSKIdentity   string `toml:"psk-identity"` // Identity sent with the PSK. Required when psk is set.
+	ServerName    string `toml:"server-name"`  // TLS server name presented in the server certificate
 	BootstrapAddr string `toml:"bootstrap-address"`
 	LocalAddr     string `toml:"local-address"`
 	LocalAddrV4   string `toml:"local-address-v4"`

--- a/cmd/routedns/example-config/README.md
+++ b/cmd/routedns/example-config/README.md
@@ -39,6 +39,7 @@ Every option used here is described in the [Configuration Guide](../../../doc/co
 | [doh-quic-client.toml](doh-quic-client.toml) | DoH over QUIC transport, with 0-RTT. | [DoH resolver](../../../doc/resolvers.md#dns-over-https-resolver) |
 | [doh-quic-client-local.toml](doh-quic-client-local.toml) | DoH over QUIC against the local test server in `doh-quic-server.toml`. | [DoH resolver](../../../doc/resolvers.md#dns-over-https-resolver) |
 | [dtls-client.toml](dtls-client.toml) | Forward to a DoDTLS server. | [DTLS resolver](../../../doc/resolvers.md#dns-over-dtls-resolver) |
+| [dtls-psk-client.toml](dtls-psk-client.toml) | Forward to a DoDTLS server, authenticating with a pre-shared key instead of a certificate. | [Pre-shared keys](../../../doc/resolvers.md#pre-shared-keys) |
 | [odoh-client.toml](odoh-client.toml) | Oblivious DoH client, with target and optional proxy. | [ODoH resolver](../../../doc/resolvers.md#oblivious-dns-odoh-resolver) |
 | [bootstrap-resolver.toml](bootstrap-resolver.toml) | Resolve hostnames used elsewhere in the config (resolver endpoints, blocklist URLs) through a defined resolver. | [Bootstrap resolver](../../../doc/resolvers.md#bootstrap-resolver) |
 | [socks5-dot.toml](socks5-dot.toml) | DoT upstream reached through a SOCKS5 proxy. | [SOCKS5](../../../doc/resolvers.md#socks5-proxy-support) |
@@ -56,6 +57,7 @@ Every option used here is described in the [Configuration Guide](../../../doc/co
 | [doh-no-tls.toml](doh-no-tls.toml) | DoH server with TLS disabled, for testing or behind a terminating proxy. | [DoH listener](../../../doc/listeners.md#dns-over-https) |
 | [doh-behind-proxy.toml](doh-behind-proxy.toml) | DoH server taking the client address from `X-Forwarded-For` sent by a trusted reverse proxy. | [DoH listener](../../../doc/listeners.md#dns-over-https) |
 | [dtls-server.toml](dtls-server.toml) | DoDTLS server. | [DTLS listener](../../../doc/listeners.md#dns-over-dtls) |
+| [dtls-psk-server.toml](dtls-psk-server.toml) | DoDTLS server authenticating clients with a pre-shared key instead of a certificate. | [DTLS listener](../../../doc/listeners.md#dns-over-dtls) |
 | [odoh-listener.toml](odoh-listener.toml) | ODoH listener acting as target and proxy. | [ODoH listener](../../../doc/listeners.md#oblivious-dns-odoh) |
 | [admin.toml](admin.toml) | Admin listener exposing expvar metrics over HTTPS. | [Admin listener](../../../doc/listeners.md#admin) |
 

--- a/cmd/routedns/example-config/dtls-psk-client.toml
+++ b/cmd/routedns/example-config/dtls-psk-client.toml
@@ -1,0 +1,15 @@
+# DTLS resolver authenticating with a pre-shared key instead of a certificate.
+# The key has to match the one on the server. Unlike on a listener,
+# psk-identity is required here: it names the key and is sent during the
+# handshake so the server can select the right one.
+
+[resolvers.dtls-psk]
+address      = "127.0.0.1:853"
+protocol     = "dtls"
+psk          = "0102030405060708090a0b0c0d0e0f10"
+psk-identity = "routedns-client"
+
+[listeners.local-udp]
+address  = "127.0.0.1:53"
+protocol = "udp"
+resolver = "dtls-psk"

--- a/cmd/routedns/example-config/dtls-psk-server.toml
+++ b/cmd/routedns/example-config/dtls-psk-server.toml
@@ -1,0 +1,17 @@
+# DTLS listener authenticating clients with a pre-shared key instead of a
+# certificate. Useful with constrained devices that can't do a full certificate
+# exchange. Generate a key for example with: openssl rand -hex 16
+#
+# psk-identity is optional on a listener. When set it is offered to the client
+# as a hint so it can pick the matching key.
+
+[listeners.local-dtls]
+address      = "127.0.0.1:853"
+protocol     = "dtls"
+resolver     = "cloudflare-dot"
+psk          = "0102030405060708090a0b0c0d0e0f10"
+psk-identity = "routedns-server"
+
+[resolvers.cloudflare-dot]
+address  = "1.1.1.1:853"
+protocol = "dot"

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -371,6 +371,11 @@ func run(opt options, args []string) error {
 		if l.IPVersion != 4 && l.IPVersion != 6 && l.IPVersion != 0 {
 			return errors.New("ip-version must be 4 or 6")
 		}
+		// See the equivalent check for resolvers: the options are on the shared
+		// listener struct, so they have to be rejected where they do nothing.
+		if (l.PSK != "" || l.PSKIdentity != "") && l.Protocol != "dtls" {
+			return fmt.Errorf("listener '%s': psk and psk-identity are only supported by the dtls protocol", id)
+		}
 
 		netns, err := buildNetNS(l.NetNS, l.XSocket)
 		if err != nil {

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -422,9 +422,13 @@ func run(opt options, args []string) error {
 			}
 		case "dtls":
 			l.Address = rdns.AddressWithDefault(l.Address, rdns.DTLSPort)
-			dtlsConfig, err := rdns.DTLSServerConfig(l.CA, l.ServerCrt, l.ServerKey, l.MutualTLS)
+			psk, err := parsePSK(l.PSK, l.PSKIdentity)
 			if err != nil {
-				return err
+				return fmt.Errorf("listener '%s': %w", id, err)
+			}
+			dtlsConfig, err := rdns.DTLSServerConfig(l.CA, l.ServerCrt, l.ServerKey, l.MutualTLS, psk)
+			if err != nil {
+				return fmt.Errorf("listener '%s': %w", id, err)
 			}
 			build = func() (rdns.Listener, error) {
 				return rdns.NewDTLSListener(id, l.Address, rdns.DTLSListenerOptions{DTLSConfig: dtlsConfig, ListenOptions: opt}, resolver), nil

--- a/cmd/routedns/resolver.go
+++ b/cmd/routedns/resolver.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -25,6 +27,26 @@ func idleTimeout(id string, r resolver) (time.Duration, error) {
 		return 0, fmt.Errorf("resolver '%s': idle-timeout must not be negative", id)
 	}
 	return time.Duration(seconds) * time.Second, nil
+}
+
+// parsePSK turns the hex-encoded psk options into an rdns.PSK, or nil when no
+// key is configured. An identity without a key is a config error rather than a
+// silently ignored option.
+func parsePSK(key, identity string) (*rdns.PSK, error) {
+	if key == "" {
+		if identity != "" {
+			return nil, errors.New("psk-identity requires psk to be set")
+		}
+		return nil, nil
+	}
+	b, err := hex.DecodeString(key)
+	if err != nil {
+		return nil, fmt.Errorf("psk must be hex-encoded: %w", err)
+	}
+	if len(b) == 0 {
+		return nil, errors.New("psk must not be empty")
+	}
+	return &rdns.PSK{Key: b, Identity: identity}, nil
 }
 
 // Instantiates an rdns.Resolver from a resolver config
@@ -97,9 +119,13 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 	case "dtls":
 		r.Address = rdns.AddressWithDefault(r.Address, rdns.DTLSPort)
 
-		dtlsConfig, err := rdns.DTLSClientConfig(r.CA, r.ClientCrt, r.ClientKey)
+		psk, err := parsePSK(r.PSK, r.PSKIdentity)
 		if err != nil {
-			return err
+			return fmt.Errorf("resolver '%s': %w", id, err)
+		}
+		dtlsConfig, err := rdns.DTLSClientConfig(r.CA, r.ClientCrt, r.ClientKey, psk)
+		if err != nil {
+			return fmt.Errorf("resolver '%s': %w", id, err)
 		}
 		opt := rdns.DTLSClientOptions{
 			BootstrapAddr: r.BootstrapAddr,

--- a/cmd/routedns/resolver.go
+++ b/cmd/routedns/resolver.go
@@ -63,6 +63,14 @@ func instantiateResolver(id string, r resolver, resolvers map[string]rdns.Resolv
 		return err
 	}
 
+	// Pre-shared keys only mean something to DTLS. The options live on the
+	// shared resolver struct, so without this they would be accepted and
+	// quietly ignored on every other protocol, leaving the impression that the
+	// connection is authenticated by a key when it is not.
+	if (r.PSK != "" || r.PSKIdentity != "") && r.Protocol != "dtls" {
+		return fmt.Errorf("resolver '%s': psk and psk-identity are only supported by the dtls protocol", id)
+	}
+
 	sockOpts := rdns.SocketOptions{
 		FWMark:        r.FWMark,
 		BindInterface: r.BindInterface,

--- a/doc/listeners.md
+++ b/doc/listeners.md
@@ -223,9 +223,22 @@ DTLS listeners are instantiated with `protocol = "dtls"` in the listeners sectio
 Options:
 
 - All [common listener options](#listeners), except `xsocket` which is not supported for this protocol. Use `netns` instead.
-- `server-crt`, `server-key`, `ca`, `mutual-tls` - [TLS options](#listeners) for the server certificate and client validation. `server-crt` and `server-key` are required. An EC certificate is normally used here.
+- `server-crt`, `server-key`, `ca`, `mutual-tls` - [TLS options](#listeners) for the server certificate and client validation. An EC certificate is normally used here. Required unless a `psk` is configured.
+- `psk` - Pre-shared key, hex-encoded, used to authenticate clients instead of a server certificate. Optional.
+- `psk-identity` - Identity hint offered to clients so they can select the matching key. Optional.
 
 `ip-version` has no effect on this listener.
+
+A pre-shared key is an alternative to a server certificate, intended for constrained clients that can't do a full certificate exchange. Both ends need the same key, and `psk` cannot be combined with `server-crt`/`server-key`. Unlike on a resolver, `psk-identity` is optional here and is only a hint to the client. When a key is set, only pre-shared key cipher suites are offered; see [Pre-Shared Keys](resolvers.md#pre-shared-keys) for the list. The key is a secret held in the configuration file, so the file should be readable only by the user RouteDNS runs as.
+
+```toml
+[listeners.local-dtls]
+address      = ":853"
+protocol     = "dtls"
+resolver     = "cloudflare-dot"
+psk          = "0102030405060708090a0b0c0d0e0f10"
+psk-identity = "routedns-server"
+```
 
 ### Examples
 
@@ -240,7 +253,7 @@ server-crt = "example-config/server-ec.crt"
 server-key = "example-config/server-ec.key"
 ```
 
-Example config files: [dtls-server.toml](../cmd/routedns/example-config/dtls-server.toml)
+Example config files: [dtls-server.toml](../cmd/routedns/example-config/dtls-server.toml), [dtls-psk-server.toml](../cmd/routedns/example-config/dtls-psk-server.toml)
 
 ## DNS-over-QUIC
 

--- a/doc/listeners.md
+++ b/doc/listeners.md
@@ -229,7 +229,7 @@ Options:
 
 `ip-version` has no effect on this listener.
 
-A pre-shared key is an alternative to a server certificate, intended for constrained clients that can't do a full certificate exchange. Both ends need the same key, and `psk` cannot be combined with `server-crt`/`server-key`. Unlike on a resolver, `psk-identity` is optional here and is only a hint to the client. When a key is set, only pre-shared key cipher suites are offered; see [Pre-Shared Keys](resolvers.md#pre-shared-keys) for the list. The key is a secret held in the configuration file, so the file should be readable only by the user RouteDNS runs as.
+A pre-shared key is an alternative to a server certificate, intended for constrained clients that can't do a full certificate exchange. Both ends need the same key, and `psk` cannot be combined with `server-crt`/`server-key`. Unlike on a resolver, `psk-identity` is optional here and is only a hint to the client. `psk` cannot be combined with `mutual-tls`, since a pre-shared key handshake carries no client certificate. When a key is set, only pre-shared key cipher suites are offered; see [Pre-Shared Keys](resolvers.md#pre-shared-keys) for the list and for why the forward secret one is preferred. The key is a secret held in the configuration file, so the file should be readable only by the user RouteDNS runs as.
 
 ```toml
 [listeners.local-dtls]

--- a/doc/resolvers.md
+++ b/doc/resolvers.md
@@ -2,7 +2,7 @@
 
 [Guide index](configuration.md) | [Overview](overview.md) | [Listeners](listeners.md) | [Routing](routing.md) | [Blocklists](blocklists.md) | [Caching and Performance](caching.md) | [Failover and Load Balancing](groups.md) | [Modifiers](modifiers.md) | [Responders](responders.md) | [Lua Scripting](scripting.md) | [DNSSEC and Rate Limiting](security.md) | [Logging](observability.md) | **Resolvers** | [Templates](templates.md)
 
-**On this page:** [Bootstrapping](#bootstrapping) | [Plain DNS Resolver](#plain-dns-resolver) | [DNS-over-TLS Resolver](#dns-over-tls-resolver) | [DNS-over-HTTPS Resolver](#dns-over-https-resolver) | [Oblivious DNS (ODoH) Resolver](#oblivious-dns-odoh-resolver) | [DNS-over-DTLS Resolver](#dns-over-dtls-resolver) | [DNS-over-QUIC Resolver](#dns-over-quic-resolver) | [Idle Connection Timeout](#idle-connection-timeout) | [Bootstrap Resolver](#bootstrap-resolver) | [SOCKS5 Proxy Support](#socks5-proxy-support) | [Network Namespace Support](#network-namespace-support) | [Firewall Mark and Interface Binding](#firewall-mark-and-interface-binding)
+**On this page:** [Bootstrapping](#bootstrapping) | [Plain DNS Resolver](#plain-dns-resolver) | [DNS-over-TLS Resolver](#dns-over-tls-resolver) | [DNS-over-HTTPS Resolver](#dns-over-https-resolver) | [Oblivious DNS (ODoH) Resolver](#oblivious-dns-odoh-resolver) | [DNS-over-DTLS Resolver](#dns-over-dtls-resolver) | [Pre-Shared Keys](#pre-shared-keys) | [DNS-over-QUIC Resolver](#dns-over-quic-resolver) | [Idle Connection Timeout](#idle-connection-timeout) | [Bootstrap Resolver](#bootstrap-resolver) | [SOCKS5 Proxy Support](#socks5-proxy-support) | [Network Namespace Support](#network-namespace-support) | [Firewall Mark and Interface Binding](#firewall-mark-and-interface-binding)
 
 Resolvers forward queries to other DNS servers over the network and typically represent the end of one or many processing pipelines. Resolvers encode every query that is passed from listeners, modifiers, routers etc and send them to a DNS server without further processing. Like with other elements in the pipeline, resolvers require a unique identifier to reference them from other elements. The following protocols are supported:
 
@@ -296,8 +296,30 @@ Options:
 - All [common resolver options](#resolvers).
 - `ca`, `client-crt`, `client-key` - [TLS options](#resolvers) for validating the server and presenting a client certificate. `server-name` is not supported for DTLS.
 - `edns0-udp-size` - Set the EDNS0 UDP size in queries sent upstream. Optional.
+- `psk` - Pre-shared key, hex-encoded, used instead of certificates. See [Pre-Shared Keys](#pre-shared-keys). Optional.
+- `psk-identity` - Identity naming the key, sent to the server during the handshake. Required when `psk` is set.
 
 `enable-0rtt` and the SOCKS5 options do not apply to this protocol.
+
+### Pre-Shared Keys
+
+Instead of certificates, a DTLS connection can be authenticated with a pre-shared key, which suits constrained devices that can't do a full certificate exchange. Both ends need the same key, and a `psk` cannot be combined with `client-crt`/`client-key` on the same resolver since the two are alternatives.
+
+The key is given as hex, for example from `openssl rand -hex 16`. `psk-identity` names the key and is sent to the server so it can select the matching one. It is required on a resolver.
+
+```toml
+[resolvers.dtls-psk]
+address      = "server.acme.test:853"
+protocol     = "dtls"
+psk          = "0102030405060708090a0b0c0d0e0f10"
+psk-identity = "routedns-client"
+```
+
+When a key is configured, only pre-shared key cipher suites are offered: `TLS_PSK_WITH_AES_128_GCM_SHA256`, `TLS_PSK_WITH_CHACHA20_POLY1305_SHA256`, `TLS_PSK_WITH_AES_128_CCM`, `TLS_PSK_WITH_AES_128_CCM_8`, `TLS_PSK_WITH_AES_256_CCM_8`, `TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256` and `TLS_PSK_WITH_AES_128_CBC_SHA256`, in that order. A peer that supports only one of them, such as `TLS_PSK_WITH_AES_128_CCM_8` on an embedded stack, negotiates it without further configuration.
+
+Note the key is a secret held in the configuration file, so the file should be readable only by the user RouteDNS runs as.
+
+Example config files: [dtls-psk-client.toml](../cmd/routedns/example-config/dtls-psk-client.toml)
 
 ### Examples
 

--- a/doc/resolvers.md
+++ b/doc/resolvers.md
@@ -315,9 +315,23 @@ psk          = "0102030405060708090a0b0c0d0e0f10"
 psk-identity = "routedns-client"
 ```
 
-When a key is configured, only pre-shared key cipher suites are offered: `TLS_PSK_WITH_AES_128_GCM_SHA256`, `TLS_PSK_WITH_CHACHA20_POLY1305_SHA256`, `TLS_PSK_WITH_AES_128_CCM`, `TLS_PSK_WITH_AES_128_CCM_8`, `TLS_PSK_WITH_AES_256_CCM_8`, `TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256` and `TLS_PSK_WITH_AES_128_CBC_SHA256`, in that order. A peer that supports only one of them, such as `TLS_PSK_WITH_AES_128_CCM_8` on an embedded stack, negotiates it without further configuration.
+When a key is configured, only pre-shared key cipher suites are offered, in this order:
 
-Note the key is a secret held in the configuration file, so the file should be readable only by the user RouteDNS runs as.
+1. `TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256`
+2. `TLS_PSK_WITH_AES_128_GCM_SHA256`
+3. `TLS_PSK_WITH_CHACHA20_POLY1305_SHA256`
+4. `TLS_PSK_WITH_AES_128_CCM`
+5. `TLS_PSK_WITH_AES_128_CCM_8`
+6. `TLS_PSK_WITH_AES_256_CCM_8`
+7. `TLS_PSK_WITH_AES_128_CBC_SHA256`
+
+The server picks the first entry it also supports, so a peer that only implements one of them, such as `TLS_PSK_WITH_AES_128_CCM_8` on an embedded stack, negotiates it without further configuration.
+
+The ECDHE suite is first despite the others being AEAD, because it is the only one that provides forward secrecy. The rest derive their keys from the shared secret alone, so anyone who obtains the key later can decrypt traffic captured earlier, and the key stays in a configuration file for its whole lifetime. Two peers that both support ECDHE therefore get forward secrecy, while constrained ones still fall through to a suite further down.
+
+Note the key is a secret held in the configuration file, so the file should be readable only by the user RouteDNS runs as. Generating fewer than 16 bytes is allowed, since some devices use shorter keys, but logs a warning at startup: on this path the key is the only thing authenticating the connection.
+
+`psk` cannot be combined with `mutual-tls` on a listener. A pre-shared key handshake carries no client certificate, so requiring one produces a listener that starts and then fails every handshake.
 
 Example config files: [dtls-psk-client.toml](../cmd/routedns/example-config/dtls-psk-client.toml)
 

--- a/dtls.go
+++ b/dtls.go
@@ -10,9 +10,60 @@ import (
 	"github.com/pion/dtls/v3"
 )
 
+// PSK is a DTLS pre-shared key and the identity presented alongside it. Used
+// as an alternative to certificates, typically with constrained devices that
+// can't do a full certificate exchange.
+type PSK struct {
+	// Key is the shared secret itself.
+	Key []byte
+
+	// Identity names the key so the peer can select the right one. Required
+	// for clients, which send it during the handshake. Optional for servers,
+	// where it is offered as a hint.
+	Identity string
+}
+
+// pskCipherSuites are the pre-shared key suites pion supports, AEAD first.
+// They have to be selected explicitly: pion's default list holds only
+// certificate suites, so a config with a PSK and no suites of its own fails
+// the handshake with no available cipher suite.
+var pskCipherSuites = []dtls.CipherSuiteID{
+	dtls.TLS_PSK_WITH_AES_128_GCM_SHA256,
+	dtls.TLS_PSK_WITH_CHACHA20_POLY1305_SHA256,
+	dtls.TLS_PSK_WITH_AES_128_CCM,
+	dtls.TLS_PSK_WITH_AES_128_CCM_8,
+	dtls.TLS_PSK_WITH_AES_256_CCM_8,
+	dtls.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256,
+	dtls.TLS_PSK_WITH_AES_128_CBC_SHA256,
+}
+
+// applyPSK puts a pre-shared key into a DTLS config. Certificates and a PSK
+// are mutually exclusive here: pion can offer both, but the mix makes it
+// unclear which one a peer actually used, so a config asking for both is
+// rejected instead.
+func applyPSK(cfg *dtls.Config, psk *PSK) error {
+	if psk == nil {
+		return nil
+	}
+	if len(psk.Key) == 0 {
+		return errors.New("psk must not be empty")
+	}
+	if len(cfg.Certificates) > 0 {
+		return errors.New("psk cannot be combined with a certificate and key, they are alternatives")
+	}
+	key := psk.Key
+	cfg.PSK = func([]byte) ([]byte, error) { return key, nil }
+	if psk.Identity != "" {
+		cfg.PSKIdentityHint = []byte(psk.Identity)
+	}
+	cfg.CipherSuites = pskCipherSuites
+	return nil
+}
+
 // DTLSServerConfig is a convenience function that builds a dtls.Config instance for DTLS servers
-// based on common options and certificate+key files.
-func DTLSServerConfig(caFile, crtFile, keyFile string, mutualTLS bool) (*dtls.Config, error) {
+// based on common options and certificate+key files. A non-nil psk configures
+// pre-shared key authentication instead of certificates.
+func DTLSServerConfig(caFile, crtFile, keyFile string, mutualTLS bool, psk *PSK) (*dtls.Config, error) {
 	if mutualTLS && caFile == "" {
 		return nil, errors.New("mutual-tls requires a ca to be configured to verify client certificates")
 	}
@@ -40,12 +91,16 @@ func DTLSServerConfig(caFile, crtFile, keyFile string, mutualTLS bool) (*dtls.Co
 			return nil, err
 		}
 	}
+	if err := applyPSK(dtlsConfig, psk); err != nil {
+		return nil, err
+	}
 	return dtlsConfig, nil
 }
 
 // DTLSClientConfig is a convenience function that builds a dtls.Config instance for TLS clients
-// based on common options and certificate+key files.
-func DTLSClientConfig(caFile, crtFile, keyFile string) (*dtls.Config, error) {
+// based on common options and certificate+key files. A non-nil psk configures
+// pre-shared key authentication instead of certificates.
+func DTLSClientConfig(caFile, crtFile, keyFile string, psk *PSK) (*dtls.Config, error) {
 	dtlsConfig := &dtls.Config{}
 
 	// Add client key/cert if provided
@@ -69,6 +124,12 @@ func DTLSClientConfig(caFile, crtFile, keyFile string) (*dtls.Config, error) {
 			return nil, fmt.Errorf("no CA certificates found in %s", caFile)
 		}
 		dtlsConfig.RootCAs = certPool
+	}
+	if psk != nil && psk.Identity == "" {
+		return nil, errors.New("psk-identity is required when using a psk on a resolver")
+	}
+	if err := applyPSK(dtlsConfig, psk); err != nil {
+		return nil, err
 	}
 	return dtlsConfig, nil
 }

--- a/dtls.go
+++ b/dtls.go
@@ -23,33 +23,54 @@ type PSK struct {
 	Identity string
 }
 
-// pskCipherSuites are the pre-shared key suites pion supports, AEAD first.
-// They have to be selected explicitly: pion's default list holds only
-// certificate suites, so a config with a PSK and no suites of its own fails
-// the handshake with no available cipher suite.
+// pskCipherSuites are the pre-shared key suites pion supports. They have to be
+// selected explicitly: pion's default list holds only certificate suites, so a
+// config with a PSK and no suites of its own fails the handshake with no
+// available cipher suite.
+//
+// The ECDHE suite comes first even though the rest are AEAD, because it is the
+// only one here that provides forward secrecy. The others derive their keys
+// from the shared secret alone, so anyone who later obtains the key can decrypt
+// traffic captured earlier, and the key sits in a config file for its whole
+// lifetime. A server picks the first entry of this list that it also supports,
+// so peers that can do ECDHE get forward secrecy while constrained ones still
+// negotiate a suite further down.
 var pskCipherSuites = []dtls.CipherSuiteID{
+	dtls.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256,
 	dtls.TLS_PSK_WITH_AES_128_GCM_SHA256,
 	dtls.TLS_PSK_WITH_CHACHA20_POLY1305_SHA256,
 	dtls.TLS_PSK_WITH_AES_128_CCM,
 	dtls.TLS_PSK_WITH_AES_128_CCM_8,
 	dtls.TLS_PSK_WITH_AES_256_CCM_8,
-	dtls.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256,
 	dtls.TLS_PSK_WITH_AES_128_CBC_SHA256,
 }
+
+// recommendedPSKLength is the key size the documentation suggests generating.
+// Shorter keys are allowed, since embedded peers sometimes use them, but they
+// are the only thing authenticating the connection so a short one is worth
+// pointing out.
+const recommendedPSKLength = 16
 
 // applyPSK puts a pre-shared key into a DTLS config. Certificates and a PSK
 // are mutually exclusive here: pion can offer both, but the mix makes it
 // unclear which one a peer actually used, so a config asking for both is
 // rejected instead.
-func applyPSK(cfg *dtls.Config, psk *PSK) error {
+func applyPSK(cfg *dtls.Config, psk *PSK, crtFile, keyFile string) error {
 	if psk == nil {
 		return nil
 	}
 	if len(psk.Key) == 0 {
 		return errors.New("psk must not be empty")
 	}
-	if len(cfg.Certificates) > 0 {
+	// Checked against the file names rather than cfg.Certificates, which is
+	// only populated when both a certificate and a key were given. Otherwise a
+	// half-specified certificate would be dropped without a word.
+	if crtFile != "" || keyFile != "" {
 		return errors.New("psk cannot be combined with a certificate and key, they are alternatives")
+	}
+	if len(psk.Key) < recommendedPSKLength {
+		Log.Warn("psk is shorter than recommended",
+			"bytes", len(psk.Key), "recommended", recommendedPSKLength)
 	}
 	key := psk.Key
 	cfg.PSK = func([]byte) ([]byte, error) { return key, nil }
@@ -66,6 +87,11 @@ func applyPSK(cfg *dtls.Config, psk *PSK) error {
 func DTLSServerConfig(caFile, crtFile, keyFile string, mutualTLS bool, psk *PSK) (*dtls.Config, error) {
 	if mutualTLS && caFile == "" {
 		return nil, errors.New("mutual-tls requires a ca to be configured to verify client certificates")
+	}
+	// A PSK handshake never carries a client certificate, so requiring one
+	// leaves a listener that starts up but fails every handshake.
+	if mutualTLS && psk != nil {
+		return nil, errors.New("psk cannot be combined with mutual-tls, a pre-shared key handshake has no client certificate")
 	}
 	dtlsConfig := &dtls.Config{}
 	if mutualTLS {
@@ -91,7 +117,7 @@ func DTLSServerConfig(caFile, crtFile, keyFile string, mutualTLS bool, psk *PSK)
 			return nil, err
 		}
 	}
-	if err := applyPSK(dtlsConfig, psk); err != nil {
+	if err := applyPSK(dtlsConfig, psk, crtFile, keyFile); err != nil {
 		return nil, err
 	}
 	return dtlsConfig, nil
@@ -128,7 +154,7 @@ func DTLSClientConfig(caFile, crtFile, keyFile string, psk *PSK) (*dtls.Config, 
 	if psk != nil && psk.Identity == "" {
 		return nil, errors.New("psk-identity is required when using a psk on a resolver")
 	}
-	if err := applyPSK(dtlsConfig, psk); err != nil {
+	if err := applyPSK(dtlsConfig, psk, crtFile, keyFile); err != nil {
 		return nil, err
 	}
 	return dtlsConfig, nil

--- a/dtlslistener_test.go
+++ b/dtlslistener_test.go
@@ -151,9 +151,16 @@ func TestDTLSPSKNegotiatesForwardSecrecy(t *testing.T) {
 	clientConfig, err := DTLSClientConfig("", "", "", &PSK{Key: key, Identity: "client"})
 	require.NoError(t, err)
 
+	// Driven through the options API rather than the deprecated dtls.Listen,
+	// but from the configs built above, so the suite list under test is still
+	// the one this package produces.
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
 	require.NoError(t, err)
-	ln, err := dtls.Listen("udp", addr, serverConfig)
+	ln, err := dtls.ListenWithOptions("udp", addr,
+		dtls.WithPSK(serverConfig.PSK),
+		dtls.WithPSKIdentityHint(serverConfig.PSKIdentityHint),
+		dtls.WithCipherSuites(serverConfig.CipherSuites...),
+	)
 	require.NoError(t, err)
 	defer ln.Close()
 
@@ -169,7 +176,11 @@ func TestDTLSPSKNegotiatesForwardSecrecy(t *testing.T) {
 		_, _ = conn.Read(buf) // completes the handshake on this side
 	}()
 
-	conn, err := dtls.Dial("udp", ln.Addr().(*net.UDPAddr), clientConfig)
+	conn, err := dtls.DialWithOptions("udp", ln.Addr().(*net.UDPAddr),
+		dtls.WithPSK(clientConfig.PSK),
+		dtls.WithPSKIdentityHint(clientConfig.PSKIdentityHint),
+		dtls.WithCipherSuites(clientConfig.CipherSuites...),
+	)
 	require.NoError(t, err)
 	defer conn.Close()
 	_, err = conn.Write([]byte("ping"))

--- a/dtlslistener_test.go
+++ b/dtlslistener_test.go
@@ -16,7 +16,7 @@ func TestDTLSListener(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the listener
-	dtlsConfig, err := DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+	dtlsConfig, err := DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", false, nil)
 	require.NoError(t, err)
 	s := NewDTLSListener("test-dtls-server", addr, DTLSListenerOptions{DTLSConfig: dtlsConfig}, upstream)
 	go s.Start()
@@ -24,7 +24,7 @@ func TestDTLSListener(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Make a client talking to the listener
-	dtlsClientConfig, err := DTLSClientConfig("testdata/ca.crt", "", "")
+	dtlsClientConfig, err := DTLSClientConfig("testdata/ca.crt", "", "", nil)
 	require.NoError(t, err)
 	c, err := NewDTLSClient("test-dtls-client", addr, DTLSClientOptions{DTLSConfig: dtlsClientConfig})
 	require.NoError(t, err)
@@ -37,4 +37,79 @@ func TestDTLSListener(t *testing.T) {
 
 	// The upstream resolver should have seen the query
 	require.Equal(t, 1, upstream.HitCount())
+}
+
+// A PSK handshake end-to-end, with no certificates on either side.
+func TestDTLSListenerPSK(t *testing.T) {
+	key := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	upstream := new(TestResolver)
+
+	addr, err := getLnAddress()
+	require.NoError(t, err)
+
+	serverConfig, err := DTLSServerConfig("", "", "", false, &PSK{Key: key, Identity: "test-server"})
+	require.NoError(t, err)
+	s := NewDTLSListener("test-dtls-psk-server", addr, DTLSListenerOptions{DTLSConfig: serverConfig}, upstream)
+	go s.Start()
+	defer s.Stop()
+	time.Sleep(time.Second)
+
+	clientConfig, err := DTLSClientConfig("", "", "", &PSK{Key: key, Identity: "test-client"})
+	require.NoError(t, err)
+	c, err := NewDTLSClient("test-dtls-psk-client", addr, DTLSClientOptions{DTLSConfig: clientConfig})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	_, err = c.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.Equal(t, 1, upstream.HitCount())
+}
+
+// The key has to be verified, not just accepted, so a client with the wrong
+// one must not get an answer through.
+//
+// The listener is stopped without waiting here. Shutdown blocks after a
+// handshake the peer abandoned, because dns.Server.Shutdown waits on the
+// connection pion left behind. That is a pre-existing issue in the DTLS
+// listener, unrelated to pre-shared keys: the same happens with certificates,
+// and it does not affect the successful path above.
+func TestDTLSListenerPSKMismatch(t *testing.T) {
+	upstream := new(TestResolver)
+
+	addr, err := getLnAddress()
+	require.NoError(t, err)
+
+	serverConfig, err := DTLSServerConfig("", "", "", false, &PSK{Key: []byte{0x01, 0x02, 0x03, 0x04}, Identity: "test-server"})
+	require.NoError(t, err)
+	s := NewDTLSListener("test-dtls-psk-mismatch", addr, DTLSListenerOptions{DTLSConfig: serverConfig}, upstream)
+	go s.Start()
+	defer func() { go s.Stop() }()
+	time.Sleep(time.Second)
+
+	clientConfig, err := DTLSClientConfig("", "", "", &PSK{Key: []byte{0xff, 0xfe, 0xfd, 0xfc}, Identity: "test-client"})
+	require.NoError(t, err)
+	c, err := NewDTLSClient("test-dtls-psk-mismatch-client", addr, DTLSClientOptions{DTLSConfig: clientConfig, QueryTimeout: time.Second})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	_, err = c.Resolve(q, ClientInfo{})
+	require.Error(t, err, "a query must not succeed with the wrong key")
+	require.Equal(t, 0, upstream.HitCount(), "the query must not reach the upstream")
+}
+
+// A client PSK without an identity is rejected up front, since pion fails the
+// dial with the same requirement.
+func TestDTLSClientPSKRequiresIdentity(t *testing.T) {
+	_, err := DTLSClientConfig("", "", "", &PSK{Key: []byte{0x01}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "psk-identity is required")
+}
+
+// Certificates and a PSK are alternatives, not a combination.
+func TestDTLSPSKAndCertificateRejected(t *testing.T) {
+	_, err := DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", false, &PSK{Key: []byte{0x01}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot be combined with a certificate")
 }

--- a/dtlslistener_test.go
+++ b/dtlslistener_test.go
@@ -1,10 +1,12 @@
 package rdns
 
 import (
+	"net"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/pion/dtls/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -107,9 +109,75 @@ func TestDTLSClientPSKRequiresIdentity(t *testing.T) {
 	require.Contains(t, err.Error(), "psk-identity is required")
 }
 
-// Certificates and a PSK are alternatives, not a combination.
+// Certificates and a PSK are alternatives, not a combination. A half-specified
+// certificate counts too: checking the loaded certificates rather than the file
+// names would let one through and silently drop it.
 func TestDTLSPSKAndCertificateRejected(t *testing.T) {
-	_, err := DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", false, &PSK{Key: []byte{0x01}})
+	for _, tc := range []struct{ name, crt, key string }{
+		{"both", "testdata/server.crt", "testdata/server.key"},
+		{"certificate only", "testdata/server.crt", ""},
+		{"key only", "", "testdata/server.key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DTLSServerConfig("", tc.crt, tc.key, false, &PSK{Key: []byte{0x01}})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "cannot be combined with a certificate")
+
+			_, err = DTLSClientConfig("", tc.crt, tc.key, &PSK{Key: []byte{0x01}, Identity: "client"})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "cannot be combined with a certificate")
+		})
+	}
+}
+
+// mutual-tls asks the client for a certificate, which a PSK handshake never
+// sends. Without this the listener starts and then fails every handshake.
+func TestDTLSPSKAndMutualTLSRejected(t *testing.T) {
+	_, err := DTLSServerConfig("testdata/ca.crt", "", "", true, &PSK{Key: []byte{0x01}})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot be combined with a certificate")
+	require.Contains(t, err.Error(), "cannot be combined with mutual-tls")
+}
+
+// Two peers both using the configs built here have to end up on the forward
+// secret suite. A server selects the first entry of the client's list that it
+// also supports, so this depends on the order of pskCipherSuites and would
+// silently regress if the AEAD suites were moved to the front.
+func TestDTLSPSKNegotiatesForwardSecrecy(t *testing.T) {
+	key := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	serverConfig, err := DTLSServerConfig("", "", "", false, &PSK{Key: key, Identity: "server"})
+	require.NoError(t, err)
+	clientConfig, err := DTLSClientConfig("", "", "", &PSK{Key: key, Identity: "client"})
+	require.NoError(t, err)
+
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	ln, err := dtls.Listen("udp", addr, serverConfig)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 16)
+		_, _ = conn.Read(buf) // completes the handshake on this side
+	}()
+
+	conn, err := dtls.Dial("udp", ln.Addr().(*net.UDPAddr), clientConfig)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.Write([]byte("ping"))
+	require.NoError(t, err)
+	<-done
+
+	state, ok := conn.ConnectionState()
+	require.True(t, ok)
+	require.Equal(t, dtls.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256, state.CipherSuiteID,
+		"a PSK connection between two RouteDNS peers should use the forward secret suite")
 }

--- a/tls_test.go
+++ b/tls_test.go
@@ -22,12 +22,12 @@ func TestTLSServerConfigMutualTLSRequiresCA(t *testing.T) {
 }
 
 func TestDTLSServerConfigMutualTLSRequiresCA(t *testing.T) {
-	_, err := DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", true)
+	_, err := DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", true, nil)
 	require.Error(t, err)
 
-	_, err = DTLSServerConfig("testdata/ca.crt", "testdata/server.crt", "testdata/server.key", true)
+	_, err = DTLSServerConfig("testdata/ca.crt", "testdata/server.crt", "testdata/server.key", true, nil)
 	require.NoError(t, err)
 
-	_, err = DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+	_, err = DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", false, nil)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Adds `psk` and `psk-identity` to DTLS resolvers and listeners, authenticating the connection with a shared secret instead of certificates.

```toml
[listeners.local-dtls]
address      = ":853"
protocol     = "dtls"
resolver     = "cloudflare-dot"
psk          = "0102030405060708090a0b0c0d0e0f10"
psk-identity = "routedns-server"

[resolvers.dtls-psk]
address      = "server.acme.test:853"
protocol     = "dtls"
psk          = "0102030405060708090a0b0c0d0e0f10"
psk-identity = "routedns-client"
```

## Why it did not work before

The reporter asked how to configure this and could not find a way. There was a concrete reason beyond the missing options.

pion's `defaultCipherSuites()` contains only certificate suites. The pre-shared key suites exist solely in `allCipherSuites()`, so a config that sets `PSK` while leaving `CipherSuites` nil gets the defaults filtered down to nothing usable and fails the handshake with no available cipher suite. A key therefore has to bring its own suites, which is what this change does.

## Cipher suites and forward secrecy

Setting a key selects the pre-shared key suites, led by `TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256`. That is the only one of them offering forward secrecy; the rest derive their keys from the shared secret alone, so anyone obtaining the key later can decrypt traffic captured earlier, and the key sits in a config file for its whole lifetime. A server picks the first entry of the client's list that it also supports, so two RouteDNS peers get forward secrecy while a constrained peer still falls through to a suite below, including `TLS_PSK_WITH_AES_128_CCM_8`, the suite named in the issue.

A test asserts the negotiated suite rather than the list contents, so moving the AEAD suites back to the front fails it.

## Validation

Configurations that cannot work are rejected at startup rather than starting and failing every handshake:

- `psk` with `mutual-tls`, since a pre-shared key handshake carries no client certificate to require
- `psk` with `server-crt`/`server-key` or `client-crt`/`client-key`, which are alternatives. Checked against the configured file names, so a half-specified certificate is caught too rather than being silently dropped
- `psk` or `psk-identity` on any non-DTLS protocol. They sit on the shared listener and resolver structs, so without this they would be accepted and ignored, leaving the impression a connection was key-authenticated when it was not
- `psk-identity` without a key, and a key that is not valid hex

`psk-identity` is required on a resolver, matching pion, which fails the dial without it. On a listener it is optional and offered as a hint.

Keys shorter than 16 bytes log a warning rather than failing, since embedded peers sometimes use them, but the key is the only thing authenticating the connection.

The key is a secret held in the config file. The docs note the file should be readable only by the user RouteDNS runs as. A `psk-file` option was considered and left out for now.

## Verification

An end-to-end test stands up a PSK listener and a PSK resolver with no certificates anywhere and asserts the query reaches the upstream, with a mismatched key failing and the upstream seeing nothing. Config-level tests cover each rejection above.

A live run of the built binary chains a PSK DTLS listener and a PSK DTLS resolver in one process and answers a query through the encrypted hop.

## One thing found along the way, not fixed here

`DTLSListener.Stop()` blocks after a handshake the peer abandoned, because `dns.Server.Shutdown` waits on the connection pion left behind. This is pre-existing and unrelated to pre-shared keys; the successful path is unaffected and a failed certificate handshake shuts down cleanly. The mismatched-key test stops its listener without waiting and carries a comment explaining why. Worth its own issue rather than widening this change.

Fixes #187
