### PR TITLE
Bound the DTLS handshake so an abandoned one can't pin a connection

### DIFF
--- a/dtlsclient.go
+++ b/dtlsclient.go
@@ -159,5 +159,5 @@ func (d dtlsDialer) Dial(address string) (*dns.Conn, error) {
 		pConn.Close()
 		return nil, err
 	}
-	return &dns.Conn{Conn: &dtlsConn{Conn: c}}, nil
+	return &dns.Conn{Conn: newDTLSConn(c)}, nil
 }

--- a/dtlslistener.go
+++ b/dtlslistener.go
@@ -96,7 +96,7 @@ type dtlsListener struct {
 
 func (l dtlsListener) Accept() (net.Conn, error) {
 	conn, err := l.Listener.Accept()
-	return &dtlsConn{Conn: conn}, err
+	return newDTLSConn(conn), err
 }
 
 // dtlsHandshakeTimeout bounds how long a DTLS handshake is given to complete.
@@ -108,9 +108,7 @@ func (l dtlsListener) Accept() (net.Conn, error) {
 // forever. On a listener that is the connection goroutine dns.Server.Shutdown
 // waits for, so the server never shuts down; on a resolver it is the pipeline's
 // reader and writer, which leak for every abandoned connection.
-// A variable rather than a constant so tests can shorten it; nothing else
-// writes to it.
-var dtlsHandshakeTimeout = 10 * time.Second
+const dtlsHandshakeTimeout = 10 * time.Second
 
 // dtlsConn wraps a dtls.Conn to support partial read operations. While
 // github.com/pion/dtls/v3 returns a net.Conn, that Read() fails on
@@ -122,9 +120,51 @@ var dtlsHandshakeTimeout = 10 * time.Second
 // dtlsHandshakeTimeout.
 type dtlsConn struct {
 	net.Conn
-	buf       *bytes.Buffer
+	buf *bytes.Buffer
+
+	// handshakeTimeout overrides dtlsHandshakeTimeout when non-zero. Only the
+	// tests set it, so production connections all use the default and nothing
+	// writes to it once the connection is in use.
+	handshakeTimeout time.Duration
+
 	handshake sync.Once
 	hsErr     error
+
+	// abort is closed when the connection is closed, or when its read deadline
+	// is moved into the past, which is how dns.Server.Shutdown unblocks a
+	// connection it is waiting on. A handshake in flight ignores the deadline,
+	// so it watches this instead and shutdown does not have to wait out
+	// dtlsHandshakeTimeout.
+	abortOnce sync.Once
+	abort     chan struct{}
+}
+
+func newDTLSConn(conn net.Conn) *dtlsConn {
+	return &dtlsConn{Conn: conn, abort: make(chan struct{})}
+}
+
+// signalAbort tells a handshake in flight to give up.
+func (c *dtlsConn) signalAbort() {
+	if c.abort == nil {
+		return
+	}
+	c.abortOnce.Do(func() { close(c.abort) })
+}
+
+func (c *dtlsConn) Close() error {
+	c.signalAbort()
+	return c.Conn.Close()
+}
+
+// SetReadDeadline passes the deadline through, and treats one that has already
+// passed as a request to unblock. That is what dns.Server.Shutdown does to the
+// connections it waits on, and a handshake would otherwise ignore it, since
+// pion only consults the read deadline once the handshake is complete.
+func (c *dtlsConn) SetReadDeadline(t time.Time) error {
+	if !t.IsZero() && !t.After(time.Now()) {
+		c.signalAbort()
+	}
+	return c.Conn.SetReadDeadline(t)
 }
 
 // dtlsHandshaker is implemented by *dtls.Conn. Taken as an interface so the
@@ -143,8 +183,19 @@ func (c *dtlsConn) completeHandshake() error {
 		if !ok {
 			return
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), dtlsHandshakeTimeout)
+		timeout := c.handshakeTimeout
+		if timeout == 0 {
+			timeout = dtlsHandshakeTimeout
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
+		go func() {
+			select {
+			case <-c.abort:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
 		c.hsErr = hs.HandshakeContext(ctx)
 	})
 	return c.hsErr

--- a/dtlslistener.go
+++ b/dtlslistener.go
@@ -2,9 +2,12 @@ package rdns
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"net"
 	"strconv"
+	"sync"
+	"time"
 
 	"log/slog"
 
@@ -96,17 +99,61 @@ func (l dtlsListener) Accept() (net.Conn, error) {
 	return &dtlsConn{Conn: conn}, err
 }
 
+// dtlsHandshakeTimeout bounds how long a DTLS handshake is given to complete.
+//
+// pion runs the handshake lazily, on the first Read or Write, and uses
+// context.Background() for it, so the connection's read deadline does not
+// apply: it is only consulted once the handshake is done. A peer that starts a
+// handshake and then stops responding therefore pins the goroutine driving it
+// forever. On a listener that is the connection goroutine dns.Server.Shutdown
+// waits for, so the server never shuts down; on a resolver it is the pipeline's
+// reader and writer, which leak for every abandoned connection.
+// A variable rather than a constant so tests can shorten it; nothing else
+// writes to it.
+var dtlsHandshakeTimeout = 10 * time.Second
+
 // dtlsConn wraps a dtls.Conn to support partial read operations. While
 // github.com/pion/dtls/v3 returns a net.Conn, that Read() fails on
 // slices that are smaller than the data available. This wrapper adds a
 // buffer to allow github.com/miekg/dns to first read 2 bytes (size) and
 // then the rest of the DNS packet.
+//
+// It also completes the handshake under a deadline before any data moves, see
+// dtlsHandshakeTimeout.
 type dtlsConn struct {
 	net.Conn
-	buf *bytes.Buffer
+	buf       *bytes.Buffer
+	handshake sync.Once
+	hsErr     error
+}
+
+// dtlsHandshaker is implemented by *dtls.Conn. Taken as an interface so the
+// wrapper stays usable with any net.Conn, which the tests rely on.
+type dtlsHandshaker interface {
+	HandshakeContext(context.Context) error
+}
+
+// completeHandshake runs the DTLS handshake once, bounded by a deadline, and
+// returns the same result to every later caller. Read and Write run on separate
+// goroutines in the pipeline, so both have to go through here, and whichever
+// arrives second waits for the first rather than starting its own.
+func (c *dtlsConn) completeHandshake() error {
+	c.handshake.Do(func() {
+		hs, ok := c.Conn.(dtlsHandshaker)
+		if !ok {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), dtlsHandshakeTimeout)
+		defer cancel()
+		c.hsErr = hs.HandshakeContext(ctx)
+	})
+	return c.hsErr
 }
 
 func (c *dtlsConn) Read(b []byte) (int, error) {
+	if err := c.completeHandshake(); err != nil {
+		return 0, err
+	}
 	var (
 		n   int
 		err error
@@ -118,4 +165,11 @@ func (c *dtlsConn) Read(b []byte) (int, error) {
 	}
 	n, _ = c.buf.Read(b)
 	return n, err
+}
+
+func (c *dtlsConn) Write(b []byte) (int, error) {
+	if err := c.completeHandshake(); err != nil {
+		return 0, err
+	}
+	return c.Conn.Write(b)
 }

--- a/dtlslistener_test.go
+++ b/dtlslistener_test.go
@@ -74,7 +74,6 @@ func TestDTLSListenerPSK(t *testing.T) {
 // The key has to be verified, not just accepted, so a client with the wrong
 // one must not get an answer through.
 func TestDTLSListenerPSKMismatch(t *testing.T) {
-	defer shortenDTLSHandshakeTimeout(t)()
 	upstream := new(TestResolver)
 
 	addr, err := getLnAddress()
@@ -196,7 +195,6 @@ func TestDTLSPSKNegotiatesForwardSecrecy(t *testing.T) {
 // context, so without a deadline of our own the connection goroutine never
 // returns and dns.Server.Shutdown waits on it forever.
 func TestDTLSListenerStopAfterAbandonedHandshake(t *testing.T) {
-	defer shortenDTLSHandshakeTimeout(t)()
 	upstream := new(TestResolver)
 
 	addr, err := getLnAddress()
@@ -223,22 +221,18 @@ func TestDTLSListenerStopAfterAbandonedHandshake(t *testing.T) {
 	require.NoError(t, conn.Close())
 	time.Sleep(500 * time.Millisecond)
 
+	// Shutdown has to cancel the handshake rather than wait it out, so this is
+	// deliberately far below dtlsHandshakeTimeout.
 	stopped := make(chan error, 1)
+	start := time.Now()
 	go func() { stopped <- s.Stop() }()
 	select {
 	case <-stopped:
-	case <-time.After(10 * time.Second):
+	case <-time.After(dtlsHandshakeTimeout / 2):
 		t.Fatal("Stop blocked on a connection whose handshake was abandoned")
 	}
-}
-
-// shortenDTLSHandshakeTimeout keeps the tests that wait out a handshake from
-// spending the production timeout doing it.
-func shortenDTLSHandshakeTimeout(t *testing.T) func() {
-	t.Helper()
-	previous := dtlsHandshakeTimeout
-	dtlsHandshakeTimeout = time.Second
-	return func() { dtlsHandshakeTimeout = previous }
+	require.Less(t, time.Since(start), dtlsHandshakeTimeout/2,
+		"shutdown waited out the handshake timeout instead of cancelling it")
 }
 
 // stalledHandshakeConn stands in for a *dtls.Conn whose peer never finishes the
@@ -260,10 +254,9 @@ func (c *stalledHandshakeConn) Write([]byte) (int, error) { panic("handshake sho
 // Read and Write both wait for the handshake, so both have to give up when it
 // does not finish, and between them they must only run it once.
 func TestDTLSConnHandshakeDeadline(t *testing.T) {
-	defer shortenDTLSHandshakeTimeout(t)()
-
 	stalled := &stalledHandshakeConn{}
-	c := &dtlsConn{Conn: stalled}
+	c := newDTLSConn(stalled)
+	c.handshakeTimeout = time.Second
 
 	var wg sync.WaitGroup
 	errs := make([]error, 2)

--- a/dtlslistener_test.go
+++ b/dtlslistener_test.go
@@ -1,7 +1,10 @@
 package rdns
 
 import (
+	"context"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -70,13 +73,8 @@ func TestDTLSListenerPSK(t *testing.T) {
 
 // The key has to be verified, not just accepted, so a client with the wrong
 // one must not get an answer through.
-//
-// The listener is stopped without waiting here. Shutdown blocks after a
-// handshake the peer abandoned, because dns.Server.Shutdown waits on the
-// connection pion left behind. That is a pre-existing issue in the DTLS
-// listener, unrelated to pre-shared keys: the same happens with certificates,
-// and it does not affect the successful path above.
 func TestDTLSListenerPSKMismatch(t *testing.T) {
+	defer shortenDTLSHandshakeTimeout(t)()
 	upstream := new(TestResolver)
 
 	addr, err := getLnAddress()
@@ -86,7 +84,7 @@ func TestDTLSListenerPSKMismatch(t *testing.T) {
 	require.NoError(t, err)
 	s := NewDTLSListener("test-dtls-psk-mismatch", addr, DTLSListenerOptions{DTLSConfig: serverConfig}, upstream)
 	go s.Start()
-	defer func() { go s.Stop() }()
+	defer s.Stop()
 	time.Sleep(time.Second)
 
 	clientConfig, err := DTLSClientConfig("", "", "", &PSK{Key: []byte{0xff, 0xfe, 0xfd, 0xfc}, Identity: "test-client"})
@@ -191,4 +189,103 @@ func TestDTLSPSKNegotiatesForwardSecrecy(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, dtls.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256, state.CipherSuiteID,
 		"a PSK connection between two RouteDNS peers should use the forward secret suite")
+}
+
+// A peer that starts a handshake and then stops responding must not pin the
+// listener open. pion runs the handshake on the first Read with an unbounded
+// context, so without a deadline of our own the connection goroutine never
+// returns and dns.Server.Shutdown waits on it forever.
+func TestDTLSListenerStopAfterAbandonedHandshake(t *testing.T) {
+	defer shortenDTLSHandshakeTimeout(t)()
+	upstream := new(TestResolver)
+
+	addr, err := getLnAddress()
+	require.NoError(t, err)
+
+	serverConfig, err := DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", false, nil)
+	require.NoError(t, err)
+	s := NewDTLSListener("test-dtls-abandoned", addr, DTLSListenerOptions{DTLSConfig: serverConfig}, upstream)
+	go s.Start()
+	time.Sleep(time.Second)
+
+	// Send a ClientHello and then go away. The server accepts the connection
+	// and starts a handshake that never completes.
+	conn, err := net.Dial("udp", addr)
+	require.NoError(t, err)
+	clientHello := []byte{
+		0x16, 0xfe, 0xfd, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x10, 0x01, 0x00, 0x00,
+		0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x04, 0xfe, 0xfd, 0x00, 0x00,
+	}
+	_, err = conn.Write(clientHello)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	time.Sleep(500 * time.Millisecond)
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- s.Stop() }()
+	select {
+	case <-stopped:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Stop blocked on a connection whose handshake was abandoned")
+	}
+}
+
+// shortenDTLSHandshakeTimeout keeps the tests that wait out a handshake from
+// spending the production timeout doing it.
+func shortenDTLSHandshakeTimeout(t *testing.T) func() {
+	t.Helper()
+	previous := dtlsHandshakeTimeout
+	dtlsHandshakeTimeout = time.Second
+	return func() { dtlsHandshakeTimeout = previous }
+}
+
+// stalledHandshakeConn stands in for a *dtls.Conn whose peer never finishes the
+// handshake: HandshakeContext returns only when the context is done.
+type stalledHandshakeConn struct {
+	net.Conn
+	calls atomic.Int64
+}
+
+func (c *stalledHandshakeConn) HandshakeContext(ctx context.Context) error {
+	c.calls.Add(1)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (c *stalledHandshakeConn) Read([]byte) (int, error)  { panic("handshake should not complete") }
+func (c *stalledHandshakeConn) Write([]byte) (int, error) { panic("handshake should not complete") }
+
+// Read and Write both wait for the handshake, so both have to give up when it
+// does not finish, and between them they must only run it once.
+func TestDTLSConnHandshakeDeadline(t *testing.T) {
+	defer shortenDTLSHandshakeTimeout(t)()
+
+	stalled := &stalledHandshakeConn{}
+	c := &dtlsConn{Conn: stalled}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, errs[0] = c.Read(make([]byte, 2))
+	}()
+	go func() {
+		defer wg.Done()
+		_, errs[1] = c.Write([]byte("query"))
+	}()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Read and Write did not return after the handshake deadline")
+	}
+
+	require.ErrorIs(t, errs[0], context.DeadlineExceeded)
+	require.ErrorIs(t, errs[1], context.DeadlineExceeded)
+	require.Equal(t, int64(1), stalled.calls.Load(), "the handshake should run once for the connection")
 }


### PR DESCRIPTION
Fixes a DTLS listener that never shuts down, and a matching goroutine leak on DTLS resolvers.

## The problem

pion runs the DTLS handshake lazily, on the first `Read` or `Write`, and uses `context.Background()` for it:

```go
func (c *Conn) Read(buff []byte) (n int, err error) {
	if err := c.Handshake(); err != nil {   // HandshakeContext(context.Background())
		return 0, err
	}
	select {
	case <-c.readDeadline.Done():           // only reached once the handshake is done
```

The connection's read deadline does not bound it, because it is only consulted after the handshake completes. `miekg/dns` does set a read deadline on the connection, so it looks covered, but that deadline never gets a chance to fire.

A peer that sends a ClientHello and then stops responding pins the goroutine driving the handshake forever. Where that goroutine sits decides what breaks:

- On a **listener** it is the connection goroutine that `dns.Server.Shutdown` waits for, so `Stop()` never returns. A query with a mismatched pre-shared key is enough, and so is any handshake a peer walks away from.
- On a **resolver** it is the pipeline's reader and writer, so `Pipeline.start` leaks one goroutine set per connection that fails this way. Queries still return, via the query timeout, so nothing surfaces to the user.

## The fix

`dtlsConn` already wraps the connection to support partial reads. It now also completes the handshake under a deadline, once, before any data moves. Both `Read` and `Write` go through it, since the pipeline drives them on separate goroutines and either can be first.

A deadline alone bounds the wait without ending it promptly. `dns.Server` unblocks the connections it waits on by moving their read deadline into the past, and a handshake ignores that, because pion only consults the deadline once the handshake is complete. Shutdown would return, but only after the full timeout: 9.5 seconds against a 10 second bound. So the connection also cancels a handshake in flight when it is closed, or when its read deadline is moved into the past, which makes shutdown prompt rather than merely bounded.

The timeout is 10 seconds, generous next to a handshake that normally completes in well under a second, including pion's retransmits. There is no pion configuration hook for this: `ConnectContextMaker` existed in v2 but not in v3, so the context has to come from the caller.

## Verification

Three tests, each confirmed to fail with the fix reverted:

- A listener shuts down after a peer sends a ClientHello and disappears. Without the fix the test binary hits its own timeout.
- The pre-shared key mismatch test now stops its listener normally. It previously had to leave it running to avoid this hang, and that workaround and its comment are gone.
- A unit test drives the wrapper with a stalled handshake and asserts `Read` and `Write` both give up with the deadline error, and that between them the handshake runs exactly once.

The shutdown test asserts the elapsed time rather than just that shutdown finishes, so a version that waits out the timeout instead of cancelling fails it.

A live run of the built binary confirms the successful path is unchanged, answering a query through a PSK-authenticated DTLS hop with nothing logged, and shutting down in 10ms.

The timeout is a constant. The one test that needs a shorter one sets a per-connection override, rather than writing a package-level variable that production goroutines read, which raced under `-race`.
