### PR TITLE
Unexport the metrics types and name the upstream transport apart

### DIFF
--- a/blocklist.go
+++ b/blocklist.go
@@ -17,7 +17,7 @@ type Blocklist struct {
 	BlocklistOptions
 	resolver Resolver
 	mu       sync.RWMutex
-	metrics  *BlocklistMetrics
+	metrics  *blocklistMetrics
 }
 
 var _ Resolver = &Blocklist{}
@@ -47,7 +47,7 @@ type BlocklistOptions struct {
 	EDNS0EDETemplate *EDNS0EDETemplate
 }
 
-type BlocklistMetrics struct {
+type blocklistMetrics struct {
 	// Blocked queries count.
 	blocked *expvar.Int
 	// Allowed queries count.
@@ -59,8 +59,8 @@ const (
 	maxPTRResponses = 10
 )
 
-func NewBlocklistMetrics(id string) *BlocklistMetrics {
-	return &BlocklistMetrics{
+func newBlocklistMetrics(id string) *blocklistMetrics {
+	return &blocklistMetrics{
 		allowed: getVarInt("router", id, "allow"),
 		blocked: getVarInt("router", id, "deny"),
 	}
@@ -72,7 +72,7 @@ func NewBlocklist(id string, resolver Resolver, opt BlocklistOptions) (*Blocklis
 		id:               id,
 		resolver:         resolver,
 		BlocklistOptions: opt,
-		metrics:          NewBlocklistMetrics(id),
+		metrics:          newBlocklistMetrics(id),
 	}
 
 	// Start the refresh goroutines if we have a list and a refresh period was given

--- a/cache.go
+++ b/cache.go
@@ -18,11 +18,11 @@ type Cache struct {
 	CacheOptions
 	id       string
 	resolver Resolver
-	metrics  *CacheMetrics
+	metrics  *cacheMetrics
 	backend  CacheBackend
 }
 
-type CacheMetrics struct {
+type cacheMetrics struct {
 	// Cache hit count.
 	hit *expvar.Int
 	// Cache miss count.
@@ -170,7 +170,7 @@ func NewCache(id string, resolver Resolver, opt CacheOptions) *Cache {
 		CacheOptions: opt,
 		id:           id,
 		resolver:     resolver,
-		metrics: &CacheMetrics{
+		metrics: &cacheMetrics{
 			hit:     getVarInt("cache", id, "hit"),
 			miss:    getVarInt("cache", id, "miss"),
 			entries: getVarInt("cache", id, "entries"),

--- a/client-blocklist.go
+++ b/client-blocklist.go
@@ -16,7 +16,7 @@ type ClientBlocklist struct {
 	ClientBlocklistOptions
 	resolver Resolver
 	mu       sync.RWMutex
-	metrics  *BlocklistMetrics
+	metrics  *blocklistMetrics
 }
 
 var _ Resolver = &ClientBlocklist{}
@@ -42,7 +42,7 @@ func NewClientBlocklist(id string, resolver Resolver, opt ClientBlocklistOptions
 		id:                     id,
 		resolver:               resolver,
 		ClientBlocklistOptions: opt,
-		metrics:                NewBlocklistMetrics(id),
+		metrics:                newBlocklistMetrics(id),
 	}
 
 	// Start the refresh goroutines if we have a list and a refresh period was given

--- a/dnsclient.go
+++ b/dnsclient.go
@@ -85,7 +85,7 @@ func (d *DNSClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	log := logger(d.id, q, ci)
 	log.Debug("querying upstream resolver",
 		slog.String("resolver", d.endpoint),
-		slog.String("protocol", d.net),
+		slog.String("upstream-protocol", d.net),
 	)
 
 	q = setUDPSize(q, d.opt.UDPSize)

--- a/dnslistener.go
+++ b/dnslistener.go
@@ -82,7 +82,7 @@ func (s DNSListener) String() string {
 
 // DNS handler to forward all incoming requests to a given resolver.
 func listenHandler(id, protocol, addr string, r Resolver, allowedNet []*net.IPNet) dns.HandlerFunc {
-	metrics := NewListenerMetrics("listener", id)
+	metrics := newListenerMetrics("listener", id)
 	return func(w dns.ResponseWriter, req *dns.Msg) {
 		var err error
 

--- a/dohclient.go
+++ b/dohclient.go
@@ -98,7 +98,7 @@ type DoHClient struct {
 	template *uritemplates.UriTemplate
 	client   *http.Client
 	opt      DoHClientOptions
-	metrics  *ListenerMetrics
+	metrics  *listenerMetrics
 }
 
 var _ Resolver = &DoHClient{}
@@ -172,7 +172,7 @@ func NewDoHClient(id, endpoint string, opt DoHClientOptions) (*DoHClient, error)
 		template: template,
 		client:   client,
 		opt:      opt,
-		metrics:  NewListenerMetrics("client", id),
+		metrics:  newListenerMetrics("client", id),
 	}, nil
 }
 
@@ -184,7 +184,7 @@ func (d *DoHClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 
 	log.Debug("querying upstream resolver",
 		slog.String("resolver", d.endpoint),
-		slog.String("protocol", "doh"),
+		slog.String("upstream-protocol", "doh"),
 		slog.String("method", d.opt.Method),
 	)
 

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -43,7 +43,7 @@ type DoHListener struct {
 	r    Resolver
 	opt  DoHListenerOptions
 
-	metrics *DoHListenerMetrics
+	metrics *dohListenerMetrics
 }
 
 var _ Listener = &DoHListener{}
@@ -66,17 +66,17 @@ type DoHListenerOptions struct {
 	customMux *http.ServeMux
 }
 
-type DoHListenerMetrics struct {
-	ListenerMetrics
+type dohListenerMetrics struct {
+	listenerMetrics
 
 	// HTTP method used for query.
 	get  *expvar.Int
 	post *expvar.Int
 }
 
-func NewDoHListenerMetrics(id string) *DoHListenerMetrics {
-	return &DoHListenerMetrics{
-		ListenerMetrics: ListenerMetrics{
+func newDohListenerMetrics(id string) *dohListenerMetrics {
+	return &dohListenerMetrics{
+		listenerMetrics: listenerMetrics{
 			query:    getVarInt("listener", id, "query"),
 			response: getVarMap("listener", id, "response"),
 			err:      getVarMap("listener", id, "error"),
@@ -103,7 +103,7 @@ func NewDoHListener(id, addr string, opt DoHListenerOptions, resolver Resolver) 
 		addr:    addr,
 		r:       resolver,
 		opt:     opt,
-		metrics: NewDoHListenerMetrics(id),
+		metrics: newDohListenerMetrics(id),
 	}
 
 	if opt.customMux == nil {

--- a/doqclient.go
+++ b/doqclient.go
@@ -28,7 +28,7 @@ type DoQClient struct {
 	endpoint string
 	requests chan *request
 	log      *slog.Logger
-	metrics  *ListenerMetrics
+	metrics  *listenerMetrics
 
 	connection   *quicConnection
 	connectionV4 *quicConnection // IPv4-specific connection, used in dual-stack mode
@@ -100,7 +100,7 @@ func NewDoQClient(id, endpoint string, opt DoQClientOptions) (*DoQClient, error)
 	}
 	log := Log.With(
 		"id", id,
-		"protocol", "doq",
+		"upstream-protocol", "doq",
 		"endpoint", endpoint,
 	)
 	config := &quic.Config{
@@ -117,7 +117,7 @@ func NewDoQClient(id, endpoint string, opt DoQClientOptions) (*DoQClient, error)
 		DoQClientOptions: opt,
 		requests:         make(chan *request),
 		log:              log,
-		metrics:          NewListenerMetrics("client", id),
+		metrics:          newListenerMetrics("client", id),
 	}
 
 	// When both V4 and V6 local addresses are specified, create two QUIC connections
@@ -158,7 +158,7 @@ func NewDoQClient(id, endpoint string, opt DoQClientOptions) (*DoQClient, error)
 func (d *DoQClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	logger(d.id, q, ci).Debug("querying upstream resolver",
 		"resolver", d.endpoint,
-		"protocol", "doq",
+		"upstream-protocol", "doq",
 	)
 
 	d.metrics.query.Add(1)
@@ -390,16 +390,16 @@ func (s *quicConnection) awaitReplaySafe(replaySafe bool) {
 func (s *quicConnection) restart(rAddr *net.UDPAddr) error {
 	_ = s.Conn.CloseWithError(DOQNoError, "")
 
-	Log.Debug("attempt reconnect", slog.String("protocol", "quic"),
+	Log.Debug("attempt reconnect", slog.String("upstream-protocol", "quic"),
 		slog.String("local", s.lAddr.String()),
 		slog.String("remote", rAddr.String()),
 	)
 	conn, err := s.dialFunc(context.TODO(), rAddr, s.tlsConfig, s.config)
 	if err != nil {
-		Log.Warn("couldn't restart quic connection", "protocol", "quic", "remote", rAddr.String(), "local", s.lAddr.String(), "error", err)
+		Log.Warn("couldn't restart quic connection", "upstream-protocol", "quic", "remote", rAddr.String(), "local", s.lAddr.String(), "error", err)
 		return err
 	}
-	Log.Debug("restarted quic connection", "protocol", "quic", "remote", rAddr.String(), "local", s.lAddr.String())
+	Log.Debug("restarted quic connection", "upstream-protocol", "quic", "remote", rAddr.String(), "local", s.lAddr.String())
 
 	s.Conn = conn
 	return nil

--- a/doqlistener.go
+++ b/doqlistener.go
@@ -28,7 +28,7 @@ type DoQListener struct {
 	transport *quic.Transport
 	conn      *net.UDPConn
 	log       *slog.Logger
-	metrics   *DoQListenerMetrics
+	metrics   *doqListenerMetrics
 }
 
 var _ Listener = &DoQListener{}
@@ -40,8 +40,8 @@ type DoQListenerOptions struct {
 	TLSConfig *tls.Config
 }
 
-type DoQListenerMetrics struct {
-	ListenerMetrics
+type doqListenerMetrics struct {
+	listenerMetrics
 
 	// Count of connections initiated.
 	connection *expvar.Int
@@ -49,9 +49,9 @@ type DoQListenerMetrics struct {
 	stream *expvar.Int
 }
 
-func NewDoQListenerMetrics(id string) *DoQListenerMetrics {
-	return &DoQListenerMetrics{
-		ListenerMetrics: ListenerMetrics{
+func newDoqListenerMetrics(id string) *doqListenerMetrics {
+	return &doqListenerMetrics{
+		listenerMetrics: listenerMetrics{
 			query:    getVarInt("listener", id, "query"),
 			response: getVarMap("listener", id, "response"),
 			drop:     getVarInt("listener", id, "drop"),
@@ -74,7 +74,7 @@ func NewQUICListener(id, addr string, opt DoQListenerOptions, resolver Resolver)
 		r:       resolver,
 		opt:     opt,
 		log:     Log.With("id", id, "protocol", "doq", "addr", addr),
-		metrics: NewDoQListenerMetrics(id),
+		metrics: newDoqListenerMetrics(id),
 	}
 	return l
 }

--- a/dotclient.go
+++ b/dotclient.go
@@ -88,7 +88,7 @@ func (d *DoTClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	// Packing a message is not always a read-only operation, make a copy
 	q = q.Copy()
 	log := logger(d.id, q, ci)
-	log.Debug("querying upstream resolver", "resolver", d.endpoint, "protocol", "dot")
+	log.Debug("querying upstream resolver", "resolver", d.endpoint, "upstream-protocol", "dot")
 
 	// Add padding to the query before sending over TLS
 	padQuery(q)

--- a/dtlsclient.go
+++ b/dtlsclient.go
@@ -120,7 +120,7 @@ func (d *DTLSClient) Resolve(q *dns.Msg, ci ClientInfo) (*dns.Msg, error) {
 	log := logger(d.id, q, ci)
 	log.Debug("querying upstream resolver",
 		"resolver", d.endpoint,
-		"protocol", "dtls",
+		"upstream-protocol", "dtls",
 	)
 
 	q = setUDPSize(q, d.opt.UDPSize)

--- a/failback.go
+++ b/failback.go
@@ -22,7 +22,7 @@ type FailBack struct {
 	failCh    chan struct{} // signal the timer to reset on failure
 	active    int
 	opt       FailBackOptions
-	metrics   *FailRouterMetrics
+	metrics   *failRouterMetrics
 }
 
 // FailBackOptions contain group-specific options.
@@ -42,17 +42,17 @@ type FailBackOptions struct {
 
 var _ Resolver = &FailBack{}
 
-type FailRouterMetrics struct {
-	RouterMetrics
+type failRouterMetrics struct {
+	routerMetrics
 	// Failover count
 	failover *expvar.Int
 }
 
-func NewFailRouterMetrics(id string, available int) *FailRouterMetrics {
+func newFailRouterMetrics(id string, available int) *failRouterMetrics {
 	avail := getVarInt("router", id, "available")
 	avail.Set(int64(available))
-	return &FailRouterMetrics{
-		RouterMetrics: RouterMetrics{
+	return &failRouterMetrics{
+		routerMetrics: routerMetrics{
 			route:     getVarMap("router", id, "route"),
 			failure:   getVarMap("router", id, "failure"),
 			available: avail,
@@ -67,7 +67,7 @@ func NewFailBack(id string, opt FailBackOptions, resolvers ...Resolver) *FailBac
 		id:        id,
 		resolvers: resolvers,
 		opt:       opt,
-		metrics:   NewFailRouterMetrics(id, len(resolvers)),
+		metrics:   newFailRouterMetrics(id, len(resolvers)),
 	}
 }
 

--- a/failrotate.go
+++ b/failrotate.go
@@ -16,7 +16,7 @@ type FailRotate struct {
 	resolvers []Resolver
 	mu        sync.RWMutex
 	active    int
-	metrics   *FailRouterMetrics
+	metrics   *failRouterMetrics
 	opt       FailRotateOptions
 }
 
@@ -39,7 +39,7 @@ func NewFailRotate(id string, opt FailRotateOptions, resolvers ...Resolver) *Fai
 		id:        id,
 		resolvers: resolvers,
 		opt:       opt,
-		metrics:   NewFailRouterMetrics(id, len(resolvers)),
+		metrics:   newFailRouterMetrics(id, len(resolvers)),
 	}
 }
 

--- a/listener.go
+++ b/listener.go
@@ -38,7 +38,7 @@ type ClientInfo struct {
 }
 
 // Metrics that are available from listeners and clients.
-type ListenerMetrics struct {
+type listenerMetrics struct {
 	// DNS query count.
 	query *expvar.Int
 	// DNS response type counts.
@@ -51,8 +51,8 @@ type ListenerMetrics struct {
 	maxQueueLen *expvar.Int
 }
 
-func NewListenerMetrics(base string, id string) *ListenerMetrics {
-	return &ListenerMetrics{
+func newListenerMetrics(base string, id string) *listenerMetrics {
+	return &listenerMetrics{
 		query:       getVarInt(base, id, "query"),
 		response:    getVarMap(base, id, "response"),
 		drop:        getVarInt(base, id, "drop"),

--- a/loadbalance.go
+++ b/loadbalance.go
@@ -39,7 +39,7 @@ type LoadBalance struct {
 	mu        sync.RWMutex
 	stats     []loadBalanceStats
 	opt       LoadBalanceOptions
-	metrics   *FailRouterMetrics
+	metrics   *failRouterMetrics
 	// Per-resolver current rttEMA in microseconds, published under
 	// routedns.router.<id>.rtt keyed by resolver String().
 	rttVars   []*expvar.Float
@@ -91,7 +91,7 @@ func NewLoadBalance(id string, opt LoadBalanceOptions, resolvers ...Resolver) *L
 		resolvers: resolvers,
 		stats:     make([]loadBalanceStats, len(resolvers)),
 		opt:       opt,
-		metrics:   NewFailRouterMetrics(id, len(resolvers)),
+		metrics:   newFailRouterMetrics(id, len(resolvers)),
 		rttVars:   rttVars,
 		randFloat: rand.Float64,
 	}

--- a/pipeline.go
+++ b/pipeline.go
@@ -27,7 +27,7 @@ type Pipeline struct {
 	client   DNSDialer
 	requests chan *request
 	inFlight inFlightQueue
-	metrics  *ListenerMetrics
+	metrics  *listenerMetrics
 	timeout  time.Duration
 	idle     time.Duration
 }
@@ -50,7 +50,7 @@ func NewPipeline(id string, addr string, client DNSDialer, timeout, idle time.Du
 		addr:     addr,
 		client:   client,
 		requests: make(chan *request),
-		metrics:  NewListenerMetrics("client", id),
+		metrics:  newListenerMetrics("client", id),
 		timeout:  timeout,
 		idle:     idle,
 	}

--- a/random.go
+++ b/random.go
@@ -17,7 +17,7 @@ type Random struct {
 	resolvers []Resolver
 	mu        sync.RWMutex
 	opt       RandomOptions
-	metrics   *FailRouterMetrics
+	metrics   *failRouterMetrics
 }
 
 var _ Resolver = &Random{}
@@ -42,7 +42,7 @@ func NewRandom(id string, opt RandomOptions, resolvers ...Resolver) *Random {
 		id:        id,
 		resolvers: resolvers,
 		opt:       opt,
-		metrics:   NewFailRouterMetrics(id, len(resolvers)),
+		metrics:   newFailRouterMetrics(id, len(resolvers)),
 	}
 }
 

--- a/rate-limiter.go
+++ b/rate-limiter.go
@@ -19,7 +19,7 @@ type RateLimiter struct {
 	mu        sync.RWMutex
 	currWinID int64
 	counters  map[string]*uint
-	metrics   *RateLimiterMetrics
+	metrics   *rateLimiterMetrics
 }
 
 var _ Resolver = &RateLimiter{}
@@ -32,7 +32,7 @@ type RateLimiterOptions struct {
 	LimitResolver Resolver // Alternate resolver for rate-limited requests
 }
 
-type RateLimiterMetrics struct {
+type rateLimiterMetrics struct {
 	// Count of queries.
 	query *expvar.Int
 	// Count of queries that have exceeded the rate limit.
@@ -56,7 +56,7 @@ func NewRateLimiter(id string, resolver Resolver, opt RateLimiterOptions) *RateL
 		id:                 id,
 		resolver:           resolver,
 		RateLimiterOptions: opt,
-		metrics: &RateLimiterMetrics{
+		metrics: &rateLimiterMetrics{
 			query:  getVarInt("router", id, "query"),
 			exceed: getVarInt("router", id, "exceed"),
 			drop:   getVarInt("router", id, "drop"),

--- a/roundrobin.go
+++ b/roundrobin.go
@@ -13,7 +13,7 @@ type RoundRobin struct {
 	resolvers []Resolver
 	mu        sync.Mutex
 	current   int
-	metrics   *RouterMetrics
+	metrics   *routerMetrics
 }
 
 var _ Resolver = &RoundRobin{}
@@ -23,7 +23,7 @@ func NewRoundRobin(id string, resolvers ...Resolver) *RoundRobin {
 	return &RoundRobin{
 		id:        id,
 		resolvers: resolvers,
-		metrics:   NewRouterMetrics(id, len(resolvers)),
+		metrics:   newRouterMetrics(id, len(resolvers)),
 	}
 }
 

--- a/router.go
+++ b/router.go
@@ -11,12 +11,12 @@ import (
 type Router struct {
 	id      string
 	routes  []*route
-	metrics *RouterMetrics
+	metrics *routerMetrics
 }
 
 var _ Resolver = &Router{}
 
-type RouterMetrics struct {
+type routerMetrics struct {
 	// Next route counts.
 	route *expvar.Map
 	// Next route failure counts.
@@ -25,10 +25,10 @@ type RouterMetrics struct {
 	available *expvar.Int
 }
 
-func NewRouterMetrics(id string, available int) *RouterMetrics {
+func newRouterMetrics(id string, available int) *routerMetrics {
 	avail := getVarInt("router", id, "available")
 	avail.Set(int64(available))
-	return &RouterMetrics{
+	return &routerMetrics{
 		route:     getVarMap("router", id, "route"),
 		failure:   getVarMap("router", id, "failure"),
 		available: avail,
@@ -40,7 +40,7 @@ func NewRouterMetrics(id string, available int) *RouterMetrics {
 func NewRouter(id string) *Router {
 	return &Router{
 		id:      id,
-		metrics: NewRouterMetrics(id, 0),
+		metrics: newRouterMetrics(id, 0),
 	}
 }
 


### PR DESCRIPTION
Two changes to the package's surfaces, one in Go, one in the logs.

## Metrics types

Eight metrics types were exported while holding nothing exported themselves, no field and no method: `RouterMetrics`, `FailRouterMetrics`, `CacheMetrics`, `BlocklistMetrics`, `RateLimiterMetrics`, `ListenerMetrics`, `DoHListenerMetrics` and `DoQListenerMetrics`. A program importing the library could name them and then do nothing with them. The equivalents for DNS64 and DNSSEC were already unexported, so the split was arbitrary.

They are now all unexported, along with their constructors. Nothing outside the package referenced them, in this repository or in the command. This shrinks the API surface without changing what anything can do with it, which is why it wants a release where a break, however cosmetic, is acceptable.

## protocol vs upstream-protocol

Every record a resolver logs carries the protocol the query arrived on, taken from the `ClientInfo` the listener filled in. The five upstream clients then added a `protocol` attribute of their own for the transport they were about to use, so a single record came out with the key twice, holding two different values:

```
level=DEBUG msg="querying upstream resolver" id=test-client qtype=A qname=www.example.com. protocol=doh addr=:443 resolver=127.0.0.1:65535 protocol=udp
```

Anything parsing that as JSON sees one key win arbitrarily, and the one that wins is not the same across handlers.

The clients now log `upstream-protocol`, which leaves `protocol` meaning the transport a query arrived on wherever it appears. The DoQ client's connection-scoped records follow the same rule, since the transport they name is the upstream one too.
