### PR TITLE
Match domain blocklists in one lookup per label

### DIFF
--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -1,8 +1,8 @@
 package rdns
 
 import (
+	"bytes"
 	"fmt"
-	"maps"
 	"net"
 	"strings"
 
@@ -22,21 +22,29 @@ import (
 // (e.g. hagezi's "Wildcard Domains" lists).
 type DomainDB struct {
 	name              string
-	root              node
+	root              *domainNode
 	loader            BlocklistLoader
 	includeSubdomains bool
 }
 
-type node map[string]node
+// A node in the trie of domain labels, holding the rules that end on it. All
+// three rule shapes describe the node of their base domain, so "domain.com",
+// ".domain.com" and "*.domain.com" all record themselves on the node for
+// domain.com and differ only in the flag they set.
+type domainNode struct {
+	children map[string]*domainNode
+	flags    uint8
+}
 
-// exactKey marks a node as an exact-match terminal that must also act
-// as an interior node for more-specific rules. A nil/empty node still
-// means an exact terminal on its own; exactKey is only added when the
-// same node additionally carries children or other sentinels so the
-// marker isn't masked. The value can never collide with a real label
-// (rules are split on ".", so labels never contain ".") nor with the
-// "" (apex+sub) or "*" (sub-only) sentinels.
-const exactKey = "."
+const (
+	ruleExact   uint8 = 1 << iota // domain.com, the name itself
+	ruleApexSub                   // .domain.com, the name and everything under it
+	ruleSubOnly                   // *.domain.com, everything under it but not itself
+)
+
+// The longest name that can arrive in a query. Presentation-format names can
+// exceed it when they carry escapes, which the match path handles separately.
+const maxDomainName = 255
 
 var _ BlocklistDB = &DomainDB{}
 
@@ -52,128 +60,70 @@ func NewDomainSubdomainDB(name string, loader BlocklistLoader) (*DomainDB, error
 }
 
 func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainDB, error) {
-	// Large lists (e.g. hagezi NRD) produce huge numbers of identical
-	// terminal nodes: empty leaves, "{"": empty}" (.X.tld), and
-	// "{"*": empty}" (*.X.tld). Empty leaves are represented as the nil
-	// node so they cost zero allocations. The two depth-1 shapes share
-	// a single map instance per build. Any later rule that descends
-	// through one of them clones first so it doesn't corrupt sibling
-	// paths that share the same instance.
-	dotNode := node{"": nil}
-	starNode := node{"*": nil}
-
 	rules, err := loader.Load()
 	if err != nil {
 		return nil, err
 	}
-	root := make(node)
+	root := new(domainNode)
 	for _, r := range rules {
-		r = strings.TrimSpace(r)
-
-		// Strip trailing . in case the list has FQDN names with . suffixes.
-		r = strings.TrimSuffix(r, ".")
-
-		// Force all domain names to lower case
-		r = strings.ToLower(r)
-
-		// In subdomain-matching mode, treat bare entries as ".entry" so they
-		// match the apex and all sub-domains. Leave entries that already
-		// start with "." or "*." alone.
-		if includeSubdomains && r != "" && !strings.HasPrefix(r, ".") && !strings.HasPrefix(r, "*.") {
-			r = "." + r
+		// Strip a trailing dot in case the list holds FQDNs, and force the
+		// rule to lower case since queries are matched in lower case.
+		r = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(r), "."))
+		if r == "" {
+			continue
 		}
 
-		// Break up the domain into its parts and iterate backwards over them, building
-		// a graph of maps
-		parts := strings.Split(r, ".")
+		// A bare wildcard only ever applied to the labels under it, of which
+		// there are none here, so it's not an error, just nothing to record.
+		if r == "*" {
+			continue
+		}
+
+		// The prefix decides what the rule matches, the remainder is the base
+		// domain that carries the flag. In subdomain mode a bare entry covers
+		// the apex and everything under it, while entries that bring their own
+		// prefix keep their meaning.
+		flag := ruleExact
+		switch {
+		case strings.HasPrefix(r, "*."):
+			r, flag = r[2:], ruleSubOnly
+		case strings.HasPrefix(r, "."):
+			r, flag = r[1:], ruleApexSub
+		case includeSubdomains:
+			flag = ruleApexSub
+		}
+
+		// Walk the labels from the TLD inwards, building the path as needed.
 		n := root
-		for i := len(parts) - 1; i >= 0; i-- {
-			part := parts[i]
+		end := len(r)
+		for {
+			i := strings.LastIndexByte(r[:end], '.')
+			label := r[i+1 : end]
 
-			// Only allow wildcards as the first domain part, and not in a string
-			if strings.Contains(part, "*") && (i > 0 || len(part) != 1) {
-				return nil, fmt.Errorf("invalid blocklist item: '%s'", part)
+			// Wildcards are only valid as the whole first label, which the
+			// prefix above has already taken off.
+			if strings.Contains(label, "*") {
+				return nil, fmt.Errorf("invalid blocklist item: '%s'", label)
 			}
-
-			subNode, ok := n[part]
+			child, ok := n.children[label]
 			if !ok {
-				switch {
-				case i == 0:
-					subNode = nil
-				case i == 1 && parts[0] == "":
-					subNode = dotNode
-				case i == 1 && parts[0] == "*":
-					subNode = starNode
-				default:
-					subNode = make(node)
+				child = new(domainNode)
+				if n.children == nil {
+					n.children = make(map[string]*domainNode)
 				}
-				n[part] = subNode
-				n = subNode
-				continue
+				// Cloned so the node doesn't pin the whole rule line, which
+				// is a slice of the same backing array.
+				n.children[strings.Clone(label)] = child
 			}
-
-			// The path segment already exists.
-			if i == 0 {
-				// This rule is an exact match terminating here. A
-				// nil/empty leaf already means an exact terminal, and a
-				// "" sentinel already matches the apex, so in both
-				// cases there's nothing to add. Otherwise the node also
-				// acts as an interior node for more-specific rules, so
-				// record an explicit exact marker that survives
-				// alongside the children. Clone shared shapes before
-				// mutating so siblings sharing the instance aren't
-				// corrupted.
-				if len(subNode) == 0 {
-					break
-				}
-				if _, apex := subNode[""]; apex {
-					break
-				}
-				if isSharedShape(subNode) {
-					subNode = maps.Clone(subNode)
-					n[part] = subNode
-				}
-				subNode[exactKey] = nil
+			n = child
+			if i <= 0 {
 				break
 			}
-
-			// Descending through an existing segment. Clone/expand
-			// shared shapes so sibling paths that share the instance
-			// aren't corrupted, preserving an exact terminal that a
-			// shorter rule stored here as a nil leaf.
-			if isSharedShape(subNode) {
-				if subNode == nil {
-					subNode = node{exactKey: nil}
-				} else {
-					subNode = maps.Clone(subNode)
-				}
-				n[part] = subNode
-			}
-			n = subNode
+			end = i
 		}
+		n.flags |= flag
 	}
 	return &DomainDB{name, root, loader, includeSubdomains}, nil
-}
-
-// isSharedShape reports whether n looks like one of the build-time
-// sentinels: a nil empty leaf, {"": nil} (the .X dot-sentinel), or
-// {"*": nil} (the *.X star-sentinel). The build path never produces
-// nodes of these shapes outside the sentinel paths, so a shape match
-// safely identifies a (possibly shared) instance that must be cloned
-// before mutation.
-func isSharedShape(n node) bool {
-	switch len(n) {
-	case 0:
-		return n == nil
-	case 1:
-		if v, ok := n[""]; ok {
-			return v == nil
-		}
-		if v, ok := n["*"]; ok {
-			return v == nil
-		}
-	}
-	return false
 }
 
 func (m *DomainDB) Reload() (BlocklistDB, error) {
@@ -181,57 +131,69 @@ func (m *DomainDB) Reload() (BlocklistDB, error) {
 }
 
 func (m *DomainDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
-	q := msg.Question[0]
-	s := strings.ToLower(strings.TrimSuffix(q.Name, "."))
-	var matched []string
-	parts := strings.Split(s, ".")
+	name := strings.TrimSuffix(msg.Question[0].Name, ".")
+
+	// Lower-cased into a stack buffer, so the mixed-case names 0x20 encoding
+	// produces don't cost an allocation like strings.ToLower would.
+	var buf [maxDomainName]byte
+	if len(name) <= len(buf) {
+		return m.match(lowerASCII(buf[:len(name)], name))
+	}
+	return m.match([]byte(strings.ToLower(name)))
+}
+
+// match walks the labels of a lower-cased query name from the TLD inwards,
+// stopping at the first rule that covers it.
+func (m *DomainDB) match(name []byte) ([]net.IP, []string, *BlocklistMatch, bool) {
 	n := m.root
-	for i := len(parts) - 1; i >= 0; i-- {
-		part := parts[i]
-		subNode, ok := n[part]
+	end := len(name)
+	for end > 0 {
+		i := bytes.LastIndexByte(name[:end], '.')
+
+		// Indexing a map with a string conversion of a byte slice doesn't
+		// allocate, so a query that doesn't match costs nothing on the heap.
+		child, ok := n.children[string(name[i+1:end])]
 		if !ok {
 			return nil, nil, nil, false
 		}
-		matched = append(matched, part)
-		if _, ok := subNode[""]; ok { // exact and sub-domain match
-			return nil,
-				nil,
-				&BlocklistMatch{
-					List: m.name,
-					Rule: matchedDomainParts(".", matched),
-				},
-				true
+		if child.flags&ruleApexSub != 0 {
+			return nil, nil, m.matched(".", name[i+1:]), true
 		}
-		if _, ok := subNode["*"]; ok && i > 0 { // wildcard match on sub-domains
-			return nil,
-				nil,
-				&BlocklistMatch{
-					List: m.name,
-					Rule: matchedDomainParts("*.", matched),
-				},
-				true
+		if child.flags&ruleSubOnly != 0 && i > 0 { // only if a label remains to the left
+			return nil, nil, m.matched("*.", name[i+1:]), true
 		}
-		n = subNode
+		n = child
+		end = i
 	}
-	_, exact := n[exactKey]
-	return nil,
-		nil,
-		&BlocklistMatch{
-			List: m.name,
-			Rule: matchedDomainParts("", matched),
-		},
-		len(n) == 0 || exact // exact match
+	if n.flags&ruleExact != 0 {
+		return nil, nil, m.matched("", name), true
+	}
+	return nil, nil, nil, false
+}
+
+// matched reports the rule that matched, rebuilt from the part of the query
+// name it matched on.
+func (m *DomainDB) matched(prefix string, name []byte) *BlocklistMatch {
+	var b strings.Builder
+	b.Grow(len(prefix) + len(name))
+	b.WriteString(prefix)
+	b.Write(name)
+	return &BlocklistMatch{List: m.name, Rule: b.String()}
 }
 
 func (m *DomainDB) String() string {
 	return "Domain"
 }
 
-// Turn a list of matched domain fragments into a domain (rule)
-func matchedDomainParts(prefix string, p []string) string {
-	for i := len(p)/2 - 1; i >= 0; i-- {
-		opp := len(p) - 1 - i
-		p[i], p[opp] = p[opp], p[i]
+// lowerASCII copies name into b, lower-cased. Domain names are ASCII, so
+// byte-wise lowering is all that's needed.
+func lowerASCII(b []byte, name string) []byte {
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		b[i] = c
 	}
-	return prefix + strings.Join(p, ".")
+	return b
 }

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -1,6 +1,9 @@
 package rdns
 
 import (
+	"fmt"
+	"math/rand"
+	"strings"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -242,5 +245,159 @@ func TestDomainDBError(t *testing.T) {
 		loader := NewStaticLoader([]string{test.name})
 		_, err := NewDomainDB("testlist", loader)
 		require.Error(t, err)
+	}
+}
+
+// generateDomainRules builds a deterministic ruleset shaped like a real
+// blocklist: mostly two-label entries, some deeper, in all three rule forms.
+func generateDomainRules(n int) []string {
+	rnd := rand.New(rand.NewSource(42))
+	words := []string{"ads", "track", "cdn", "api", "metrics", "cloud", "static",
+		"pixel", "log", "stats", "img", "click", "promo", "banner", "beacon"}
+	tlds := []string{"com", "net", "org", "io", "xyz", "top", "info", "biz"}
+	rules := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		domain := fmt.Sprintf("%s%d.%s", words[rnd.Intn(len(words))], i, tlds[rnd.Intn(len(tlds))])
+		if rnd.Intn(4) == 0 { // a quarter of the rules sit a level deeper
+			domain = words[rnd.Intn(len(words))] + "." + domain
+		}
+		switch rnd.Intn(3) {
+		case 0:
+			rules = append(rules, domain) // the name itself
+		case 1:
+			rules = append(rules, "."+domain) // the name and everything under it
+		default:
+			rules = append(rules, "*."+domain) // everything under it
+		}
+	}
+	return rules
+}
+
+// A rule reduced to the base domain it applies to and what it covers.
+type parsedDomainRule struct {
+	domain    string
+	apex, sub bool
+	reported  string // the rule string a match on it reports
+}
+
+func parseDomainRules(rules []string, includeSubdomains bool) []parsedDomainRule {
+	parsed := make([]parsedDomainRule, 0, len(rules))
+	for _, r := range rules {
+		r = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(r), "."))
+		if r == "" || r == "*" {
+			continue
+		}
+		p := parsedDomainRule{}
+		switch {
+		case strings.HasPrefix(r, "*."):
+			p.domain, p.sub = r[2:], true
+			p.reported = "*." + p.domain
+		case strings.HasPrefix(r, "."):
+			p.domain, p.apex, p.sub = r[1:], true, true
+			p.reported = "." + p.domain
+		case includeSubdomains:
+			p.domain, p.apex, p.sub = r, true, true
+			p.reported = "." + p.domain
+		default:
+			p.domain, p.apex = r, true
+			p.reported = p.domain
+		}
+		parsed = append(parsed, p)
+	}
+	return parsed
+}
+
+// referenceDomainMatch applies the rule semantics from the DomainDB doc
+// comment one rule at a time. A rule can only ever add a match, never take one
+// away, so checking each independently is a valid oracle for what the trie
+// does in one pass.
+func referenceDomainMatch(parsed []parsedDomainRule, name string) bool {
+	name = strings.ToLower(strings.TrimSuffix(name, "."))
+	for _, p := range parsed {
+		if p.apex && name == p.domain {
+			return true
+		}
+		if p.sub && strings.HasSuffix(name, "."+p.domain) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDomainDBGenerated checks the trie against the rule semantics applied
+// directly, over a generated list and queries derived from it.
+func TestDomainDBGenerated(t *testing.T) {
+	for _, includeSubdomains := range []bool{false, true} {
+		rules := generateDomainRules(500)
+		parsed := parseDomainRules(rules, includeSubdomains)
+		reported := make(map[string]bool, len(parsed))
+		for _, p := range parsed {
+			reported[p.reported] = true
+		}
+
+		db, err := newDomainDB("testlist", NewStaticLoader(rules), includeSubdomains)
+		require.NoError(t, err)
+
+		var queries []string
+		for _, p := range parsed {
+			queries = append(queries, p.domain, "www."+p.domain, "a.b."+p.domain)
+			if i := strings.IndexByte(p.domain, '.'); i > 0 {
+				queries = append(queries, p.domain[i+1:]) // the parent domain
+			}
+		}
+		for i := 0; i < 200; i++ {
+			queries = append(queries, fmt.Sprintf("unlisted%d.example.net", i))
+		}
+
+		msg := new(dns.Msg)
+		for _, q := range queries {
+			msg.SetQuestion(dns.Fqdn(q), dns.TypeA)
+			_, _, match, ok := db.Match(msg)
+			require.Equal(t, referenceDomainMatch(parsed, q), ok,
+				"subdomain-mode=%v query=%s", includeSubdomains, q)
+			if !ok {
+				require.Nil(t, match, "a miss must not build a match")
+				continue
+			}
+			require.True(t, reported[match.Rule],
+				"reported rule %q is not one of the rules loaded", match.Rule)
+		}
+	}
+}
+
+func BenchmarkDomainDBMatch(b *testing.B) {
+	for _, n := range []int{1000, 100000} {
+		rules := generateDomainRules(n)
+		db, err := newDomainDB("testlist", NewStaticLoader(rules), false)
+		require.NoError(b, err)
+
+		// A name that matches the last rule loaded, one that shares its TLD
+		// but nothing else, and a mixed-case name to cover the lowering path.
+		hit := "www." + strings.TrimPrefix(strings.TrimPrefix(rules[len(rules)-1], "*."), ".")
+		for _, q := range []string{hit, "www.example.com", "WWW.ExAmPlE.CoM"} {
+			b.Run(fmt.Sprintf("rules=%d/name=%s", n, q), func(b *testing.B) {
+				msg := new(dns.Msg)
+				msg.SetQuestion(dns.Fqdn(q), dns.TypeA)
+				b.ReportAllocs()
+				for b.Loop() {
+					_, _, _, _ = db.Match(msg)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkDomainDBBuild(b *testing.B) {
+	for _, n := range []int{10000, 100000} {
+		rules := generateDomainRules(n)
+		loader := NewStaticLoader(rules)
+		b.Run(fmt.Sprintf("rules=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := newDomainDB("testlist", loader, false); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -62,8 +62,8 @@ func TestDomainDB(t *testing.T) {
 }
 
 // TestDomainDBOverlap covers exact rules that overlap with more-specific
-// rules. The trie's exact-match marker must survive regardless of the
-// order in which the overlapping rules are inserted.
+// rules. The exact-match flag must survive regardless of the order in which
+// the overlapping rules are inserted.
 func TestDomainDBOverlap(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -111,7 +111,7 @@ func TestDomainDBOverlap(t *testing.T) {
 			},
 		},
 		{
-			name:  "apex+sub rule then exact apex (shared dot sentinel untouched)",
+			name:  "apex+sub rule then exact apex",
 			rules: []string{".domain.com", "domain.com", ".other.com"},
 			tests: []struct {
 				q     string
@@ -124,7 +124,7 @@ func TestDomainDBOverlap(t *testing.T) {
 			},
 		},
 		{
-			name:  "wildcard rule then exact apex (shared star sentinel untouched)",
+			name:  "wildcard rule then exact apex",
 			rules: []string{"*.domain.com", "*.other.com", "domain.com"},
 			tests: []struct {
 				q     string

--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -46,16 +46,21 @@ func (l *HTTPLoader) Load() (rules []string, err error) {
 	log.Debug("loading blocklist")
 
 	// If AllowFailure is enabled, return the last successfully loaded list
-	// and nil
+	// and nil. Without it there's nothing to fall back to, so the rules are
+	// not kept: for a large list that copy would be held for the life of the
+	// process.
 	defer func() {
-		if err != nil && l.opt.AllowFailure {
+		if !l.opt.AllowFailure {
+			return
+		}
+		if err != nil {
 			log.Warn("failed to load blocklist, continuing with previous ruleset",
 				"error", err)
 			rules = l.lastSuccess
 			err = nil
-		} else {
-			l.lastSuccess = rules
+			return
 		}
+		l.lastSuccess = rules
 	}()
 
 	// If a cache-dir was given, try to load the list from disk on first load

--- a/blocklistloader-local.go
+++ b/blocklistloader-local.go
@@ -30,16 +30,21 @@ func (l *FileLoader) Load() (rules []string, err error) {
 	log.Debug("loading blocklist")
 
 	// If AllowFailure is enabled, return the last successfully loaded list
-	// and nil
+	// and nil. Without it there's nothing to fall back to, so the rules are
+	// not kept: for a large list that copy would be held for the life of the
+	// process.
 	defer func() {
-		if err != nil && l.opt.AllowFailure {
+		if !l.opt.AllowFailure {
+			return
+		}
+		if err != nil {
 			log.Warn("failed to load blocklist, continuing with previous ruleset",
 				"error", err)
 			rules = l.lastSuccess
 			err = nil
-		} else {
-			l.lastSuccess = rules
+			return
 		}
+		l.lastSuccess = rules
 	}()
 
 	f, err := os.Open(l.filename)


### PR DESCRIPTION
A rule's terminal semantics were encoded as sentinel children of the node it
ended on: `""` for `.domain.com`, `"*"` for `*.domain.com`, and `"."` for a
`domain.com` that also had more specific rules beneath it. Matching a name cost
three map lookups per label to read what amounts to three flag bits, and the
sentinels had to be shared between paths and cloned again on descent so the
node count stayed reasonable, with a shape check to tell a shared instance from
a real one.

The node now carries those flags itself. A label costs one lookup, and the
sharing, the cloning and the shape check are gone along with the sentinels.
`Match` walks the name with `LastIndexByte` rather than splitting it into a
slice, and lower-cases into a stack buffer, so a query that does not match
allocates nothing at all, including the mixed-case names 0x20 encoding
produces, which used to allocate through `strings.ToLower`. A query that
matches allocates the rule string and the `BlocklistMatch` the interface asks
for, rather than four times.

Both blocklist loaders also assigned every successfully loaded ruleset to
`lastSuccess`, which only the allow-failure path reads. Without allow-failure
the raw list was pinned for the life of the process where nothing could reach
it, a second copy of every line, around 80 MB for a list of two million rules.

### Measured

hagezi's ultimate list at 274k rules and a 2M rule NRD-style list, old and new
interleaved on an idle machine, best of four for the timings and best of two
for the collector:

| list | retained | GC mark | miss | 50% hit |
| --- | --- | --- | --- | --- |
| ultimate, `domain` | 42.3 -> 41.1 MB | 14.1 -> 17.3 ms | 263 -> 100 ns | 565 -> 248 ns |
| ultimate, `domain-subdomain` | 48.3 -> 41.1 MB | | | |
| 2M rules, `domain-subdomain` | 233.2 -> 166.9 MB | 110 -> 164 ms | 197 -> 79 ns | 476 -> 271 ns |

Lookups are 1.75x to 2.62x faster. Subdomain mode gains the most memory because
a bare entry no longer builds a sentinel child, so the same list now costs the
same in either mode.

Collector mark time goes the other way at two million rules, because a node is
an object now rather than a bare map. Holding nodes by value in the parent's
map avoids that and was measured as well, at 76 ms with the 2M list resident
and 12.0 ms at 274k, but it costs 16-byte map values instead of 8: 6.7 MB more
on the 274k list, 17.6 MB more at 2M, and a 15% slower miss in the large
fan-out under `com`. Resident memory is paid continuously while a collection is
rare now that a query does not allocate, so the pointer layout is the one used
here.

### Behaviour

Two rules that could never match a real query are no longer built. A blank line
used to register a node that only a query for the root zone would match, and a
bare `*` used to build a node nothing could reach. Both are skipped now, `*`
without an error so an existing list cannot suddenly fail to load. Everything
else matches exactly as it did.

### Tests

The table-driven tests state the semantics case by case, which leaves every
combination they do not name uncovered. A generated ruleset of all three rule
forms is now matched against the same rules applied one at a time, which is a
valid oracle because a rule can only ever add a match, never take one away. It
covers the apex, a sub-domain, a deeper sub-domain and the parent of every
rule, along with names on no list at all, and asserts that a miss builds no
match and that every rule reported is one of the rules loaded.

The benchmarks cover a hit, a miss and a mixed-case miss at a thousand and a
hundred thousand rules, and building a list at ten and a hundred thousand.