### PR TITLE
Describe the Lua EDNS0 types as tables rather than 14 copies

### DIFF
--- a/lua-edns0.go
+++ b/lua-edns0.go
@@ -10,712 +10,125 @@ import (
 
 // EDNS0 functions
 
+// RegisterEDNS0Types makes the supported EDNS0 options available to scripts,
+// each as a global type with a "new" constructor and named fields.
+//
+// A type is described by the value its constructor builds and its fields, in
+// the order "new" takes them as arguments. Every field can also be read and
+// written by name, alongside "option" which gives the option code.
 func (s *LuaScript) RegisterEDNS0Types() {
-	s.registerEDNS0COOKIEType()
-	s.registerEDNS0DAUType()
-	s.registerEDNS0DHUType()
-	s.registerEDNS0EDEType()
-	s.registerEDNS0ESUType()
-	s.registerEDNS0EXPIREType()
-	s.registerEDNS0LLQType()
-	s.registerEDNS0LOCALType()
-	s.registerEDNS0N3UType()
-	s.registerEDNS0NSIDType()
-	s.registerEDNS0PADDINGType()
-	s.registerEDNS0SUBNETType()
-	s.registerEDNS0TCPKEEPALIVEType()
-	s.registerEDNS0ULType()
+	registerEDNS0Type(s, "EDNS0_COOKIE",
+		func() *dns.EDNS0_COOKIE { return &dns.EDNS0_COOKIE{Code: dns.EDNS0COOKIE} },
+		stringField("cookie", func(e *dns.EDNS0_COOKIE) *string { return &e.Cookie }),
+	)
+	registerEDNS0Type(s, "EDNS0_DAU",
+		func() *dns.EDNS0_DAU { return &dns.EDNS0_DAU{Code: dns.EDNS0DAU} },
+		numberSliceField("algcode", func(e *dns.EDNS0_DAU) *[]uint8 { return &e.AlgCode }),
+	)
+	registerEDNS0Type(s, "EDNS0_DHU",
+		func() *dns.EDNS0_DHU { return &dns.EDNS0_DHU{Code: dns.EDNS0DHU} },
+		numberSliceField("algcode", func(e *dns.EDNS0_DHU) *[]uint8 { return &e.AlgCode }),
+	)
+	registerEDNS0Type(s, "EDNS0_EDE",
+		func() *dns.EDNS0_EDE { return new(dns.EDNS0_EDE) },
+		numberField("infocode", func(e *dns.EDNS0_EDE) *uint16 { return &e.InfoCode }),
+		stringField("extratext", func(e *dns.EDNS0_EDE) *string { return &e.ExtraText }),
+	)
+	registerEDNS0Type(s, "EDNS0_ESU",
+		func() *dns.EDNS0_ESU { return &dns.EDNS0_ESU{Code: dns.EDNS0ESU} },
+		stringField("uri", func(e *dns.EDNS0_ESU) *string { return &e.Uri }),
+	)
+	registerEDNS0Type(s, "EDNS0_EXPIRE",
+		func() *dns.EDNS0_EXPIRE { return &dns.EDNS0_EXPIRE{Code: dns.EDNS0EXPIRE} },
+		numberField("expire", func(e *dns.EDNS0_EXPIRE) *uint32 { return &e.Expire }),
+	)
+	registerEDNS0Type(s, "EDNS0_LLQ",
+		func() *dns.EDNS0_LLQ { return &dns.EDNS0_LLQ{Code: dns.EDNS0LLQ} },
+		numberField("version", func(e *dns.EDNS0_LLQ) *uint16 { return &e.Version }),
+		numberField("opcode", func(e *dns.EDNS0_LLQ) *uint16 { return &e.Opcode }),
+		numberField("error", func(e *dns.EDNS0_LLQ) *uint16 { return &e.Error }),
+		numberField("id", func(e *dns.EDNS0_LLQ) *uint64 { return &e.Id }),
+		numberField("leaselife", func(e *dns.EDNS0_LLQ) *uint32 { return &e.LeaseLife }),
+	)
+	registerEDNS0Type(s, "EDNS0_LOCAL",
+		func() *dns.EDNS0_LOCAL { return new(dns.EDNS0_LOCAL) },
+		numberField("code", func(e *dns.EDNS0_LOCAL) *uint16 { return &e.Code }),
+		bytesField("data", func(e *dns.EDNS0_LOCAL) *[]byte { return &e.Data }),
+	)
+	registerEDNS0Type(s, "EDNS0_N3U",
+		func() *dns.EDNS0_N3U { return &dns.EDNS0_N3U{Code: dns.EDNS0N3U} },
+		numberSliceField("algcode", func(e *dns.EDNS0_N3U) *[]uint8 { return &e.AlgCode }),
+	)
+	registerEDNS0Type(s, "EDNS0_NSID",
+		func() *dns.EDNS0_NSID { return &dns.EDNS0_NSID{Code: dns.EDNS0NSID} },
+		stringField("nsid", func(e *dns.EDNS0_NSID) *string { return &e.Nsid }),
+	)
+	registerEDNS0Type(s, "EDNS0_PADDING",
+		func() *dns.EDNS0_PADDING { return new(dns.EDNS0_PADDING) },
+		bytesField("padding", func(e *dns.EDNS0_PADDING) *[]byte { return &e.Padding }),
+	)
+	registerEDNS0Type(s, "EDNS0_SUBNET",
+		func() *dns.EDNS0_SUBNET { return &dns.EDNS0_SUBNET{Code: dns.EDNS0SUBNET} },
+		numberField("family", func(e *dns.EDNS0_SUBNET) *uint16 { return &e.Family }),
+		numberField("sourcenetmask", func(e *dns.EDNS0_SUBNET) *uint8 { return &e.SourceNetmask }),
+		numberField("sourcescope", func(e *dns.EDNS0_SUBNET) *uint8 { return &e.SourceScope }),
+		ipField("address", func(e *dns.EDNS0_SUBNET) *net.IP { return &e.Address }),
+	)
+	registerEDNS0Type(s, "EDNS0_TCP_KEEPALIVE",
+		func() *dns.EDNS0_TCP_KEEPALIVE {
+			return &dns.EDNS0_TCP_KEEPALIVE{Code: dns.EDNS0TCPKEEPALIVE}
+		},
+		numberField("timeout", func(e *dns.EDNS0_TCP_KEEPALIVE) *uint16 { return &e.Timeout }),
+	)
+	registerEDNS0Type(s, "EDNS0_UL",
+		func() *dns.EDNS0_UL { return &dns.EDNS0_UL{Code: dns.EDNS0UL} },
+		numberField("lease", func(e *dns.EDNS0_UL) *uint32 { return &e.Lease }),
+		numberField("keylease", func(e *dns.EDNS0_UL) *uint32 { return &e.KeyLease }),
+	)
 }
 
-func (s *LuaScript) registerEDNS0COOKIEType() {
+// edns0Field is one named field of an EDNS0 option type as scripts see it. The
+// setter takes the stack index to read the value from, which is the argument
+// position in a constructor call and always 3 in an assignment.
+type edns0Field[T dns.EDNS0] struct {
+	name string
+	get  func(L *lua.LState, e T) lua.LValue
+	set  func(L *lua.LState, e T, n int)
+}
+
+// Registers a global Lua type for one EDNS0 option: a "new" constructor taking
+// the fields as positional arguments, all of them optional, and metamethods to
+// read and write them by name.
+func registerEDNS0Type[T dns.EDNS0](s *LuaScript, mtName string, newOption func() T, fields ...edns0Field[T]) {
 	L := s.L
-	mtName := "EDNS0_COOKIE"
 	mt := L.NewTypeMetatable(mtName)
 	L.SetGlobal(mtName, mt)
+
+	byName := make(map[string]edns0Field[T], len(fields))
+	for _, field := range fields {
+		byName[field.name] = field
+	}
+	// Reports the field being read or written, having raised a Lua error if
+	// the type doesn't have it. ArgError does not return.
+	lookup := func(L *lua.LState) (edns0Field[T], bool) {
+		fieldName := L.CheckString(2)
+		field, ok := byName[fieldName]
+		if !ok {
+			L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
+		}
+		return field, ok
+	}
+
 	// static attributes
 	L.SetField(mt, "new", L.NewFunction(
 		func(L *lua.LState) int {
-			e := new(dns.EDNS0_COOKIE)
-			e.Code = dns.EDNS0COOKIE
+			e := newOption()
 			nArgs := L.GetTop()
-			if nArgs >= 1 { // Cookie
-				e.Cookie = L.CheckString(1)
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_COOKIE](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "cookie":
-				L.Push(lua.LString(e.Cookie))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_COOKIE](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "cookie":
-				e.Cookie = L.CheckString(3)
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
-}
-
-func (s *LuaScript) registerEDNS0DAUType() {
-	L := s.L
-	mtName := "EDNS0_DAU"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_DAU)
-			e.Code = dns.EDNS0DAU
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // Alg Codes
-				values, _ := getNumberSlice[uint8](L, 1)
-				e.AlgCode = values
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_DAU](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "algcode":
-				L.Push(numberSliceToTable(L, e.AlgCode))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_DAU](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "algcode":
-				values, _ := getNumberSlice[uint8](L, 3)
-				e.AlgCode = values
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
-}
-
-func (s *LuaScript) registerEDNS0DHUType() {
-	L := s.L
-	mtName := "EDNS0_DHU"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_DHU)
-			e.Code = dns.EDNS0DHU
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // Alg Codes
-				values, _ := getNumberSlice[uint8](L, 1)
-				e.AlgCode = values
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_DHU](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "algcode":
-				L.Push(numberSliceToTable(L, e.AlgCode))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_DHU](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "algcode":
-				values, _ := getNumberSlice[uint8](L, 3)
-				e.AlgCode = values
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
-}
-
-func (s *LuaScript) registerEDNS0EDEType() {
-	L := s.L
-	mtName := "EDNS0_EDE"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_EDE)
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // Code
-				e.InfoCode = uint16(L.CheckNumber(1))
-			}
-			if nArgs >= 2 { // Extra Text
-				e.ExtraText = L.CheckString(2)
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_EDE](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "infocode":
-				L.Push(lua.LNumber(e.InfoCode))
-			case "extratext":
-				L.Push(lua.LString(e.ExtraText))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_EDE](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "infocode":
-				e.InfoCode = uint16(L.CheckNumber(3))
-			case "extratext":
-				e.ExtraText = L.CheckString(3)
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
-}
-
-func (s *LuaScript) registerEDNS0ESUType() {
-	L := s.L
-	mtName := "EDNS0_ESU"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_ESU)
-			e.Code = dns.EDNS0ESU
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // URI
-				e.Uri = L.CheckString(1)
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_ESU](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "uri":
-				L.Push(lua.LString(e.Uri))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_ESU](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "uri":
-				e.Uri = L.CheckString(3)
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
-}
-
-func (s *LuaScript) registerEDNS0EXPIREType() {
-	L := s.L
-	mtName := "EDNS0_EXPIRE"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_EXPIRE)
-			e.Code = dns.EDNS0EXPIRE
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // Expire
-				e.Expire = uint32(L.CheckNumber(1))
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_EXPIRE](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "expire":
-				L.Push(lua.LNumber(e.Expire))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_EXPIRE](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "expire":
-				e.Expire = uint32(L.CheckNumber(3))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
-}
-
-func (s *LuaScript) registerEDNS0LLQType() {
-	L := s.L
-	mtName := "EDNS0_LLQ"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_LLQ)
-			e.Code = dns.EDNS0LLQ
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // Version
-				e.Version = uint16(L.CheckNumber(1))
-			}
-			if nArgs >= 2 { // Opcode
-				e.Opcode = uint16(L.CheckNumber(2))
-			}
-			if nArgs >= 3 { // Error
-				e.Error = uint16(L.CheckNumber(3))
-			}
-			if nArgs >= 4 { // Id
-				e.Id = uint64(L.CheckNumber(4))
-			}
-			if nArgs >= 5 { // LeaseLife
-				e.LeaseLife = uint32(L.CheckNumber(5))
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_LLQ](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "version":
-				L.Push(lua.LNumber(e.Version))
-			case "opcode":
-				L.Push(lua.LNumber(e.Opcode))
-			case "error":
-				L.Push(lua.LNumber(e.Error))
-			case "id":
-				L.Push(lua.LNumber(e.Id))
-			case "leaselife":
-				L.Push(lua.LNumber(e.LeaseLife))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_LLQ](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "version":
-				e.Version = uint16(L.CheckNumber(3))
-			case "opcode":
-				e.Opcode = uint16(L.CheckNumber(3))
-			case "error":
-				e.Error = uint16(L.CheckNumber(3))
-			case "id":
-				e.Id = uint64(L.CheckNumber(3))
-			case "leaselife":
-				e.LeaseLife = uint32(L.CheckNumber(3))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
-}
-
-func (s *LuaScript) registerEDNS0LOCALType() {
-	L := s.L
-	mtName := "EDNS0_LOCAL"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_LOCAL)
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // Code
-				e.Code = uint16(L.CheckNumber(1))
-			}
-			if nArgs >= 2 { // Data
-				e.Data = []byte(L.CheckString(2))
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_LOCAL](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "code":
-				L.Push(lua.LNumber(e.Code))
-			case "data":
-				L.Push(lua.LString(e.Data))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_LOCAL](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "code":
-				e.Code = uint16(L.CheckNumber(3))
-			case "data":
-				e.Data = []byte(L.CheckString(3))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
-}
-
-func (s *LuaScript) registerEDNS0N3UType() {
-	L := s.L
-	mtName := "EDNS0_N3U"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_N3U)
-			e.Code = dns.EDNS0N3U
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // Alg Codes
-				values, _ := getNumberSlice[uint8](L, 1)
-				e.AlgCode = values
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_N3U](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "algcode":
-				L.Push(numberSliceToTable(L, e.AlgCode))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_N3U](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "algcode":
-				values, _ := getNumberSlice[uint8](L, 3)
-				e.AlgCode = values
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
-}
-
-func (s *LuaScript) registerEDNS0NSIDType() {
-	L := s.L
-	mtName := "EDNS0_NSID"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_NSID)
-			e.Code = dns.EDNS0NSID
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // NSID
-				e.Nsid = L.CheckString(1)
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_NSID](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "nsid":
-				L.Push(lua.LString(e.Nsid))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_NSID](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "nsid":
-				e.Nsid = L.CheckString(3)
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
-}
-
-func (s *LuaScript) registerEDNS0PADDINGType() {
-	L := s.L
-	mtName := "EDNS0_PADDING"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_PADDING)
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // NSID
-				e.Padding = []byte(L.CheckString(1))
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_PADDING](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "padding":
-				L.Push(lua.LString(e.Padding))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_PADDING](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "padding":
-				e.Padding = []byte(L.CheckString(3))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
-}
-
-func (s *LuaScript) registerEDNS0SUBNETType() {
-	L := s.L
-	mtName := "EDNS0_SUBNET"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_SUBNET)
-			e.Code = dns.EDNS0SUBNET
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // Family
-				e.Family = uint16(L.CheckNumber(1))
-			}
-			if nArgs >= 2 { // SourceNetmask
-				e.SourceNetmask = uint8(L.CheckNumber(2))
-			}
-			if nArgs >= 3 { // SourceScope
-				e.SourceScope = uint8(L.CheckNumber(3))
-			}
-			if nArgs >= 4 { // Address
-				value := L.CheckString(4)
-				ip := net.ParseIP(value)
-				if ip == nil {
-					L.ArgError(4, fmt.Sprintf("expected IP address, got %q", value))
-					return 0
+			for i, field := range fields {
+				if nArgs < i+1 {
+					break
 				}
-				e.Address = ip
+				field.set(L, e, i+1)
 			}
 			L.Push(userDataWithMetatable(L, mtName, e))
 			return 1
@@ -724,177 +137,87 @@ func (s *LuaScript) registerEDNS0SUBNETType() {
 	// methods
 	L.SetField(mt, "__index", L.NewFunction(
 		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_SUBNET](L, 1)
+			e, ok := getUserDataArg[T](L, 1)
 			if !ok {
 				return 0
 			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
+			if L.CheckString(2) == "option" {
 				L.Push(lua.LNumber(e.Option()))
 				return 1
-			case "family":
-				L.Push(lua.LNumber(e.Family))
-			case "sourcenetmask":
-				L.Push(lua.LNumber(e.SourceNetmask))
-			case "sourcescope":
-				L.Push(lua.LNumber(e.SourceScope))
-			case "address":
-				L.Push(lua.LString(e.Address.String()))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
+			}
+			field, ok := lookup(L)
+			if !ok {
 				return 0
 			}
+			L.Push(field.get(L, e))
 			return 1
 		}))
 	L.SetField(mt, "__newindex", L.NewFunction(
 		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_SUBNET](L, 1)
+			e, ok := getUserDataArg[T](L, 1)
 			if !ok {
 				return 0
 			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "family":
-				e.Family = uint16(L.CheckNumber(3))
-			case "sourcenetmask":
-				e.SourceNetmask = uint8(L.CheckNumber(3))
-			case "sourcescope":
-				e.SourceScope = uint8(L.CheckNumber(3))
-			case "address":
-				value := L.CheckString(3)
-				ip := net.ParseIP(value)
-				if ip == nil {
-					L.ArgError(4, fmt.Sprintf("expected IP address, got %q", value))
-					return 0
-				}
-				e.Address = ip
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
+			field, ok := lookup(L)
+			if !ok {
 				return 0
 			}
+			field.set(L, e, 3)
 			return 0
 		}))
 }
 
-func (s *LuaScript) registerEDNS0TCPKEEPALIVEType() {
-	L := s.L
-	mtName := "EDNS0_TCP_KEEPALIVE"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_TCP_KEEPALIVE)
-			e.Code = dns.EDNS0TCPKEEPALIVE
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // Timeout
-				e.Timeout = uint16(L.CheckNumber(1))
-			}
-			if nArgs >= 2 { // Length
-				e.Length = uint16(L.CheckNumber(2))
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
-
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_TCP_KEEPALIVE](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "timeout":
-				L.Push(lua.LNumber(e.Timeout))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_TCP_KEEPALIVE](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "timeout":
-				e.Timeout = uint16(L.CheckNumber(3))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
+// A numeric field, converted between Lua numbers and the field's own width.
+func numberField[T dns.EDNS0, V numbers](name string, field func(T) *V) edns0Field[T] {
+	return edns0Field[T]{
+		name: name,
+		get:  func(L *lua.LState, e T) lua.LValue { return lua.LNumber(*field(e)) },
+		set:  func(L *lua.LState, e T, n int) { *field(e) = V(L.CheckNumber(n)) },
+	}
 }
 
-func (s *LuaScript) registerEDNS0ULType() {
-	L := s.L
-	mtName := "EDNS0_UL"
-	mt := L.NewTypeMetatable(mtName)
-	L.SetGlobal(mtName, mt)
-	// static attributes
-	L.SetField(mt, "new", L.NewFunction(
-		func(L *lua.LState) int {
-			e := new(dns.EDNS0_UL)
-			e.Code = dns.EDNS0UL
-			nArgs := L.GetTop()
-			if nArgs >= 1 { // Lease
-				e.Lease = uint32(L.CheckNumber(1))
-			}
-			if nArgs >= 2 { // KeyLease
-				e.KeyLease = uint32(L.CheckNumber(2))
-			}
-			L.Push(userDataWithMetatable(L, mtName, e))
-			return 1
-		}))
+// A field of numbers, exposed as a Lua table.
+func numberSliceField[T dns.EDNS0, V numbers](name string, field func(T) *[]V) edns0Field[T] {
+	return edns0Field[T]{
+		name: name,
+		get:  func(L *lua.LState, e T) lua.LValue { return numberSliceToTable(L, *field(e)) },
+		set: func(L *lua.LState, e T, n int) {
+			values, _ := getNumberSlice[V](L, n)
+			*field(e) = values
+		},
+	}
+}
 
-	// methods
-	L.SetField(mt, "__index", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_UL](L, 1)
-			if !ok {
-				return 0
+func stringField[T dns.EDNS0](name string, field func(T) *string) edns0Field[T] {
+	return edns0Field[T]{
+		name: name,
+		get:  func(L *lua.LState, e T) lua.LValue { return lua.LString(*field(e)) },
+		set:  func(L *lua.LState, e T, n int) { *field(e) = L.CheckString(n) },
+	}
+}
+
+// A byte-slice field, exposed to scripts as a string.
+func bytesField[T dns.EDNS0](name string, field func(T) *[]byte) edns0Field[T] {
+	return edns0Field[T]{
+		name: name,
+		get:  func(L *lua.LState, e T) lua.LValue { return lua.LString(*field(e)) },
+		set:  func(L *lua.LState, e T, n int) { *field(e) = []byte(L.CheckString(n)) },
+	}
+}
+
+// An IP address field, exposed as a string and rejected if it doesn't parse.
+func ipField[T dns.EDNS0](name string, field func(T) *net.IP) edns0Field[T] {
+	return edns0Field[T]{
+		name: name,
+		get:  func(L *lua.LState, e T) lua.LValue { return lua.LString(field(e).String()) },
+		set: func(L *lua.LState, e T, n int) {
+			value := L.CheckString(n)
+			ip := net.ParseIP(value)
+			if ip == nil {
+				L.ArgError(n, fmt.Sprintf("expected IP address, got %q", value))
+				return
 			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "option":
-				L.Push(lua.LNumber(e.Option()))
-				return 1
-			case "lease":
-				L.Push(lua.LNumber(e.Lease))
-			case "keylease":
-				L.Push(lua.LNumber(e.KeyLease))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 1
-		}))
-	L.SetField(mt, "__newindex", L.NewFunction(
-		func(L *lua.LState) int {
-			e, ok := getUserDataArg[*dns.EDNS0_UL](L, 1)
-			if !ok {
-				return 0
-			}
-			fieldName := L.CheckString(2)
-			switch fieldName {
-			case "lease":
-				e.Lease = uint32(L.CheckNumber(3))
-			case "keylease":
-				e.KeyLease = uint32(L.CheckNumber(3))
-			default:
-				L.ArgError(2, fmt.Sprintf("%s does not have field %q", mtName, fieldName))
-				return 0
-			}
-			return 0
-		}))
+			*field(e) = ip
+		},
+	}
 }

--- a/lua-edns0_test.go
+++ b/lua-edns0_test.go
@@ -17,6 +17,7 @@ var luaEDNS0Types = []struct {
 	new    string
 	option uint16
 	fields map[string]string // field name -> Lua expression, compared with ==
+	slice  string            // name of the field holding a table of numbers, if any
 }{
 	{
 		name: "EDNS0_COOKIE", new: `EDNS0_COOKIE.new("24a5ac1a012345ff")`, option: dns.EDNS0COOKIE,
@@ -24,9 +25,11 @@ var luaEDNS0Types = []struct {
 	},
 	{
 		name: "EDNS0_DAU", new: `EDNS0_DAU.new({ 1, 2, 3 })`, option: dns.EDNS0DAU,
+		slice: "algcode",
 	},
 	{
 		name: "EDNS0_DHU", new: `EDNS0_DHU.new({ 1, 2, 3 })`, option: dns.EDNS0DHU,
+		slice: "algcode",
 	},
 	{
 		name: "EDNS0_EDE", new: `EDNS0_EDE.new(15, "domain blocked")`, option: dns.EDNS0EDE,
@@ -51,6 +54,7 @@ var luaEDNS0Types = []struct {
 	},
 	{
 		name: "EDNS0_N3U", new: `EDNS0_N3U.new({ 1, 2, 3 })`, option: dns.EDNS0N3U,
+		slice: "algcode",
 	},
 	{
 		// NSID packs as hex, so the value has to be one.
@@ -92,6 +96,9 @@ func TestLuaEDNS0OptionCode(t *testing.T) {
 func TestLuaEDNS0FieldRoundTrip(t *testing.T) {
 	for _, tt := range luaEDNS0Types {
 		t.Run(tt.name, func(t *testing.T) {
+			// A type with neither is one whose fields nothing checks, which
+			// is what this asserts against for types added later.
+			require.True(t, len(tt.fields) > 0 || tt.slice != "", "no fields to check")
 			for field, value := range tt.fields {
 				runLuaEDNS0Check(t, fmt.Sprintf(`
 	local e = %s
@@ -106,17 +113,20 @@ func TestLuaEDNS0FieldRoundTrip(t *testing.T) {
 
 // Slice fields come back as a table of numbers, indexed from 1.
 func TestLuaEDNS0SliceFieldRoundTrip(t *testing.T) {
-	for _, name := range []string{"EDNS0_DAU", "EDNS0_DHU", "EDNS0_N3U"} {
-		t.Run(name, func(t *testing.T) {
+	for _, tt := range luaEDNS0Types {
+		if tt.slice == "" {
+			continue
+		}
+		t.Run(tt.name, func(t *testing.T) {
 			runLuaEDNS0Check(t, fmt.Sprintf(`
-	local e = %s.new({ 1, 2, 3 })
-	if e.algcode[1] ~= 1 or e.algcode[3] ~= 3 then
+	local e = %s
+	if e.%s[1] ~= 1 or e.%s[3] ~= 3 then
 		return nil, Error.new("constructor value not readable")
 	end
-	e.algcode = { 8, 9 }
-	if e.algcode[1] ~= 8 or e.algcode[2] ~= 9 then
+	e.%s = { 8, 9 }
+	if e.%s[1] ~= 8 or e.%s[2] ~= 9 then
 		return nil, Error.new("assigned value not readable")
-	end`, name))
+	end`, tt.new, tt.slice, tt.slice, tt.slice, tt.slice, tt.slice))
 		})
 	}
 }

--- a/lua-edns0_test.go
+++ b/lua-edns0_test.go
@@ -1,0 +1,212 @@
+package rdns
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// Every registered EDNS0 type, with the constructor call a script would write,
+// the option code it must report, and the fields it exposes with a value to
+// assign and read back.
+var luaEDNS0Types = []struct {
+	name   string
+	new    string
+	option uint16
+	fields map[string]string // field name -> Lua expression, compared with ==
+}{
+	{
+		name: "EDNS0_COOKIE", new: `EDNS0_COOKIE.new("24a5ac1a012345ff")`, option: dns.EDNS0COOKIE,
+		fields: map[string]string{"cookie": `"aabb"`},
+	},
+	{
+		name: "EDNS0_DAU", new: `EDNS0_DAU.new({ 1, 2, 3 })`, option: dns.EDNS0DAU,
+	},
+	{
+		name: "EDNS0_DHU", new: `EDNS0_DHU.new({ 1, 2, 3 })`, option: dns.EDNS0DHU,
+	},
+	{
+		name: "EDNS0_EDE", new: `EDNS0_EDE.new(15, "domain blocked")`, option: dns.EDNS0EDE,
+		fields: map[string]string{"infocode": "16", "extratext": `"censored"`},
+	},
+	{
+		name: "EDNS0_ESU", new: `EDNS0_ESU.new("http://example.com")`, option: dns.EDNS0ESU,
+		fields: map[string]string{"uri": `"sip:example.com"`},
+	},
+	{
+		name: "EDNS0_EXPIRE", new: `EDNS0_EXPIRE.new(123)`, option: dns.EDNS0EXPIRE,
+		fields: map[string]string{"expire": "124"},
+	},
+	{
+		name: "EDNS0_LLQ", new: `EDNS0_LLQ.new(1, 16, 0, 1234, 4321)`, option: dns.EDNS0LLQ,
+		fields: map[string]string{"version": "2", "opcode": "17", "error": "3", "id": "99", "leaselife": "60"},
+	},
+	{
+		// LOCAL is the one type whose option code is the code it was given.
+		name: "EDNS0_LOCAL", new: `EDNS0_LOCAL.new(65001, "somedata")`, option: 65001,
+		fields: map[string]string{"code": "65001", "data": `"other"`},
+	},
+	{
+		name: "EDNS0_N3U", new: `EDNS0_N3U.new({ 1, 2, 3 })`, option: dns.EDNS0N3U,
+	},
+	{
+		// NSID packs as hex, so the value has to be one.
+		name: "EDNS0_NSID", new: `EDNS0_NSID.new("abcd")`, option: dns.EDNS0NSID,
+		fields: map[string]string{"nsid": `"beef"`},
+	},
+	{
+		name: "EDNS0_PADDING", new: `EDNS0_PADDING.new("somepadding")`, option: dns.EDNS0PADDING,
+		fields: map[string]string{"padding": `"more"`},
+	},
+	{
+		name: "EDNS0_SUBNET", new: `EDNS0_SUBNET.new(1, 32, 0, "192.168.0.0")`, option: dns.EDNS0SUBNET,
+		fields: map[string]string{"family": "2", "sourcenetmask": "24", "sourcescope": "1", "address": `"10.0.0.1"`},
+	},
+	{
+		name: "EDNS0_TCP_KEEPALIVE", new: `EDNS0_TCP_KEEPALIVE.new(1)`, option: dns.EDNS0TCPKEEPALIVE,
+		fields: map[string]string{"timeout": "10"},
+	},
+	{
+		name: "EDNS0_UL", new: `EDNS0_UL.new(1, 2)`, option: dns.EDNS0UL,
+		fields: map[string]string{"lease": "10", "keylease": "20"},
+	},
+}
+
+// The option code a script reads is the one the option carries on the wire.
+func TestLuaEDNS0OptionCode(t *testing.T) {
+	for _, tt := range luaEDNS0Types {
+		t.Run(tt.name, func(t *testing.T) {
+			runLuaEDNS0Check(t, fmt.Sprintf(`
+	local e = %s
+	if e.option ~= %d then
+		return nil, Error.new("wrong option code: " .. e.option)
+	end`, tt.new, tt.option))
+		})
+	}
+}
+
+// Each field assigned through the metatable reads back as it was written.
+func TestLuaEDNS0FieldRoundTrip(t *testing.T) {
+	for _, tt := range luaEDNS0Types {
+		t.Run(tt.name, func(t *testing.T) {
+			for field, value := range tt.fields {
+				runLuaEDNS0Check(t, fmt.Sprintf(`
+	local e = %s
+	e.%s = %s
+	if e.%s ~= %s then
+		return nil, Error.new("%s did not round-trip")
+	end`, tt.new, field, value, field, value, field))
+			}
+		})
+	}
+}
+
+// Slice fields come back as a table of numbers, indexed from 1.
+func TestLuaEDNS0SliceFieldRoundTrip(t *testing.T) {
+	for _, name := range []string{"EDNS0_DAU", "EDNS0_DHU", "EDNS0_N3U"} {
+		t.Run(name, func(t *testing.T) {
+			runLuaEDNS0Check(t, fmt.Sprintf(`
+	local e = %s.new({ 1, 2, 3 })
+	if e.algcode[1] ~= 1 or e.algcode[3] ~= 3 then
+		return nil, Error.new("constructor value not readable")
+	end
+	e.algcode = { 8, 9 }
+	if e.algcode[1] ~= 8 or e.algcode[2] ~= 9 then
+		return nil, Error.new("assigned value not readable")
+	end`, name))
+		})
+	}
+}
+
+// Reading or writing a field the type doesn't have is an error naming both.
+func TestLuaEDNS0UnknownField(t *testing.T) {
+	for _, tt := range luaEDNS0Types {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, script := range []string{
+				fmt.Sprintf("local e = %s\n\tlocal v = e.nosuchfield", tt.new),
+				fmt.Sprintf("local e = %s\n\te.nosuchfield = 1", tt.new),
+			} {
+				err := runLuaEDNS0Script(t, script)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.name+` does not have field "nosuchfield"`)
+			}
+		})
+	}
+}
+
+// An address that isn't an IP is rejected, in the constructor and on assignment.
+func TestLuaEDNS0SubnetInvalidAddress(t *testing.T) {
+	for _, script := range []string{
+		`local e = EDNS0_SUBNET.new(1, 32, 0, "not-an-ip")`,
+		`local e = EDNS0_SUBNET.new(1, 32, 0, "192.168.0.0")
+	e.address = "not-an-ip"`,
+	} {
+		err := runLuaEDNS0Script(t, script)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `expected IP address, got "not-an-ip"`)
+	}
+}
+
+// Options built in a script survive a round trip through the wire format,
+// which is what the option code they carry is for.
+func TestLuaEDNS0AttachedToQuery(t *testing.T) {
+	for _, tt := range luaEDNS0Types {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *dns.Msg
+			resolver := &TestResolver{
+				ResolveFunc: func(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
+					packed, err := q.Pack()
+					require.NoError(t, err)
+					got = new(dns.Msg)
+					require.NoError(t, got.Unpack(packed))
+					a := new(dns.Msg)
+					a.SetReply(q)
+					return a, nil
+				},
+			}
+			r, err := NewLua("test-lua", LuaOptions{Script: fmt.Sprintf(`
+function Resolve(msg, ci)
+	local opt = OPT.new()
+	opt.option = { %s }
+	msg.extra = { opt }
+	local resolver = Resolvers[1]
+	return resolver:resolve(msg, ci)
+end`, tt.new)}, resolver)
+			require.NoError(t, err)
+
+			q := new(dns.Msg)
+			q.SetQuestion("example.com.", dns.TypeA)
+			_, err = r.Resolve(q, ClientInfo{})
+			require.NoError(t, err)
+
+			require.NotNil(t, got)
+			edns0 := got.IsEdns0()
+			require.NotNil(t, edns0)
+			require.Len(t, edns0.Option, 1)
+			require.Equal(t, tt.option, edns0.Option[0].Option())
+		})
+	}
+}
+
+// Runs a script fragment that returns an Error when it finds a bad value, and
+// fails the test with it.
+func runLuaEDNS0Check(t *testing.T, body string) {
+	t.Helper()
+	require.NoError(t, runLuaEDNS0Script(t, body))
+}
+
+// Runs a script fragment inside a Resolve function and returns whatever went
+// wrong, whether raised by Lua or returned by the script.
+func runLuaEDNS0Script(t *testing.T, body string) error {
+	t.Helper()
+	script := "function Resolve(msg, ci)\n\t" + strings.TrimLeft(body, "\n\t") + "\n\treturn nil, nil\nend"
+	r, err := NewLua("test-lua", LuaOptions{Script: script}, new(TestResolver))
+	require.NoError(t, err)
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	_, err = r.Resolve(q, ClientInfo{})
+	return err
+}


### PR DESCRIPTION
`lua-edns0.go` was 900 lines holding the same 55-line block fourteen times. Each `registerEDNS0*Type` built a metatable, defined a `new` constructor reading positional arguments, and a pair of `__index`/`__newindex` metamethods switching over field names with the same `getUserDataArg` check, the same `option` case and the same `ArgError` for anything unknown. Only the Go type, the field names and the fields they map to differed.

The scaffolding is now one generic `registerEDNS0Type`, and each option is a call naming the value to construct and its fields in the order `new` takes them:

```go
registerEDNS0Type(s, "EDNS0_EDE",
    func() *dns.EDNS0_EDE { return new(dns.EDNS0_EDE) },
    numberField("infocode", func(e *dns.EDNS0_EDE) *uint16 { return &e.InfoCode }),
    stringField("extratext", func(e *dns.EDNS0_EDE) *string { return &e.ExtraText }),
)
```

The field kinds that repeat across types (a number of some width, a string, a byte slice read as a string, a table of numbers, an IP address) are helpers, so a type costs one line per field. 834 lines removed, 157 added.

## Behaviour

Two edges change:

- Assigning an unparsable address to a subnet option reported it as argument 4, which is its position in the constructor but not in an assignment. It now names the argument actually passed.
- The `EDNS0_TCP_KEEPALIVE` constructor took a second argument setting the option's `Length` field, which the DNS library deprecated, always packs as zero, and which no field exposed to scripts. Extra arguments are still accepted and ignored, so a script passing one still runs.

Everything else is identical, including the option codes each type presets, the `option` pseudo-field, and the `"<type> does not have field <name>"` error on both read and write.

## Tests

The file had no tests of its own; the Lua suite covered construction and one field per type, around 76% of the file. The new table-driven tests cover every registered type: the option code it reports, each field through both a constructor and an assignment, slice fields as tables, the error for a field the type does not have, a rejected address, and a round trip through the wire format with the option attached to a query. Coverage of the file is now 88-100% per function.

They pass unchanged against the previous implementation, which is what establishes the two are equivalent.