### PR TITLE
Hold domain blocklist rules in three flat arrays

### DIFF
--- a/blocklistdb-domain-trie.go
+++ b/blocklistdb-domain-trie.go
@@ -1,0 +1,205 @@
+package rdns
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/bits"
+)
+
+// The longest label a domain name can carry. A rule with anything longer could
+// never be reached by a valid query.
+const maxDomainLabel = 63
+
+// A slot in the lookup table packs the three things a probe needs into one
+// word: the parent it hangs under, the child it points at, and a byte of the
+// hash to reject a mismatch before reading the child's label. A node index is
+// therefore 28 bits wide, and index 0 is the root, which is nobody's child, so
+// a filled slot is never zero.
+const (
+	domainNodeBits   = 28
+	maxDomainNodes   = 1 << domainNodeBits
+	domainSlotParent = 64 - domainNodeBits
+	domainSlotKey    = uint64(maxDomainNodes-1)<<domainSlotParent | 0xff // parent and tag
+	domainSlotChild  = maxDomainNodes - 1
+)
+
+func domainSlot(parent, child uint32, tag uint8) uint64 {
+	return uint64(parent)<<domainSlotParent | uint64(child)<<8 | uint64(tag)
+}
+
+// labelText is a domain label as its two callers hold it: a string while the
+// rules are read, a slice of the lower-cased query while a name is matched.
+// Neither is converted to the other, so neither path allocates.
+type labelText interface{ ~string | ~[]byte }
+
+const (
+	fnvOffsetBasis64 = 14695981039346656037
+	fnvPrime64       = 1099511628211
+	goldenRatio64    = 0x9e3779b97f4a7c15 // spreads a node index over the word
+)
+
+// domainHash hashes a label together with the node it hangs under, so that the
+// same label below two parents lands in two different places.
+//
+// The loop is FNV-1a, but this is not hash/fnv and cannot be swapped for it. It
+// starts from the parent mixed into the offset basis rather than the basis
+// alone, which keys the hash on the pair without encoding the two into bytes
+// first, and it ends in a finalizer because the two ends of the result are read
+// separately: the table index is taken off the top of the word by bits.Mul64,
+// where FNV-1a is weakest, and the tag stored in a slot off the bottom.
+func domainHash[T labelText](parent uint32, label T) uint64 {
+	h := uint64(parent)*goldenRatio64 ^ fnvOffsetBasis64
+	for i := 0; i < len(label); i++ {
+		h ^= uint64(label[i])
+		h *= fnvPrime64
+	}
+	return avalanche64(h)
+}
+
+// avalanche64 is splitmix64's finalizer, which spreads every input bit over the
+// whole word.
+func avalanche64(h uint64) uint64 {
+	h ^= h >> 30
+	h *= 0xbf58476d1ce4e5b9
+	h ^= h >> 27
+	h *= 0x94d049bb133111eb
+	return h ^ h>>31
+}
+
+// index maps a hash onto the table without a division.
+func (t *domainTrie) index(h uint64) uint64 {
+	idx, _ := bits.Mul64(h, uint64(len(t.slots)))
+	return idx
+}
+
+func (t *domainTrie) next(idx uint64) uint64 {
+	idx++
+	if idx == uint64(len(t.slots)) {
+		return 0
+	}
+	return idx
+}
+
+// labelAt returns a node's label, from the node itself or from the blob.
+func (t *domainTrie) labelAt(node uint32) []byte {
+	n := &t.nodes[node]
+	if n.length <= domainInlineLabel {
+		return n.label[:n.length]
+	}
+	off := binary.LittleEndian.Uint32(n.label[:4])
+	return t.blob[off : off+uint32(n.length)]
+}
+
+// trieFind returns the child of parent carrying the given label. A slot is
+// accepted only once its parent and its label both match what was asked for,
+// which the hash never stands in for, so a hash collision costs a comparison
+// rather than a wrong answer. The byte of hash in the slot is there to settle
+// most mismatches without reading the label at all.
+func trieFind[T labelText](t *domainTrie, parent uint32, label T) (uint32, bool) {
+	h := domainHash(parent, label)
+	key := domainSlot(parent, 0, uint8(h))
+	idx := t.index(h)
+	for {
+		s := t.slots[idx]
+		if s == 0 {
+			return 0, false
+		}
+		if s&domainSlotKey == key {
+			node := uint32(s>>8) & domainSlotChild
+			if labelEqual(t.labelAt(node), label) {
+				return node, true
+			}
+		}
+		idx = t.next(idx)
+	}
+}
+
+// trieAdd records node as the child of parent under the given label. The
+// caller has established that it isn't there yet.
+func trieAdd[T labelText](t *domainTrie, parent uint32, label T, node uint32) {
+	h := domainHash(parent, label)
+	idx := t.index(h)
+	for t.slots[idx] != 0 {
+		idx = t.next(idx)
+	}
+	t.slots[idx] = domainSlot(parent, node, uint8(h))
+}
+
+func labelEqual[T labelText](stored []byte, label T) bool {
+	if len(stored) != len(label) {
+		return false
+	}
+	for i := range stored {
+		if stored[i] != label[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// domainBuilder fills a trie one rule at a time. It keeps the parent of every
+// node so the table can be rebuilt as it grows, and drops that once the trie
+// is finished.
+type domainBuilder struct {
+	domainTrie
+	parents []uint32
+}
+
+func newDomainBuilder(rules int) *domainBuilder {
+	b := &domainBuilder{}
+	b.nodes = make([]domainNode, 1, rules+1) // node 0 is the root
+	b.parents = make([]uint32, 1, rules+1)
+	b.rebuild(domainTableSize(uint64(rules)) + 8)
+	return b
+}
+
+// domainTableSize is the table a trie of n nodes wants. Linear probing degrades
+// sharply as a table fills, and two thirds is where the probe runs are still
+// short enough that a lookup rarely leaves the cache line it starts on.
+func domainTableSize(nodes uint64) uint64 {
+	return nodes * 3 / 2
+}
+
+// child returns the node for label under parent, adding it if it's new.
+func (b *domainBuilder) child(parent uint32, label string) (uint32, error) {
+	if node, ok := trieFind(&b.domainTrie, parent, label); ok {
+		return node, nil
+	}
+	if len(b.nodes) >= maxDomainNodes {
+		return 0, fmt.Errorf("blocklist has more than %d labels", maxDomainNodes)
+	}
+	if uint64(len(b.nodes)+1)*3 > uint64(len(b.slots))*2 {
+		b.rebuild(uint64(len(b.slots)) * 2)
+	}
+	node := domainNode{length: uint8(len(label))}
+	if len(label) <= domainInlineLabel {
+		copy(node.label[:], label)
+	} else {
+		binary.LittleEndian.PutUint32(node.label[:4], uint32(len(b.blob)))
+		b.blob = append(b.blob, label...)
+	}
+	id := uint32(len(b.nodes))
+	b.nodes = append(b.nodes, node)
+	b.parents = append(b.parents, parent)
+	b.nodes[parent].flags |= ruleHasChildren
+	trieAdd(&b.domainTrie, parent, label, id)
+	return id, nil
+}
+
+// rebuild lays the table out again at the given size.
+func (b *domainBuilder) rebuild(size uint64) {
+	b.slots = make([]uint64, size)
+	for id := 1; id < len(b.nodes); id++ {
+		trieAdd(&b.domainTrie, b.parents[id], b.labelAt(uint32(id)), uint32(id))
+	}
+}
+
+// done returns the finished trie, sized to what it holds rather than to the
+// rule count it was guessed from.
+func (b *domainBuilder) done() domainTrie {
+	if want := domainTableSize(uint64(len(b.nodes))) + 8; uint64(len(b.slots)) > want*4/3 {
+		b.rebuild(want)
+	}
+	b.parents = nil
+	return b.domainTrie
+}

--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -22,24 +22,43 @@ import (
 // (e.g. hagezi's "Wildcard Domains" lists).
 type DomainDB struct {
 	name              string
-	root              *domainNode
+	trie              domainTrie
 	loader            BlocklistLoader
 	includeSubdomains bool
 }
 
-// A node in the trie of domain labels, holding the rules that end on it. All
-// three rule shapes describe the node of their base domain, so "domain.com",
-// ".domain.com" and "*.domain.com" all record themselves on the node for
-// domain.com and differ only in the flag they set.
-type domainNode struct {
-	children map[string]*domainNode
-	flags    uint8
+// domainTrie holds the rules as a trie of domain labels in three flat pieces:
+// every node in one array, the labels too long to sit inside a node in one
+// blob, and one open-addressed table mapping a node and a label to the child
+// under it. None of it holds a pointer, so a list of millions of rules costs
+// the garbage collector three objects to mark rather than one per node.
+type domainTrie struct {
+	nodes []domainNode
+	blob  []byte
+	slots []uint64 // tag<<32 | node index, zero when empty
 }
 
+// A node carries its label and the rules that end on it. All three rule shapes
+// describe the node of their base domain, so "domain.com", ".domain.com" and
+// "*.domain.com" all record themselves on the node for domain.com and differ
+// only in the flag they set.
+//
+// Labels of domainInlineLabel bytes or fewer, which is most of them, sit in the
+// node itself. Longer ones give up the first four bytes of the same field to an
+// offset into the blob.
+type domainNode struct {
+	label  [6]byte
+	length uint8
+	flags  uint8
+}
+
+const domainInlineLabel = 6
+
 const (
-	ruleExact   uint8 = 1 << iota // domain.com, the name itself
-	ruleApexSub                   // .domain.com, the name and everything under it
-	ruleSubOnly                   // *.domain.com, everything under it but not itself
+	ruleExact       uint8 = 1 << iota // domain.com, the name itself
+	ruleApexSub                       // .domain.com, the name and everything under it
+	ruleSubOnly                       // *.domain.com, everything under it but not itself
+	ruleHasChildren                   // more specific rules sit below this node
 )
 
 // The longest name that can arrive in a query. Presentation-format names can
@@ -64,7 +83,7 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 	if err != nil {
 		return nil, err
 	}
-	root := new(domainNode)
+	b := newDomainBuilder(len(rules))
 	for _, r := range rules {
 		// Strip a trailing dot in case the list holds FQDNs, and force the
 		// rule to lower case since queries are matched in lower case.
@@ -76,6 +95,13 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 		// A bare wildcard only ever applied to the labels under it, of which
 		// there are none here, so it's not an error, just nothing to record.
 		if r == "*" {
+			continue
+		}
+
+		// Lists carry comment lines and other noise, and a name with a label
+		// over the DNS limit could never be queried anyway, so such a rule is
+		// skipped rather than failing the list it came in.
+		if hasOverlongLabel(r) {
 			continue
 		}
 
@@ -94,7 +120,7 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 		}
 
 		// Walk the labels from the TLD inwards, building the path as needed.
-		n := root
+		n := uint32(0)
 		end := len(r)
 		for {
 			i := strings.LastIndexByte(r[:end], '.')
@@ -105,25 +131,18 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 			if strings.Contains(label, "*") {
 				return nil, fmt.Errorf("invalid blocklist item: '%s'", label)
 			}
-			child, ok := n.children[label]
-			if !ok {
-				child = new(domainNode)
-				if n.children == nil {
-					n.children = make(map[string]*domainNode)
-				}
-				// Cloned so the node doesn't pin the whole rule line, which
-				// is a slice of the same backing array.
-				n.children[strings.Clone(label)] = child
+			n, err = b.child(n, label)
+			if err != nil {
+				return nil, err
 			}
-			n = child
 			if i <= 0 {
 				break
 			}
 			end = i
 		}
-		n.flags |= flag
+		b.nodes[n].flags |= flag
 	}
-	return &DomainDB{name, root, loader, includeSubdomains}, nil
+	return &DomainDB{name, b.done(), loader, includeSubdomains}, nil
 }
 
 func (m *DomainDB) Reload() (BlocklistDB, error) {
@@ -145,27 +164,29 @@ func (m *DomainDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, boo
 // match walks the labels of a lower-cased query name from the TLD inwards,
 // stopping at the first rule that covers it.
 func (m *DomainDB) match(name []byte) ([]net.IP, []string, *BlocklistMatch, bool) {
-	n := m.root
+	node := uint32(0)
+	flags := m.trie.nodes[0].flags
 	end := len(name)
 	for end > 0 {
+		if flags&ruleHasChildren == 0 {
+			return nil, nil, nil, false // nothing more specific exists
+		}
 		i := bytes.LastIndexByte(name[:end], '.')
-
-		// Indexing a map with a string conversion of a byte slice doesn't
-		// allocate, so a query that doesn't match costs nothing on the heap.
-		child, ok := n.children[string(name[i+1:end])]
+		child, ok := trieFind(&m.trie, node, name[i+1:end])
 		if !ok {
 			return nil, nil, nil, false
 		}
-		if child.flags&ruleApexSub != 0 {
+		flags = m.trie.nodes[child].flags
+		if flags&ruleApexSub != 0 {
 			return nil, nil, m.matched(".", name[i+1:]), true
 		}
-		if child.flags&ruleSubOnly != 0 && i > 0 { // only if a label remains to the left
+		if flags&ruleSubOnly != 0 && i > 0 { // only if a label remains to the left
 			return nil, nil, m.matched("*.", name[i+1:]), true
 		}
-		n = child
+		node = child
 		end = i
 	}
-	if n.flags&ruleExact != 0 {
+	if flags&ruleExact != 0 {
 		return nil, nil, m.matched("", name), true
 	}
 	return nil, nil, nil, false
@@ -183,6 +204,21 @@ func (m *DomainDB) matched(prefix string, name []byte) *BlocklistMatch {
 
 func (m *DomainDB) String() string {
 	return "Domain"
+}
+
+// hasOverlongLabel reports whether any label of the rule is longer than a
+// domain label may be.
+func hasOverlongLabel(r string) bool {
+	for {
+		i := strings.IndexByte(r, '.')
+		if i < 0 {
+			return len(r) > maxDomainLabel
+		}
+		if i > maxDomainLabel {
+			return true
+		}
+		r = r[i+1:]
+	}
 }
 
 // lowerASCII copies name into b, lower-cased. Domain names are ASCII, so

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -401,3 +401,112 @@ func BenchmarkDomainDBBuild(b *testing.B) {
 		})
 	}
 }
+
+// TestDomainDBLabelStorage covers the two ways a label is stored, in the node
+// itself or in the blob, either side of the boundary between them, and rules
+// that no valid query could reach.
+func TestDomainDBLabelStorage(t *testing.T) {
+	short := strings.Repeat("a", domainInlineLabel)   // stored in the node
+	long := strings.Repeat("b", domainInlineLabel+1)  // stored in the blob
+	longest := strings.Repeat("c", maxDomainLabel)    // the longest allowed
+	overlong := strings.Repeat("d", maxDomainLabel+1) // longer than any query
+
+	rules := []string{
+		short + ".com",
+		long + ".com",
+		longest + ".com",
+		overlong + ".com",                // skipped, unreachable
+		"# Comment line, as lists carry", // skipped, no label could be queried
+		"sub." + long + ".net",
+		"." + long + ".net",
+	}
+	m, err := NewDomainDB("testlist", NewStaticLoader(rules))
+	require.NoError(t, err)
+
+	tests := []struct {
+		q     string
+		match bool
+	}{
+		{short + ".com.", true},
+		{long + ".com.", true},
+		{longest + ".com.", true},
+		{overlong + ".com.", false},
+		{strings.Repeat("d", maxDomainLabel) + ".com.", false},
+		{short + "a.com.", false}, // one byte longer than a rule
+		{long[:domainInlineLabel] + ".com.", false},
+		{"sub." + long + ".net.", true},
+		{"other." + long + ".net.", true}, // covered by the .prefix rule
+	}
+	for _, test := range tests {
+		msg := new(dns.Msg)
+		msg.SetQuestion(test.q, dns.TypeA)
+		_, _, _, ok := m.Match(msg)
+		require.Equal(t, test.match, ok, "query: %s", test.q)
+	}
+}
+
+// TestDomainDBGrowth loads enough rules to rebuild the lookup table several
+// times over, and checks every one of them still matches afterwards.
+func TestDomainDBGrowth(t *testing.T) {
+	rules := generateDomainRules(20000)
+	parsed := parseDomainRules(rules, false)
+	m, err := NewDomainDB("testlist", NewStaticLoader(rules))
+	require.NoError(t, err)
+
+	msg := new(dns.Msg)
+	for _, p := range parsed {
+		q := p.domain
+		if !p.apex { // a sub-domains-only rule needs one to match
+			q = "www." + q
+		}
+		msg.SetQuestion(dns.Fqdn(q), dns.TypeA)
+		_, _, _, ok := m.Match(msg)
+		require.True(t, ok, "rule %q, query %q", p.reported, q)
+	}
+}
+
+func TestDomainDBEmpty(t *testing.T) {
+	m, err := NewDomainDB("testlist", NewStaticLoader(nil))
+	require.NoError(t, err)
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+	_, _, match, ok := m.Match(msg)
+	require.False(t, ok)
+	require.Nil(t, match)
+}
+
+// TestDomainDBSharedLabels covers the same label sitting under several parents,
+// which the lookup table has to keep apart.
+func TestDomainDBSharedLabels(t *testing.T) {
+	rules := []string{
+		"www.one.com",
+		".www.two.com",
+		"*.www.three.com",
+		"www.four.net",
+		"deep.www.one.com",
+	}
+	m, err := NewDomainDB("testlist", NewStaticLoader(rules))
+	require.NoError(t, err)
+
+	tests := []struct {
+		q     string
+		match bool
+	}{
+		{"www.one.com.", true},
+		{"www.two.com.", true},
+		{"www.three.com.", false}, // wildcard covers sub-domains only
+		{"sub.www.three.com.", true},
+		{"www.four.net.", true},
+		{"deep.www.one.com.", true},
+		{"www.four.com.", false}, // right labels, wrong parents
+		{"www.one.net.", false},
+		{"www.five.com.", false},
+		{"deep.www.four.net.", false},
+	}
+	for _, test := range tests {
+		msg := new(dns.Msg)
+		msg.SetQuestion(test.q, dns.TypeA)
+		_, _, _, ok := m.Match(msg)
+		require.Equal(t, test.match, ok, "query: %s", test.q)
+	}
+}


### PR DESCRIPTION
The trie is a map per node: a map entry per label plus the node object it
points at, and a pointer for the collector to chase for every one of them. A
list of two million rules costs 167 MB across 3.8 million objects, and marking
them takes 162 ms of every collection.

The same trie becomes three flat pieces. A node is 8 bytes in one array,
carrying its flags and its label, or for a label over six bytes an offset into
one shared blob. One open-addressed table maps a node and a label to the child
below it, each slot packing the parent, the child and a byte of the hash into a
single word. A slot is accepted only once both the parent and the label match
what was asked for, neither of which the hash stands in for, so a hash
collision costs a comparison rather than a wrong answer; the byte of hash is
there to settle most mismatches without reading a label at all. A node index is
28 bits wide, which caps a list at 268 million labels and is reported rather
than silently wrapped. None of it holds a pointer, so the whole structure is
three objects to mark whatever the list size.

### Measured

hagezi's ultimate list at 274k rules and a 2M rule NRD-style list, against the
map trie this replaces:

| list | retained | GC mark | build |
| --- | --- | --- | --- |
| ultimate, 274k rules | 41.2 -> 11.1 MB | 17.8 -> 0.5 ms | 253 -> 227 ms |
| NRD-style, 2M rules | 166.9 -> 72.3 MB | 162 -> 1.2 ms | 2.99 -> 1.31 s |

Lookups come out the same, within noise in both directions, since the walk is
unchanged and that is where the time goes. Building is quicker because the
rules go straight into the arrays rather than into a map per node first.

The table is kept two thirds full rather than five sixths. Linear probing
degrades sharply as a table fills, and the difference is worth more than the
slots it costs: a matching query against a hundred thousand rules ran in 276 ns
at five sixths and 216 ns at two thirds, for 0.8 MB more.

### Behaviour

Rules that no query could reach are skipped rather than rejected. A label
longer than the 63 bytes a domain label may carry cannot appear in a query, and
the comment lines blocklists carry parse as exactly that, so failing the list
over one would take down every rule in it.

### Tests

Matching was compared against the implementation this replaces over 12.9
million queries drawn from three real lists: the apex, a sub-domain, a deeper
sub-domain, the parent and the upper-case form of every rule, along with names
on no list at all, reading the files as a config would, comment lines included.
Verdicts and reported rule strings are identical throughout.

The new tests cover the two ways a label is stored on either side of the
boundary between them, the same label under several parents, rules too long for
any query to reach, a list large enough to rebuild the lookup table several
times over, and an empty list.