### PR TITLE
Handle dropped DNSKEY/DS lookups in the DNSSEC validator

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -3,6 +3,7 @@ package rdns
 import (
 	"errors"
 	"expvar"
+	"fmt"
 
 	"github.com/folbricht/routedns/dnssec"
 	"github.com/miekg/dns"
@@ -65,7 +66,17 @@ var defaultTrustAnchors = []TrustAnchor{
 func NewDNSSECValidator(id string, resolver Resolver, opt DNSSECValidatorOptions) (*DNSSECValidator, error) {
 	v := dnssec.NewValidator(
 		dnssec.WithResolver(func(q *dns.Msg) (*dns.Msg, error) {
-			return resolver.Resolve(q, ClientInfo{})
+			a, err := resolver.Resolve(q, ClientInfo{})
+			if err != nil {
+				return nil, err
+			}
+			// A nil response means the DNSKEY/DS lookup was dropped upstream.
+			// The validator expects a message or an error, so turn it into one
+			// rather than let it dereference a nil message.
+			if a == nil {
+				return nil, fmt.Errorf("%s lookup for %q dropped by resolver", dns.TypeToString[q.Question[0].Qtype], qName(q))
+			}
+			return a, nil
 		}),
 	)
 

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -389,3 +389,30 @@ func TestFilterDNSSECRR(t *testing.T) {
 		require.Nil(t, filtered)
 	})
 }
+
+func TestDNSSECValidatorDroppedDNSKEYLookup(t *testing.T) {
+	// The chain answers the client query but drops the DNSKEY/DS lookups the
+	// validator makes, for example when a blocklist or rate-limiter sits below
+	// the validator.
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			switch q.Question[0].Qtype {
+			case dns.TypeDNSKEY, dns.TypeDS:
+				return nil, nil
+			}
+			a := new(dns.Msg)
+			a.SetReply(q)
+			return a, nil
+		},
+	}
+
+	v, err := NewDNSSECValidator("test", upstream, DNSSECValidatorOptions{})
+	require.NoError(t, err)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	a, err := v.Resolve(q, ClientInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, a)
+	require.Equal(t, dns.RcodeServerFailure, a.Rcode)
+}


### PR DESCRIPTION
The `drop` modifier returns `nil, nil`, and every resolver, group and listener in the chain treats that as "drop this query". The one exception was the DNSSEC validator's internal lookups.

The resolver function handed to `dnssec.NewValidator` passed the nil straight through, and both `lookupDNSKEY` and `lookupDS` dereference the response without a nil check. `DNSSECValidator.Resolve` does check for nil, so a chain that drops everything was safe, but a chain that answers the client query while dropping the validator's own DNSKEY/DS lookups was not. That happens with a blocklist, rate-limiter or router below the validator, and the resulting nil dereference took the process down:

```
panic: runtime error: invalid memory address or nil pointer dereference
  dnssec.(*Validator).lookupDS(...) validator.go:352
  dnssec.(*Validator).proveNoDS(...) validator.go:140
  dnssec.(*Validator).validateDenial(...) denial_existence.go:43
```

A nil response is now turned into an error at that boundary, which the validator already handles. The query ends in SERVFAIL instead of panicking. A regression test covers a chain that drops only the DNSKEY and DS queries.

The rest of the chain was audited for the same assumption and is clean. Response modifiers all guard before touching the message, query-only modifiers never look at it, the groups are nil-safe through `isSuccessResponse` (which returns true for a nil message, so a drop is returned rather than failed over), and every listener terminates the drop on its own protocol.