### PR TITLE
Make log records one shape, and give the ODoH listener metrics

### DIFF
--- a/cache-memory.go
+++ b/cache-memory.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"log/slog"
-
 	"github.com/miekg/dns"
 )
 
@@ -157,10 +155,8 @@ func (b *memoryBackend) startGC(period time.Duration) {
 		b.mu.Unlock()
 
 		Log.Debug("cache garbage collection",
-			slog.Group("details",
-				slog.Int("total", total),
-				slog.Int("removed", removed),
-			),
+			"total", total,
+			"removed", removed,
 		)
 	}
 }

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -14,8 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"log/slog"
-
 	"github.com/miekg/dns"
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
@@ -118,7 +116,7 @@ func NewDoHListener(id, addr string, opt DoHListenerOptions, resolver Resolver) 
 
 // Start the DoH server.
 func (s *DoHListener) Start() error {
-	Log.Info("starting listener", slog.Group("details", slog.String("id", s.id), slog.String("protocol", "doh"), slog.String("transport", s.opt.Transport), slog.String("addr", s.addr)))
+	Log.Info("starting listener", "id", s.id, "protocol", "doh", "transport", s.opt.Transport, "addr", s.addr)
 	if s.opt.Transport == "quic" {
 		return s.startQUIC()
 	}
@@ -185,7 +183,7 @@ func (s *DoHListener) startQUIC() error {
 
 // Stop the server.
 func (s *DoHListener) Stop() error {
-	Log.Info("stopping listener", slog.Group("details", slog.String("id", s.id), slog.String("protocol", "doh"), slog.String("transport", s.opt.Transport), slog.String("addr", s.addr)))
+	Log.Info("stopping listener", "id", s.id, "protocol", "doh", "transport", s.opt.Transport, "addr", s.addr)
 	s.mu.Lock()
 	httpServer, quicServer := s.httpServer, s.quicServer
 	quicTransport, quicConn := s.quicTransport, s.quicConn
@@ -313,6 +311,17 @@ func (s *DoHListener) extractClientAddress(r *http.Request) net.IP {
 
 func (s *DoHListener) parseAndRespond(b []byte, w http.ResponseWriter, r *http.Request) {
 	s.metrics.query.Add(1)
+
+	// The client address and TLS name are filled in below, once the headers
+	// have been parsed. The listener half is known here, so records logged
+	// before then still identify the listener and the query.
+	ci := ClientInfo{
+		Listener:     s.id,
+		DoHPath:      r.URL.Path,
+		Protocol:     "doh",
+		ListenerAddr: s.addr,
+	}
+
 	q := new(dns.Msg)
 	if err := q.Unpack(b); err != nil {
 		s.metrics.err.Add("unpack", 1)
@@ -321,7 +330,7 @@ func (s *DoHListener) parseAndRespond(b []byte, w http.ResponseWriter, r *http.R
 	}
 	if len(q.Question) == 0 {
 		s.metrics.err.Add("noquestion", 1)
-		Log.With("id", s.id, "protocol", "doh", "addr", s.addr).Warn("dropping query with no Question section")
+		logger(s.id, q, ci).Warn("dropping query with no Question section")
 		http.Error(w, "no question in query", http.StatusBadRequest)
 		return
 	}
@@ -332,7 +341,7 @@ func (s *DoHListener) parseAndRespond(b []byte, w http.ResponseWriter, r *http.R
 	// handshake only for early data; on the TCP transport it is always complete.
 	if r.TLS != nil && !r.TLS.HandshakeComplete && !isReplayableOpcode(q.Opcode) {
 		s.metrics.err.Add("tooearly", 1)
-		Log.With("id", s.id, "protocol", "doh", "addr", s.addr).Warn("rejecting non-replayable opcode received as 0-RTT", "opcode", dns.OpcodeToString[q.Opcode])
+		logger(s.id, q, ci).Warn("rejecting non-replayable opcode received as 0-RTT", "opcode", dns.OpcodeToString[q.Opcode])
 		http.Error(w, "opcode not allowed in early data", http.StatusTooEarly)
 		return
 	}
@@ -343,17 +352,9 @@ func (s *DoHListener) parseAndRespond(b []byte, w http.ResponseWriter, r *http.R
 		http.Error(w, "Invalid RemoteAddr", http.StatusBadRequest)
 		return
 	}
-	var tlsServerName string
+	ci.SourceIP = clientIP
 	if r.TLS != nil {
-		tlsServerName = r.TLS.ServerName
-	}
-	ci := ClientInfo{
-		SourceIP:      clientIP,
-		DoHPath:       r.URL.Path,
-		TLSServerName: tlsServerName,
-		Listener:      s.id,
-		Protocol:      "doh",
-		ListenerAddr:  s.addr,
+		ci.TLSServerName = r.TLS.ServerName
 	}
 	log := logger(s.id, q, ci)
 	log.Debug("received query")

--- a/doqclient.go
+++ b/doqclient.go
@@ -99,6 +99,7 @@ func NewDoQClient(id, endpoint string, opt DoQClientOptions) (*DoQClient, error)
 		opt.QueryTimeout = defaultQueryTimeout
 	}
 	log := Log.With(
+		"id", id,
 		"protocol", "doq",
 		"endpoint", endpoint,
 	)
@@ -155,7 +156,10 @@ func NewDoQClient(id, endpoint string, opt DoQClientOptions) (*DoQClient, error)
 
 // Resolve a DNS query.
 func (d *DoQClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
-	Log.Debug("querying upstream resolver", slog.Group("details", slog.String("id", d.id), slog.String("resolver", d.endpoint), slog.String("protocol", "doq"), slog.String("qname", qName(q)), slog.String("qtype", qType(q))))
+	logger(d.id, q, ci).Debug("querying upstream resolver",
+		"resolver", d.endpoint,
+		"protocol", "doq",
+	)
 
 	d.metrics.query.Add(1)
 
@@ -392,10 +396,10 @@ func (s *quicConnection) restart(rAddr *net.UDPAddr) error {
 	)
 	conn, err := s.dialFunc(context.TODO(), rAddr, s.tlsConfig, s.config)
 	if err != nil {
-		Log.Warn("couldn't restart quic connection", slog.Group("details", slog.String("protocol", "quic"), slog.String("remote", rAddr.String()), slog.String("local", s.lAddr.String())), "error", err)
+		Log.Warn("couldn't restart quic connection", "protocol", "quic", "remote", rAddr.String(), "local", s.lAddr.String(), "error", err)
 		return err
 	}
-	Log.Debug("restarted quic connection", slog.Group("details", slog.String("protocol", "quic"), slog.String("remote", rAddr.String()), slog.String("local", s.lAddr.String())))
+	Log.Debug("restarted quic connection", "protocol", "quic", "remote", rAddr.String(), "local", s.lAddr.String())
 
 	s.Conn = conn
 	return nil

--- a/doqlistener.go
+++ b/doqlistener.go
@@ -125,7 +125,7 @@ func (s *DoQListener) Start() error {
 
 // Stop the server.
 func (s *DoQListener) Stop() error {
-	s.log.Info("stopping listener", slog.Group("details", slog.String("protocol", "quic"), slog.String("addr", s.addr)))
+	s.log.Info("stopping listener")
 	s.mu.Lock()
 	ln, transport, conn := s.ln, s.transport, s.conn
 	s.mu.Unlock()

--- a/dtlslistener.go
+++ b/dtlslistener.go
@@ -6,8 +6,6 @@ import (
 	"net"
 	"strconv"
 
-	"log/slog"
-
 	"github.com/miekg/dns"
 	"github.com/pion/dtls/v3"
 )
@@ -43,7 +41,7 @@ func NewDTLSListener(id, addr string, opt DTLSListenerOptions, resolver Resolver
 
 // Start the DTLS server.
 func (s *DTLSListener) Start() error {
-	Log.Info("starting listener", slog.Group("details", slog.String("id", s.id), slog.String("protocol", "dtls"), slog.String("addr", s.Addr)))
+	Log.Info("starting listener", "id", s.id, "protocol", "dtls", "addr", s.Addr)
 
 	if s.opt.NetNS.usesXSocket() {
 		return errors.New("xsocket is not supported for DTLS listeners")
@@ -77,7 +75,7 @@ func (s *DTLSListener) Start() error {
 
 // Stop the server.
 func (s *DTLSListener) Stop() error {
-	Log.Info("stopping listener", slog.Group("details", slog.String("id", s.id), slog.String("protocol", "dtls"), slog.String("addr", s.Addr)))
+	Log.Info("stopping listener", "id", s.id, "protocol", "dtls", "addr", s.Addr)
 	return s.Shutdown()
 }
 

--- a/failback.go
+++ b/failback.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"log/slog"
-
 	"github.com/miekg/dns"
 )
 
@@ -138,7 +136,7 @@ func (r *FailBack) errorFrom(i int) {
 	// derive the gauge from the active index rather than decrementing it,
 	// which would drift below zero over repeated rotations.
 	r.metrics.available.Set(int64(len(r.resolvers) - r.active))
-	Log.Info("failing over to resolver", slog.Group("details", slog.String("id", r.id), slog.String("resolver", r.resolvers[r.active].String())))
+	Log.Info("failing over to resolver", "id", r.id, "resolver", r.resolvers[r.active].String())
 	r.mu.Unlock()
 	r.metrics.failover.Add(1)
 	r.failCh <- struct{}{} // signal the timer to wait some more before switching back
@@ -162,7 +160,7 @@ func (r *FailBack) startResetTimer() chan struct{} {
 				// All resolvers are considered available again, regardless of
 				// how far the group had failed over.
 				r.metrics.available.Set(int64(len(r.resolvers)))
-				Log.Debug("failing back to resolver", slog.Group("details", slog.String("resolver", r.resolvers[r.active].String())))
+				Log.Debug("failing back to resolver", "id", r.id, "resolver", r.resolvers[r.active].String())
 				r.mu.Unlock()
 				// we just reset to the first resolver, let's wait for another failure before running again
 				<-failCh

--- a/failrotate.go
+++ b/failrotate.go
@@ -3,8 +3,6 @@ package rdns
 import (
 	"sync"
 
-	"log/slog"
-
 	"github.com/miekg/dns"
 )
 
@@ -93,7 +91,7 @@ func (r *FailRotate) errorFrom(i int) {
 	}
 	r.metrics.failover.Add(1)
 	r.active = (r.active + 1) % len(r.resolvers)
-	Log.Info("failing over to resolver", slog.Group("details", slog.String("id", r.id), slog.String("resolver", r.resolvers[r.active].String())))
+	Log.Info("failing over to resolver", "id", r.id, "resolver", r.resolvers[r.active].String())
 }
 
 func (r *FailRotate) isSuccessResponse(a *dns.Msg) bool {

--- a/loadbalance.go
+++ b/loadbalance.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"log/slog"
-
 	"github.com/miekg/dns"
 )
 
@@ -145,11 +143,11 @@ func (r *LoadBalance) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 		r.metrics.failover.Add(1)
 		penalized := r.updateOnFailure(idx, elapsed)
 		if penalized {
-			Log.Debug("penalizing resolver", slog.Group("details",
-				slog.String("group", r.id),
-				slog.String("resolver", resolver.String()),
-				slog.Duration("penalty", r.opt.FailurePenalty),
-			))
+			Log.Debug("penalizing resolver",
+				"id", r.id,
+				"resolver", resolver.String(),
+				"penalty", r.opt.FailurePenalty,
+			)
 		}
 
 		remaining[pos] = remaining[len(remaining)-1]

--- a/logger.go
+++ b/logger.go
@@ -78,7 +78,7 @@ func (l queryLogger) log(level slog.Level, msg string, args ...any) {
 	r := newRecord(level, msg)
 	r.Add(slog.String("id", l.id), slog.Any("client", l.ci.SourceIP))
 	if l.q != nil {
-		r.Add(slog.String("qtype", qTypeName(l.q)), slog.String("qname", qName(l.q)))
+		r.Add(slog.String("qtype", qType(l.q)), slog.String("qname", qName(l.q)))
 	}
 	if l.ci.Protocol != "" {
 		r.Add(slog.String("protocol", l.ci.Protocol))
@@ -101,13 +101,4 @@ func newRecord(level slog.Level, msg string) slog.Record {
 	var pcs [1]uintptr
 	runtime.Callers(4, pcs[:])
 	return slog.NewRecord(time.Now(), level, msg, pcs[0])
-}
-
-// Returns the string representation of the query type, rendering types with no
-// registered name as "TYPE<n>". qType returns an empty string for those.
-func qTypeName(q *dns.Msg) string {
-	if len(q.Question) == 0 {
-		return ""
-	}
-	return dns.Type(q.Question[0].Qtype).String()
 }

--- a/message.go
+++ b/message.go
@@ -44,12 +44,14 @@ func qName(q *dns.Msg) string {
 	return q.Question[0].Name
 }
 
-// Returns the string representation of the query type.
+// Returns the string representation of the query type, rendering types with no
+// registered name as "TYPE<n>". Returns an empty string for a query with no
+// question section.
 func qType(q *dns.Msg) string {
 	if len(q.Question) == 0 {
 		return ""
 	}
-	return dns.TypeToString[q.Question[0].Qtype]
+	return dns.Type(q.Question[0].Qtype).String()
 }
 
 // Reports whether an opcode may be acted on in QUIC 0-RTT data. RFC 9250 4.5

--- a/odohlistener.go
+++ b/odohlistener.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -144,8 +143,9 @@ func (s *ODoHListener) ODoHproxyHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	Log.Debug("forwarding query to ODoH target",
-		slog.String("client", r.RemoteAddr),
-		slog.String("target", host),
+		"id", s.id,
+		"client", r.RemoteAddr,
+		"target", host,
 	)
 	response, err := forwardProxyRequest(s.proxyClient, host, path, b, contentType)
 	if err != nil {
@@ -186,78 +186,101 @@ func forwardProxyRequest(client *http.Client, host string, path string, body []b
 }
 
 func (s *ODoHListener) ODoHqueryHandler(w http.ResponseWriter, r *http.Request) {
+	// The oblivious and the plain DoH path publish one set of metrics under the
+	// listener id, so a dual-mode listener counts both in the same place.
+	metrics := s.doh.metrics
+
 	qHeader := r.Header.Get("Content-Type")
 	if r.Method != http.MethodPost || qHeader == DOH_CONTENT_TYPE {
 		if s.opt.AllowDoH {
-			Log.Debug("Forwarding DoH query")
+			Log.Debug("forwarding DoH query", "id", s.id)
 			s.doh.dohHandler(w, r)
 			return
 		} else {
-			Log.Debug("DoH queries disabled, dropping DoH message")
+			Log.Debug("DoH queries disabled, dropping DoH message", "id", s.id)
+			metrics.err.Add("contenttype", 1)
 			http.Error(w, "only contentType oblivious-dns-message allowed", http.StatusMethodNotAllowed)
 			return
 		}
 	}
 
 	if qHeader != ODOH_CONTENT_TYPE {
+		metrics.err.Add("contenttype", 1)
 		http.Error(w, "only contentType oblivious-dns-message allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	metrics.query.Add(1)
 	b, err := io.ReadAll(io.LimitReader(r.Body, 4096))
 	if err != nil {
+		metrics.err.Add("read", 1)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	msg, err := odoh.UnmarshalDNSMessage(b)
 	if err != nil {
+		metrics.err.Add("unmarshal", 1)
 		http.Error(w, "error while parsing oblivious query", http.StatusBadRequest)
 		return
 	}
 
 	obliviousQuery, responseContext, err := s.odohKeyPair.DecryptQuery(msg)
 	if err != nil {
+		metrics.err.Add("decrypt", 1)
 		http.Error(w, "error while decrypting oblivious query", http.StatusBadRequest)
 		return
 	}
 
 	q := &dns.Msg{}
 	if q.Unpack(obliviousQuery.Message()) != nil {
+		metrics.err.Add("unpack", 1)
 		http.Error(w, "unpacking oblivious query failed", http.StatusBadRequest)
 		return
 	}
+
+	ci := ClientInfo{
+		Listener:     s.id,
+		Protocol:     "odoh",
+		ListenerAddr: s.addr,
+	}
+	if r.TLS != nil {
+		ci.TLSServerName = r.TLS.ServerName
+	}
+	log := logger(s.id, q, ci)
+
 	if len(q.Question) == 0 {
-		Log.With("id", s.id, "protocol", "odoh", "addr", s.addr).Warn("dropping query with no Question section")
+		metrics.err.Add("noquestion", 1)
+		log.Warn("dropping query with no Question section")
 		http.Error(w, "no question in query", http.StatusBadRequest)
 		return
 	}
+	log.Debug("received query")
 
-	a, err := s.r.Resolve(q, ClientInfo{
-		Listener:      s.id,
-		TLSServerName: r.TLS.ServerName,
-		Protocol:      "odoh",
-		ListenerAddr:  s.addr,
-	})
+	a, err := s.r.Resolve(q, ci)
 	if err != nil {
-		Log.Warn("failed to resolve", "error", err)
-		a = new(dns.Msg)
-		a.SetRcode(q, dns.RcodeServerFailure)
+		metrics.err.Add("resolve", 1)
+		log.Warn("failed to resolve", "error", err)
+		a = servfail(q)
 	}
 
 	// A nil response from the resolvers means "drop", return blank response
 	if a == nil {
+		metrics.drop.Add(1)
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}
 
+	metrics.response.Add(rCode(a), 1)
 	p, err := a.Pack()
 	if err != nil {
-		Log.Error("failed to encode response", "error", err)
+		metrics.err.Add("pack", 1)
+		log.Error("failed to encode response", "error", err)
 		return
 	}
 
 	response := odoh.CreateObliviousDNSResponse(p, 0)
 	obliviousResponse, err := responseContext.EncryptResponse(response)
 	if err != nil {
+		metrics.err.Add("encrypt", 1)
 		http.Error(w, "failed to encrypt oblivious response", http.StatusBadRequest)
 		return
 	}

--- a/odohlistener_test.go
+++ b/odohlistener_test.go
@@ -1,0 +1,74 @@
+package rdns
+
+import (
+	"bytes"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	odoh "github.com/cloudflare/odoh-go"
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// An oblivious query is answered by the upstream resolver and counted under the
+// listener id, the same place the plain DoH path counts its queries.
+func TestODoHListenerQuery(t *testing.T) {
+	upstream := &TestResolver{
+		ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+			require.Equal(t, "odoh", ci.Protocol)
+			a := new(dns.Msg)
+			a.SetReply(q)
+			return a, nil
+		},
+	}
+	l, err := NewODoHListener("test-odoh-listener", ":8443", ODoHListenerOptions{TLSConfig: new(tls.Config)}, upstream)
+	require.NoError(t, err)
+
+	metrics := l.doh.metrics
+	queries := metrics.query.Value()
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	w := postObliviousQuery(t, l, q)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, upstream.HitCount())
+	require.Equal(t, queries+1, metrics.query.Value())
+	require.Equal(t, "1", metrics.response.Get("NOERROR").String())
+}
+
+// A dropped query (a nil response from the chain) is answered with no message
+// and counted as a drop rather than as a response.
+func TestODoHListenerDrop(t *testing.T) {
+	l, err := NewODoHListener("test-odoh-drop", ":8443", ODoHListenerOptions{TLSConfig: new(tls.Config)}, NewDropResolver("drop"))
+	require.NoError(t, err)
+
+	metrics := l.doh.metrics
+	drops := metrics.drop.Value()
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	w := postObliviousQuery(t, l, q)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Empty(t, w.Body.Bytes())
+	require.Equal(t, drops+1, metrics.drop.Value())
+}
+
+// Encrypts a query for the listener's own key pair and hands it to the query
+// handler, the way an ODoH proxy would.
+func postObliviousQuery(t *testing.T, l *ODoHListener, q *dns.Msg) *httptest.ResponseRecorder {
+	t.Helper()
+	packed, err := q.Pack()
+	require.NoError(t, err)
+	encrypted, _, err := l.odohKeyPair.Config.Contents.EncryptQuery(odoh.CreateObliviousDNSQuery(packed, 0))
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodPost, ODOH_QUERY_PATH, bytes.NewReader(encrypted.Marshal()))
+	r.Header.Set("Content-Type", ODOH_CONTENT_TYPE)
+	w := httptest.NewRecorder()
+	l.ODoHqueryHandler(w, r)
+	return w
+}


### PR DESCRIPTION
Three changes to the log and metric surface. Nothing about resolution changes, but log output changes shape in places, so it is worth a release note.

## One attribute shape

Thirteen records nested their attributes under a `details` group while every other record in the process wrote them flat, so the same event came out with its fields at two different paths depending on which component logged it. The listener start and stop lines showed it most clearly: the same message was emitted flat by the plain DNS listener, grouped by the DTLS and DoH listeners, and with the attributes preset on a logger by the DoQ listener. Flat wins, being both the majority and the shape the shared query logger already produces.

## Query context where it was rebuilt by hand

`queryLogger` derives the component id, query name and type, client address, protocol, bind address and DoH path from the id, query and ClientInfo every component holds. The DoH listener, the ODoH listener and the DoQ client rebuilt a subset of that by hand, per call, and so logged some records without the query they were about. The DoH listener now builds its ClientInfo before unpacking the query and fills in the client address once the headers are parsed, so records written before that point still identify the listener and the query.

## ODoH listener metrics

The ODoH listener published no metrics at all, unlike every other listener, leaving an ODoH target invisible on the admin endpoint. It now counts queries, responses, drops and errors through the DoH listener it already wraps, so both paths of a dual-mode listener report under the one listener id.

Its handler also read `r.TLS` unconditionally. That is safe behind the TLS server it always runs under, but panics anywhere else, so it now checks the way the DoH handler does.

The listener had no tests. The new ones encrypt a query against the listener's own key pair, the way a proxy would, and cover an answered query and a dropped one.

## One query-type renderer

`qType` and `qTypeName` both rendered the type from a query's question section and differed only at the edge: one returned an empty string for a type with no registered name, the other rendered it as `TYPE<n>`. The latter behaviour stays, in `qType`, and the duplicate is gone. Syslog and query-log output now names an unregistered type instead of leaving the field blank.

