### PR TITLE
Drop nil responses in the DoQ listener instead of packing them

### DIFF
--- a/doqlistener.go
+++ b/doqlistener.go
@@ -268,6 +268,16 @@ func (s *DoQListener) handleStream(stream *quic.Stream, connection *quic.Conn, c
 		a.SetRcode(q, dns.RcodeServerFailure)
 	}
 
+	// A nil response from the resolvers means "drop", close the stream without
+	// answering. The deferred Close above ends the stream, which is all a DoQ
+	// client sees. Without this the Pack below dereferences a nil message and
+	// the panic, being in this per-stream goroutine, takes the process down.
+	if a == nil {
+		log.Debug("dropping query")
+		s.metrics.drop.Add(1)
+		return
+	}
+
 	p, err := a.Pack()
 	if err != nil {
 		log.Warn("failed to encode response", "error", err)

--- a/doqlistener_test.go
+++ b/doqlistener_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"io"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -294,4 +295,72 @@ func (r *earlyDataRelay) serverToClient() {
 			_, _ = r.conn.WriteToUDP(buf[:n], client)
 		}
 	}
+}
+
+// A nil response means "drop". Every other listener already handles it; DoQ
+// was added later and never picked the convention up, so it packed the nil
+// message and brought the process down with it. A drop group behind a DoQ
+// listener is a shipped configuration, see client-blocklist-drop.toml, which
+// made this reachable by any client the operator had deliberately blocked.
+func TestDoQListenerDropsNilResponse(t *testing.T) {
+	var seen atomic.Int32
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			// The first query is dropped, the second answered, so the test can
+			// tell "survived the drop" apart from "died quietly".
+			if seen.Add(1) == 1 {
+				return nil, nil
+			}
+			a := new(dns.Msg)
+			a.SetReply(q)
+			return a, nil
+		},
+	}
+
+	addr := startTestDoQListener(t, upstream)
+	conn, err := quic.DialAddr(context.Background(), addr, doqTestClientConfig(t), nil)
+	require.NoError(t, err)
+	defer conn.CloseWithError(0, "")
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	// The dropped query gets a closed stream and no data.
+	dropped, err := conn.OpenStreamSync(context.Background())
+	require.NoError(t, err)
+	writeDoQQueryToStream(t, dropped, q)
+	require.NoError(t, dropped.SetReadDeadline(time.Now().Add(5*time.Second)))
+	n, err := dropped.Read(make([]byte, 1))
+	require.Zero(t, n, "a dropped query must not be answered")
+	require.Error(t, err)
+
+	// The listener has to still be serving, which it cannot be if the drop
+	// took the process down.
+	answered, err := conn.OpenStreamSync(context.Background())
+	require.NoError(t, err)
+	writeDoQQueryToStream(t, answered, q)
+	require.NoError(t, answered.SetReadDeadline(time.Now().Add(5*time.Second)))
+	var length [2]byte
+	_, err = io.ReadFull(answered, length[:])
+	require.NoError(t, err, "the listener stopped serving after a dropped query")
+	body := make([]byte, binary.BigEndian.Uint16(length[:]))
+	_, err = io.ReadFull(answered, body)
+	require.NoError(t, err)
+	reply := new(dns.Msg)
+	require.NoError(t, reply.Unpack(body))
+	require.Equal(t, dns.RcodeSuccess, reply.Rcode)
+}
+
+// writeDoQQueryToStream writes a length-prefixed DNS message to an existing
+// stream, for tests that need to read the response back off it.
+func writeDoQQueryToStream(t *testing.T, stream *quic.Stream, m *dns.Msg) {
+	t.Helper()
+	p, err := m.Pack()
+	require.NoError(t, err)
+	out := make([]byte, 2+len(p))
+	binary.BigEndian.PutUint16(out, uint16(len(p)))
+	copy(out[2:], p)
+	_, err = stream.Write(out)
+	require.NoError(t, err)
+	require.NoError(t, stream.Close())
 }


### PR DESCRIPTION
A DoQ listener panics and takes the process down when a resolver drops a query.

## The bug

A nil response from a resolver means "drop this query". Three listeners implement it:

| Listener | On a nil response |
| --- | --- |
| `dnslistener.go:134`, which also serves DTLS | closes the connection |
| `dohlistener.go:377` | 403 |
| `odohlistener.go:247` | 403 |
| `doqlistener.go` | no check, falls through to `a.Pack()` |

The DoQ listener was added after the convention was established and never picked it up. `Pack` dereferences its receiver, so a dropped query panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20]
github.com/miekg/dns.(*Msg).PackBuffer(...)
github.com/folbricht/routedns.(*DoQListener).handleStream(...)
	doqlistener.go:271
created by (*DoQListener).handleConnection
```

The panic is in the per-stream goroutine, which has no recover, so it ends the process rather than the stream.

Nothing exotic is needed to reach it: a `drop` group behind a DoQ listener, which is the shape `client-blocklist-drop.toml` ships, or any blocklist or rate limiter whose resolver is a drop. In those configurations the queries that hit the drop path are the ones from clients the operator has deliberately blocked, so the crash is reachable by exactly the traffic the blocklist exists to handle.

## The fix

Close the stream without answering, which is all a DoQ client observes, and count it in the `drop` metric like the other listeners. The `defer stream.Close()` already at the top of `handleStream` ends the stream, so this matches the existing early returns in that function.

## Verification

A regression test puts a resolver behind a DoQ listener that drops the first query and answers the second. It asserts the dropped query gets a closed stream with no data, and that the second query is still answered, which distinguishes surviving the drop from dying quietly. Reverting the fix makes it fail with the SIGSEGV above.

Also checked against the built binary: a DoQ listener in front of a `drop` group answers nothing and the process stays up, with no panic logged.
