### PR TITLE
Add compact domain blocklist formats

### DIFF
--- a/blocklistdb-domain-compact.go
+++ b/blocklistdb-domain-compact.go
@@ -1,0 +1,264 @@
+package rdns
+
+import (
+	"bytes"
+	"math/rand"
+	"net"
+	"slices"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// DomainCompactDB matches the same rules as DomainDB, in the same way, but
+// stores them as fingerprints rather than as labels. It holds one 8 byte entry
+// per node of the trie DomainDB would build and no label bytes at all, which is
+// around a quarter of the memory.
+//
+// What that costs is a name nobody listed whose fingerprint equals one that is,
+// which is then answered as though a rule covered it. With 60 bits of
+// fingerprint the odds are the entry count over 2^60 for each label looked up,
+// so about one query in 800 billion against a 274k rule list and one in 140
+// billion against a 2M rule one. A name that is on the list can never be
+// missed, since it always hashes to its own entry and entries only gain flags.
+// The seed changes on every load, so a collision does not survive a refresh
+// and cannot be arranged in advance. See doc/blocklists.md for the rarer case
+// where the node that collides is one queries pass through rather than end on.
+//
+// The rule syntax and the matching are exactly DomainDB's, see there.
+type DomainCompactDB struct {
+	name              string
+	fingerprints      domainFingerprints
+	loader            BlocklistLoader
+	includeSubdomains bool
+}
+
+// domainFingerprints is one entry per node, holding a fingerprint of the suffix
+// that node stands for and the flags of the rules that end on it. Entries are
+// sorted, and an index over the top bits of the fingerprint says where each
+// bucket of them starts, so a lookup reads the index and then, almost always, a
+// single cache line of entries.
+//
+// Nothing here is a pointer and no labels are kept, so the whole database is
+// two objects for the garbage collector whatever the list holds.
+type domainFingerprints struct {
+	entries []uint64 // fingerprint<<4 | flags, ascending
+	index   []uint32 // bucket -> first entry
+	shift   uint     // fingerprint >> shift = bucket
+	seed    uint64   // per build, so a collision is not the same twice
+}
+
+// The flags live in the low four bits of an entry, leaving 60 for the
+// fingerprint.
+const (
+	domainFlagBits = 4
+	domainFlagMask = 1<<domainFlagBits - 1
+)
+
+var _ BlocklistDB = &DomainCompactDB{}
+
+// NewDomainCompactDB returns a matcher for a list of domain rules that trades
+// exactness for memory. See DomainCompactDB.
+func NewDomainCompactDB(name string, loader BlocklistLoader) (*DomainCompactDB, error) {
+	return newDomainCompactDB(name, loader, false)
+}
+
+// NewDomainSubdomainCompactDB is like NewDomainCompactDB but treats bare
+// entries as matching the apex and all sub-domains, as NewDomainSubdomainDB
+// does.
+func NewDomainSubdomainCompactDB(name string, loader BlocklistLoader) (*DomainCompactDB, error) {
+	return newDomainCompactDB(name, loader, true)
+}
+
+func newDomainCompactDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainCompactDB, error) {
+	rules, err := loader.Load()
+	if err != nil {
+		return nil, err
+	}
+	f := domainFingerprints{seed: rand.Uint64()}
+
+	// With the repeats below dropped a list appends a little over one entry per
+	// rule, so start there with room to spare: growing the slice means holding
+	// the old one and the new one at once, which is where a build peaks.
+	entries := make([]uint64, 0, len(rules)+len(rules)/4)
+	recent := new(domainRecent)
+	err = domainRules(rules, includeSubdomains, func(domain string, flag uint8) error {
+		// Walk the labels from the TLD inwards, hashing each suffix as it goes.
+		// Every node above the last one has a child by definition, which is
+		// what lets a query stop as soon as it reaches a node without one.
+		h := f.seed
+		end := len(domain)
+		for {
+			i := strings.LastIndexByte(domain[:end], '.')
+			h = domainSuffixHash(h, domain[i+1:end])
+			e := domainEntry(h, ruleHasChildren)
+			if i <= 0 {
+				e = domainEntry(h, flag)
+			}
+			if !recent.seen(e) {
+				entries = append(entries, e)
+			}
+			if i <= 0 {
+				break
+			}
+			end = i
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	f.build(entries)
+	return &DomainCompactDB{name, f, loader, includeSubdomains}, nil
+}
+
+func (m *DomainCompactDB) Reload() (BlocklistDB, error) {
+	return newDomainCompactDB(m.name, m.loader, m.includeSubdomains)
+}
+
+func (m *DomainCompactDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
+	var buf [maxDomainName]byte
+	return m.match(domainQueryName(msg, buf[:]))
+}
+
+// match walks the labels of a lower-cased query name from the TLD inwards,
+// stopping at the first rule that covers it, exactly as DomainDB does. The
+// difference is only in what identifies a node: the hash of the suffix so far
+// rather than an index into an array of them.
+func (m *DomainCompactDB) match(name []byte) ([]net.IP, []string, *BlocklistMatch, bool) {
+	h := m.fingerprints.seed
+	flags := m.fingerprints.rootFlags()
+	end := len(name)
+	for end > 0 {
+		if flags&ruleHasChildren == 0 {
+			return nil, nil, nil, false // nothing more specific exists
+		}
+		i := bytes.LastIndexByte(name[:end], '.')
+		h = domainSuffixHash(h, name[i+1:end])
+		var ok bool
+		flags, ok = m.fingerprints.find(h)
+		if !ok {
+			return nil, nil, nil, false
+		}
+		if prefix, ok := domainRuleAt(flags, i > 0); ok {
+			return nil, nil, domainMatched(m.name, prefix, name[i+1:]), true
+		}
+		end = i
+	}
+	if flags&ruleExact != 0 {
+		return nil, nil, domainMatched(m.name, "", name), true
+	}
+	return nil, nil, nil, false
+}
+
+func (m *DomainCompactDB) String() string {
+	return "Domain-Compact"
+}
+
+// Half of what a build appends is a node some earlier rule already recorded,
+// and the busiest of those are the handful of top level domains that every rule
+// passes through: a two million rule list walks over "com" a million times.
+// domainRecent is a direct-mapped cache of the entries just written, which
+// catches most of those before they reach the slice that has to be sorted.
+// Dropping a repeat is always safe, since entries carrying the same flags merge
+// into one and a second copy adds nothing.
+type domainRecent [1 << 12]uint64
+
+// seen reports whether entry was written recently, and records it if not. An
+// entry always carries at least one flag, so it is never zero and an untouched
+// slot cannot look like a hit.
+func (r *domainRecent) seen(entry uint64) bool {
+	slot := &r[entry>>domainFlagBits&uint64(len(r)-1)]
+	if *slot == entry {
+		return true
+	}
+	*slot = entry
+	return false
+}
+
+// domainSuffixHash folds one more label into the hash of the suffix to its
+// right. The separator keeps "ab.c" apart from "a.bc".
+func domainSuffixHash[T labelText](h uint64, label T) uint64 {
+	for i := 0; i < len(label); i++ {
+		h ^= uint64(label[i])
+		h *= fnvPrime64
+	}
+	h ^= '.'
+	return h * fnvPrime64
+}
+
+// domainEntry is the stored form of a node: the avalanched hash of its suffix
+// with the flags in the bits the fingerprint gives up.
+func domainEntry(h uint64, flags uint8) uint64 {
+	return avalanche64(h)>>domainFlagBits<<domainFlagBits | uint64(flags)
+}
+
+// build sorts the entries, merges the ones that describe the same node, and
+// indexes them by the top bits of their fingerprint.
+func (f *domainFingerprints) build(entries []uint64) {
+	slices.Sort(entries)
+
+	// A node is recorded once per rule that passes through it, so the same
+	// fingerprint arrives many times over. Fold those into one entry holding
+	// every flag they carried.
+	merged := entries[:0]
+	for _, e := range entries {
+		if n := len(merged); n > 0 && merged[n-1]>>domainFlagBits == e>>domainFlagBits {
+			merged[n-1] |= e & domainFlagMask
+			continue
+		}
+		merged = append(merged, e)
+	}
+	// Clone rather than keep the slice the unmerged entries were appended to,
+	// which is twice the size the merged ones need.
+	f.entries = slices.Clone(merged)
+
+	// Aim for eight entries per bucket, which is one cache line of them.
+	buckets := 8
+	for buckets*8 < len(f.entries) {
+		buckets <<= 1
+	}
+	f.shift = 64 - domainBucketBits(buckets)
+	f.index = make([]uint32, buckets+1)
+	e := 0
+	for b := range buckets {
+		f.index[b] = uint32(e)
+		for e < len(f.entries) && int(f.entries[e]>>f.shift) == b {
+			e++
+		}
+	}
+	f.index[buckets] = uint32(len(f.entries))
+}
+
+func domainBucketBits(buckets int) uint {
+	var bits uint
+	for 1<<bits < buckets {
+		bits++
+	}
+	return bits
+}
+
+// rootFlags says whether the list holds anything at all, in the same shape the
+// walk reads every other node in.
+func (f *domainFingerprints) rootFlags() uint8 {
+	if len(f.entries) == 0 {
+		return 0
+	}
+	return ruleHasChildren
+}
+
+// find returns the flags recorded for a suffix, and whether it is on the list.
+func (f *domainFingerprints) find(h uint64) (uint8, bool) {
+	want := domainEntry(h, 0)
+	bucket := want >> f.shift
+	for i := f.index[bucket]; i < f.index[bucket+1]; i++ {
+		e := f.entries[i]
+		switch {
+		case e&^domainFlagMask == want:
+			return uint8(e) & domainFlagMask, true
+		case e > want:
+			return 0, false // entries are sorted, it cannot be further on
+		}
+	}
+	return 0, false
+}

--- a/blocklistdb-domain-compact_test.go
+++ b/blocklistdb-domain-compact_test.go
@@ -1,0 +1,108 @@
+package rdns
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDomainCompactMatchesExact runs a generated list through both storage
+// formats and requires the same answer from each, rule string included. The
+// exact matcher is the oracle: a difference is either a bug or one of the
+// fingerprint collisions the compact format trades exactness for, and at this
+// size those are a once in ten billion event.
+func TestDomainCompactMatchesExact(t *testing.T) {
+	for _, includeSubdomains := range []bool{false, true} {
+		rules := generateDomainRules(20000)
+		loader := NewStaticLoader(rules)
+		exact, err := newDomainDB("testlist", loader, includeSubdomains)
+		require.NoError(t, err)
+		compact, err := newDomainCompactDB("testlist", loader, includeSubdomains)
+		require.NoError(t, err)
+
+		var queries []string
+		for _, p := range parseDomainRules(rules, includeSubdomains) {
+			queries = append(queries, p.domain, "www."+p.domain, "a.b."+p.domain)
+			if i := strings.IndexByte(p.domain, '.'); i > 0 {
+				queries = append(queries, p.domain[i+1:])
+			}
+		}
+		for i := 0; i < 20000; i++ {
+			queries = append(queries, fmt.Sprintf("unlisted%d.example.net", i))
+		}
+
+		msg := new(dns.Msg)
+		for _, q := range queries {
+			msg.SetQuestion(dns.Fqdn(q), dns.TypeA)
+			_, _, wantMatch, want := exact.Match(msg)
+			_, _, gotMatch, got := compact.Match(msg)
+			require.Equal(t, want, got, "subdomain-mode=%v query=%s", includeSubdomains, q)
+			require.Equal(t, wantMatch.GetRule(), gotMatch.GetRule(), "query=%s", q)
+		}
+	}
+}
+
+// TestDomainCompactSeeded checks that two databases built from the same rules
+// hash them differently, which is what keeps a colliding name from being worth
+// computing in advance, while answering identically.
+func TestDomainCompactSeeded(t *testing.T) {
+	rules := generateDomainRules(1000)
+	loader := NewStaticLoader(rules)
+	first, err := newDomainCompactDB("testlist", loader, false)
+	require.NoError(t, err)
+	second, err := newDomainCompactDB("testlist", loader, false)
+	require.NoError(t, err)
+	require.NotEqual(t, first.fingerprints.seed, second.fingerprints.seed)
+	require.NotEqual(t, first.fingerprints.entries, second.fingerprints.entries)
+
+	msg := new(dns.Msg)
+	for _, p := range parseDomainRules(rules, false) {
+		q := p.domain
+		if !p.apex {
+			q = "www." + q
+		}
+		msg.SetQuestion(dns.Fqdn(q), dns.TypeA)
+		_, _, _, one := first.Match(msg)
+		_, _, _, two := second.Match(msg)
+		require.True(t, one, "query %s", q)
+		require.Equal(t, one, two)
+	}
+}
+
+func BenchmarkDomainCompactMatch(b *testing.B) {
+	for _, n := range []int{1000, 100000} {
+		rules := generateDomainRules(n)
+		db, err := newDomainCompactDB("testlist", NewStaticLoader(rules), false)
+		require.NoError(b, err)
+
+		hit := "www." + strings.TrimPrefix(strings.TrimPrefix(rules[len(rules)-1], "*."), ".")
+		for _, q := range []string{hit, "www.example.com", "WWW.ExAmPlE.CoM"} {
+			b.Run(fmt.Sprintf("rules=%d/name=%s", n, q), func(b *testing.B) {
+				msg := new(dns.Msg)
+				msg.SetQuestion(dns.Fqdn(q), dns.TypeA)
+				b.ReportAllocs()
+				for b.Loop() {
+					_, _, _, _ = db.Match(msg)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkDomainCompactBuild(b *testing.B) {
+	for _, n := range []int{10000, 100000} {
+		rules := generateDomainRules(n)
+		loader := NewStaticLoader(rules)
+		b.Run(fmt.Sprintf("rules=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := newDomainCompactDB("testlist", loader, false); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -35,7 +35,7 @@ type DomainDB struct {
 type domainTrie struct {
 	nodes []domainNode
 	blob  []byte
-	slots []uint64 // tag<<32 | node index, zero when empty
+	slots []uint64 // parent, child and a tag byte, zero when empty
 }
 
 // A node carries its label and the rules that end on it. All three rule shapes
@@ -84,6 +84,35 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 		return nil, err
 	}
 	b := newDomainBuilder(len(rules))
+	err = domainRules(rules, includeSubdomains, func(domain string, flag uint8) error {
+		// Walk the labels from the TLD inwards, building the path as needed.
+		n := uint32(0)
+		end := len(domain)
+		for {
+			i := strings.LastIndexByte(domain[:end], '.')
+			child, err := b.child(n, domain[i+1:end])
+			if err != nil {
+				return err
+			}
+			n = child
+			if i <= 0 {
+				break
+			}
+			end = i
+		}
+		b.nodes[n].flags |= flag
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &DomainDB{name, b.done(), loader, includeSubdomains}, nil
+}
+
+// domainRules interprets the rules of a list, handing each one to record as the
+// domain it applies to and the flag it sets there. Both storage formats build
+// from this, so the syntax is read in one place.
+func domainRules(rules []string, includeSubdomains bool, record func(domain string, flag uint8) error) error {
 	for _, r := range rules {
 		// Strip a trailing dot in case the list holds FQDNs, and force the
 		// rule to lower case since queries are matched in lower case.
@@ -119,30 +148,24 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 			flag = ruleApexSub
 		}
 
-		// Walk the labels from the TLD inwards, building the path as needed.
-		n := uint32(0)
-		end := len(r)
-		for {
-			i := strings.LastIndexByte(r[:end], '.')
-			label := r[i+1 : end]
-
-			// Wildcards are only valid as the whole first label, which the
-			// prefix above has already taken off.
-			if strings.Contains(label, "*") {
-				return nil, fmt.Errorf("invalid blocklist item: '%s'", label)
+		// Wildcards are only valid as the whole first label, which the prefix
+		// above has already taken off.
+		if i := strings.IndexByte(r, '*'); i >= 0 {
+			start := strings.LastIndexByte(r[:i], '.') + 1
+			end := strings.IndexByte(r[i:], '.')
+			if end < 0 {
+				end = len(r)
+			} else {
+				end += i
 			}
-			n, err = b.child(n, label)
-			if err != nil {
-				return nil, err
-			}
-			if i <= 0 {
-				break
-			}
-			end = i
+			return fmt.Errorf("invalid blocklist item: '%s'", r[start:end])
 		}
-		b.nodes[n].flags |= flag
+
+		if err := record(r, flag); err != nil {
+			return err
+		}
 	}
-	return &DomainDB{name, b.done(), loader, includeSubdomains}, nil
+	return nil
 }
 
 func (m *DomainDB) Reload() (BlocklistDB, error) {
@@ -150,15 +173,20 @@ func (m *DomainDB) Reload() (BlocklistDB, error) {
 }
 
 func (m *DomainDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {
-	name := strings.TrimSuffix(msg.Question[0].Name, ".")
-
-	// Lower-cased into a stack buffer, so the mixed-case names 0x20 encoding
-	// produces don't cost an allocation like strings.ToLower would.
 	var buf [maxDomainName]byte
+	return m.match(domainQueryName(msg, buf[:]))
+}
+
+// domainQueryName returns the name a query asks about, lower-cased and without
+// its trailing dot, copied into buf when it fits. Names that fit cost no
+// allocation, including the mixed-case ones 0x20 encoding produces, which
+// strings.ToLower would allocate for.
+func domainQueryName(msg *dns.Msg, buf []byte) []byte {
+	name := strings.TrimSuffix(msg.Question[0].Name, ".")
 	if len(name) <= len(buf) {
-		return m.match(lowerASCII(buf[:len(name)], name))
+		return lowerASCII(buf[:len(name)], name)
 	}
-	return m.match([]byte(strings.ToLower(name)))
+	return []byte(strings.ToLower(name))
 }
 
 // match walks the labels of a lower-cased query name from the TLD inwards,
@@ -177,29 +205,40 @@ func (m *DomainDB) match(name []byte) ([]net.IP, []string, *BlocklistMatch, bool
 			return nil, nil, nil, false
 		}
 		flags = m.trie.nodes[child].flags
-		if flags&ruleApexSub != 0 {
-			return nil, nil, m.matched(".", name[i+1:]), true
-		}
-		if flags&ruleSubOnly != 0 && i > 0 { // only if a label remains to the left
-			return nil, nil, m.matched("*.", name[i+1:]), true
+		if prefix, ok := domainRuleAt(flags, i > 0); ok {
+			return nil, nil, domainMatched(m.name, prefix, name[i+1:]), true
 		}
 		node = child
 		end = i
 	}
 	if flags&ruleExact != 0 {
-		return nil, nil, m.matched("", name), true
+		return nil, nil, domainMatched(m.name, "", name), true
 	}
 	return nil, nil, nil, false
 }
 
-// matched reports the rule that matched, rebuilt from the part of the query
-// name it matched on.
-func (m *DomainDB) matched(prefix string, name []byte) *BlocklistMatch {
+// domainRuleAt reports whether the rules recorded on a node cover a query that
+// has walked down to it, and with what prefix the rule is written. more says
+// whether the query still has labels to the left of this node, which is what
+// separates a wildcard rule from an apex one.
+func domainRuleAt(flags uint8, more bool) (string, bool) {
+	if flags&ruleApexSub != 0 { // .domain.com
+		return ".", true
+	}
+	if flags&ruleSubOnly != 0 && more { // *.domain.com
+		return "*.", true
+	}
+	return "", false
+}
+
+// domainMatched reports the rule that matched, rebuilt from the part of the
+// query name it matched on.
+func domainMatched(list, prefix string, name []byte) *BlocklistMatch {
 	var b strings.Builder
 	b.Grow(len(prefix) + len(name))
 	b.WriteString(prefix)
 	b.Write(name)
-	return &BlocklistMatch{List: m.name, Rule: b.String()}
+	return &BlocklistMatch{List: list, Rule: b.String()}
 }
 
 func (m *DomainDB) String() string {

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -10,6 +10,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// domainFormats builds a rule list in both storage formats. Everything the
+// tables in this file assert about matching has to hold for either of them,
+// so they run against both.
+func domainFormats(t *testing.T, rules []string, includeSubdomains bool) map[string]BlocklistDB {
+	t.Helper()
+	loader := NewStaticLoader(rules)
+	exact, err := newDomainDB("testlist", loader, includeSubdomains)
+	require.NoError(t, err)
+	compact, err := newDomainCompactDB("testlist", loader, includeSubdomains)
+	require.NoError(t, err)
+	return map[string]BlocklistDB{"exact": exact, "compact": compact}
+}
+
 func TestDomainDB(t *testing.T) {
 	loader := NewStaticLoader([]string{
 		"domain1.com.",    // exact match
@@ -21,9 +34,6 @@ func TestDomainDB(t *testing.T) {
 		".domain4.com",
 		".DOMAIN5.com",
 	})
-
-	m, err := NewDomainDB("testlist", loader)
-	require.NoError(t, err)
 
 	tests := []struct {
 		q     string
@@ -55,12 +65,16 @@ func TestDomainDB(t *testing.T) {
 		// match capital blocklist item
 		{"domain5.com.", true},
 	}
-	for _, test := range tests {
-		msg := new(dns.Msg)
-		msg.SetQuestion(test.q, dns.TypeA)
+	for format, m := range domainFormats(t, loader.rules, false) {
+		t.Run(format, func(t *testing.T) {
+			for _, test := range tests {
+				msg := new(dns.Msg)
+				msg.SetQuestion(test.q, dns.TypeA)
 
-		_, _, _, ok := m.Match(msg)
-		require.Equal(t, test.match, ok, "query: %s", test.q)
+				_, _, _, ok := m.Match(msg)
+				require.Equal(t, test.match, ok, "query: %s", test.q)
+			}
+		})
 	}
 }
 
@@ -155,13 +169,15 @@ func TestDomainDBOverlap(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m, err := NewDomainDB("testlist", NewStaticLoader(c.rules))
-			require.NoError(t, err)
-			for _, test := range c.tests {
-				msg := new(dns.Msg)
-				msg.SetQuestion(test.q, dns.TypeA)
-				_, _, _, ok := m.Match(msg)
-				require.Equal(t, test.match, ok, "rules=%v query=%s", c.rules, test.q)
+			for format, m := range domainFormats(t, c.rules, false) {
+				t.Run(format, func(t *testing.T) {
+					for _, test := range c.tests {
+						msg := new(dns.Msg)
+						msg.SetQuestion(test.q, dns.TypeA)
+						_, _, _, ok := m.Match(msg)
+						require.Equal(t, test.match, ok, "rules=%v query=%s", c.rules, test.q)
+					}
+				})
 			}
 		})
 	}
@@ -175,9 +191,6 @@ func TestDomainSubdomainDB(t *testing.T) {
 		"DOMAIN4.com",   // capitalized bare entry
 		"trailing.dot.com.",
 	})
-
-	m, err := NewDomainSubdomainDB("testlist", loader)
-	require.NoError(t, err)
 
 	tests := []struct {
 		q     string
@@ -211,12 +224,16 @@ func TestDomainSubdomainDB(t *testing.T) {
 		// capitalized query
 		{"Domain1.com.", true},
 	}
-	for _, test := range tests {
-		msg := new(dns.Msg)
-		msg.SetQuestion(test.q, dns.TypeA)
+	for format, m := range domainFormats(t, loader.rules, true) {
+		t.Run(format, func(t *testing.T) {
+			for _, test := range tests {
+				msg := new(dns.Msg)
+				msg.SetQuestion(test.q, dns.TypeA)
 
-		_, _, _, ok := m.Match(msg)
-		require.Equal(t, test.match, ok, "query: %s", test.q)
+				_, _, _, ok := m.Match(msg)
+				require.Equal(t, test.match, ok, "query: %s", test.q)
+			}
+		})
 	}
 }
 
@@ -231,6 +248,8 @@ func TestDomainSubdomainDBError(t *testing.T) {
 		loader := NewStaticLoader([]string{test.name})
 		_, err := NewDomainSubdomainDB("testlist", loader)
 		require.Error(t, err)
+		_, err = NewDomainSubdomainCompactDB("testlist", loader)
+		require.Error(t, err)
 	}
 }
 
@@ -244,6 +263,8 @@ func TestDomainDBError(t *testing.T) {
 	for _, test := range tests {
 		loader := NewStaticLoader([]string{test.name})
 		_, err := NewDomainDB("testlist", loader)
+		require.Error(t, err)
+		_, err = NewDomainCompactDB("testlist", loader)
 		require.Error(t, err)
 	}
 }
@@ -335,9 +356,6 @@ func TestDomainDBGenerated(t *testing.T) {
 			reported[p.reported] = true
 		}
 
-		db, err := newDomainDB("testlist", NewStaticLoader(rules), includeSubdomains)
-		require.NoError(t, err)
-
 		var queries []string
 		for _, p := range parsed {
 			queries = append(queries, p.domain, "www."+p.domain, "a.b."+p.domain)
@@ -350,17 +368,19 @@ func TestDomainDBGenerated(t *testing.T) {
 		}
 
 		msg := new(dns.Msg)
-		for _, q := range queries {
-			msg.SetQuestion(dns.Fqdn(q), dns.TypeA)
-			_, _, match, ok := db.Match(msg)
-			require.Equal(t, referenceDomainMatch(parsed, q), ok,
-				"subdomain-mode=%v query=%s", includeSubdomains, q)
-			if !ok {
-				require.Nil(t, match, "a miss must not build a match")
-				continue
+		for format, db := range domainFormats(t, rules, includeSubdomains) {
+			for _, q := range queries {
+				msg.SetQuestion(dns.Fqdn(q), dns.TypeA)
+				_, _, match, ok := db.Match(msg)
+				require.Equal(t, referenceDomainMatch(parsed, q), ok,
+					"format=%s subdomain-mode=%v query=%s", format, includeSubdomains, q)
+				if !ok {
+					require.Nil(t, match, "a miss must not build a match")
+					continue
+				}
+				require.True(t, reported[match.Rule],
+					"reported rule %q is not one of the rules loaded", match.Rule)
 			}
-			require.True(t, reported[match.Rule],
-				"reported rule %q is not one of the rules loaded", match.Rule)
 		}
 	}
 }
@@ -420,9 +440,6 @@ func TestDomainDBLabelStorage(t *testing.T) {
 		"sub." + long + ".net",
 		"." + long + ".net",
 	}
-	m, err := NewDomainDB("testlist", NewStaticLoader(rules))
-	require.NoError(t, err)
-
 	tests := []struct {
 		q     string
 		match bool
@@ -437,11 +454,15 @@ func TestDomainDBLabelStorage(t *testing.T) {
 		{"sub." + long + ".net.", true},
 		{"other." + long + ".net.", true}, // covered by the .prefix rule
 	}
-	for _, test := range tests {
-		msg := new(dns.Msg)
-		msg.SetQuestion(test.q, dns.TypeA)
-		_, _, _, ok := m.Match(msg)
-		require.Equal(t, test.match, ok, "query: %s", test.q)
+	for format, m := range domainFormats(t, rules, false) {
+		t.Run(format, func(t *testing.T) {
+			for _, test := range tests {
+				msg := new(dns.Msg)
+				msg.SetQuestion(test.q, dns.TypeA)
+				_, _, _, ok := m.Match(msg)
+				require.Equal(t, test.match, ok, "query: %s", test.q)
+			}
+		})
 	}
 }
 
@@ -450,29 +471,33 @@ func TestDomainDBLabelStorage(t *testing.T) {
 func TestDomainDBGrowth(t *testing.T) {
 	rules := generateDomainRules(20000)
 	parsed := parseDomainRules(rules, false)
-	m, err := NewDomainDB("testlist", NewStaticLoader(rules))
-	require.NoError(t, err)
 
 	msg := new(dns.Msg)
-	for _, p := range parsed {
-		q := p.domain
-		if !p.apex { // a sub-domains-only rule needs one to match
-			q = "www." + q
-		}
-		msg.SetQuestion(dns.Fqdn(q), dns.TypeA)
-		_, _, _, ok := m.Match(msg)
-		require.True(t, ok, "rule %q, query %q", p.reported, q)
+	for format, m := range domainFormats(t, rules, false) {
+		t.Run(format, func(t *testing.T) {
+			for _, p := range parsed {
+				q := p.domain
+				if !p.apex { // a sub-domains-only rule needs one to match
+					q = "www." + q
+				}
+				msg.SetQuestion(dns.Fqdn(q), dns.TypeA)
+				_, _, _, ok := m.Match(msg)
+				require.True(t, ok, "rule %q, query %q", p.reported, q)
+			}
+		})
 	}
 }
 
 func TestDomainDBEmpty(t *testing.T) {
-	m, err := NewDomainDB("testlist", NewStaticLoader(nil))
-	require.NoError(t, err)
-	msg := new(dns.Msg)
-	msg.SetQuestion("example.com.", dns.TypeA)
-	_, _, match, ok := m.Match(msg)
-	require.False(t, ok)
-	require.Nil(t, match)
+	for format, m := range domainFormats(t, nil, false) {
+		t.Run(format, func(t *testing.T) {
+			msg := new(dns.Msg)
+			msg.SetQuestion("example.com.", dns.TypeA)
+			_, _, match, ok := m.Match(msg)
+			require.False(t, ok)
+			require.Nil(t, match)
+		})
+	}
 }
 
 // TestDomainDBSharedLabels covers the same label sitting under several parents,
@@ -485,9 +510,6 @@ func TestDomainDBSharedLabels(t *testing.T) {
 		"www.four.net",
 		"deep.www.one.com",
 	}
-	m, err := NewDomainDB("testlist", NewStaticLoader(rules))
-	require.NoError(t, err)
-
 	tests := []struct {
 		q     string
 		match bool
@@ -503,10 +525,14 @@ func TestDomainDBSharedLabels(t *testing.T) {
 		{"www.five.com.", false},
 		{"deep.www.four.net.", false},
 	}
-	for _, test := range tests {
-		msg := new(dns.Msg)
-		msg.SetQuestion(test.q, dns.TypeA)
-		_, _, _, ok := m.Match(msg)
-		require.Equal(t, test.match, ok, "query: %s", test.q)
+	for format, m := range domainFormats(t, rules, false) {
+		t.Run(format, func(t *testing.T) {
+			for _, test := range tests {
+				msg := new(dns.Msg)
+				msg.SetQuestion(test.q, dns.TypeA)
+				_, _, _, ok := m.Match(msg)
+				require.Equal(t, test.match, ok, "query: %s", test.q)
+			}
+		})
 	}
 }

--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -149,7 +149,7 @@ type group struct {
 
 	// Blocklist options
 	Blocklist []string // Blocklist rules, only used by "blocklist" type
-	Format    string   // Blocklist input format: "regex", "domain", "hosts", or "mac"
+	Format    string   // Blocklist input format, see newBlocklistDB for the full set
 	Source    string   // Location of external blocklist, can be a local path or remote URL
 	Refresh   int      // Blocklist refresh when using an external source, in seconds
 

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -1213,6 +1213,10 @@ func newBlocklistDB(l list, rules []string) (rdns.BlocklistDB, error) {
 		return rdns.NewDomainDB(name, loader)
 	case "domain-subdomain":
 		return rdns.NewDomainSubdomainDB(name, loader)
+	case "domain-compact":
+		return rdns.NewDomainCompactDB(name, loader)
+	case "domain-subdomain-compact":
+		return rdns.NewDomainSubdomainCompactDB(name, loader)
 	case "hosts":
 		return rdns.NewHostsDB(name, loader)
 	case "mac":

--- a/doc/blocklists.md
+++ b/doc/blocklists.md
@@ -10,7 +10,7 @@
 
 Query blocklists can be added to resolver-chains to prevent further processing of queries (return NXDOMAIN or spoofed IP) or to send queries to different resolvers if the query name matches a rule on the blocklist. A blocklist can have multiple rule-sets, with different formats. In its simplest form, the blocklist has just one upstream resolver and forwards anything that does not match its rules. If a query matches, it'll be answered with NXDOMAIN or a spoofed IP, depending on what blocklist format is used.
 
-The blocklist group supports 5 types of blocklist formats:
+The blocklist group supports 7 types of blocklist formats:
 
 - `regexp` - The entire query string is matched against a list of regular expressions and NXDOMAIN returned if a match is found. See [Syntax](https://github.com/google/re2/wiki/Syntax) for details on what is supported.
 - `domain` - A list of domains with some wildcard capabilities. Also results in an NXDOMAIN. Entries in the list are matched as follows:
@@ -18,12 +18,39 @@ The blocklist group supports 5 types of blocklist formats:
   - `.domain.com` matches domain.com and all sub-domains.
   - `*.domain.com` matches all subdomains but not domain.com. Only one wildcard (at the start of the string) is allowed.
 - `domain-subdomain` - Like `domain`, but bare entries (e.g. `domain.com`) match the apex *and* all sub-domains. `.domain.com` is unchanged. `*.domain.com` still matches sub-domains only and can be used as a per-entry opt-out. Designed for blocklists such as hagezi's "Wildcard Domains" lists where every line is meant to block apex + sub-domains.
+- `domain-compact` - Like `domain`, and `domain-subdomain-compact` like `domain-subdomain`, but storing a fingerprint of each rule rather than the rule itself. Roughly a quarter of the memory, at the cost of a very occasional false match. See [Compact domain formats](#compact-domain-formats).
 - `hosts` - A blocklist in hosts-file format. If a non-zero IP address is provided for a record, the response is spoofed rather than returning NXDOMAIN.
 - `mac` - A blocklist of MAC addresses in the form `01:23:34:ab:bc:de` representing the MAC address of a client. The query is expected to contain the value of the client's MAC in EDNS0 option 65001.
 
 In addition to reading the blocklist rules from the configuration file, routedns supports reading from the local filesystem and from remote servers via HTTP(S). Use the `blocklist-source` property of the blocklist to provide a list of blocklists of different formats, either local files or URLs. The `blocklist-refresh` property can be used to specify a reload-period (in seconds). If no `blocklist-refresh` period is given, the blocklist will only be loaded once at startup. The following example loads a regexp blocklist via HTTP once a day.
 
 To override the blocklist filtering behavior, the properties `allowlist`, `allowlist-format`, `allowlist-source` and `allowlist-refresh` can be used to define inverse filters. They are used just like the equivalent blocklist-options, but are effectively inverting its behavior. A query matching a rule on the allowlist will be passing through the blocklist and not be blocked.
+
+### Compact domain formats
+
+`domain-compact` and `domain-subdomain-compact` accept exactly the same rules as `domain` and `domain-subdomain`, and match them the same way. The difference is that they do not store the rules. Each node of the rule tree is kept as a 60 bit fingerprint of the name it stands for, with the four bits that say what the rule matches packed alongside it, which is 8 bytes per node and no text at all. A 2 million rule list takes about 17 MB instead of about 72 MB, and a 274 thousand rule list about 3 MB instead of 11 MB. Lookups are a little quicker where a query matches and a few percent slower where it does not.
+
+The rule reported in logs is rebuilt from the query name, not read back from the database, which is why the rules themselves are not needed.
+
+Building the database is cheaper as well as the result being smaller, which matters on a device where the peak during a list refresh is what runs it out of memory: about 37 MB above the rules themselves for a 2 million rule list, against 209 MB for the exact format.
+
+**What can go wrong.** A name that is on the list can never be missed: it always hashes to its own entry, and an entry only ever gains flags, never loses them. What can happen is the reverse, a name that nobody listed whose fingerprint happens to equal one that is, and it is then treated as though it were on the list.
+
+The chance of that is the number of entries divided by 2^60, per label of the query, since a name is looked up one label at a time and each label is another chance. For a typical three or four label name:
+
+| list size | chance per query | at 100 queries/second | at 1000 queries/second |
+| --- | --- | --- | --- |
+| 274 thousand rules | 1 in 800 billion | one every 260 years | one every 26 years |
+| 2 million rules | 1 in 140 billion | one every 46 years | one every 5 years |
+
+When it does happen, one name that should have resolved is answered as a block instead, exactly as though a rule covered it. It is easy to recognise: the rule named in the log is rebuilt from the query, so it will be a suffix of the queried name that does not appear anywhere in the list.
+
+**How long it lasts.** The fingerprints are seeded afresh every time a list is loaded, so a list with `blocklist-refresh` set loses a collision at the next refresh, and any list loses it on a restart. Without a refresh interval the list is built once at startup, so a collision lasts as long as the process does. The same seeding is what stops a colliding name from being worked out in advance by someone who wants a particular name blocked.
+
+**The rarer, larger case.** The entries cover every node of the rule tree, including the interior ones a query passes through on its way down, `com` among them. If an interior node collides with a rule that covers sub-domains, everything under that node is blocked rather than a single name. This is much rarer than one wrong name, because there are far fewer interior nodes than rules: on a 274 thousand rule list it takes one build in 56 million for an interior node and one in 6 billion for a whole top-level domain, and on a 2 million rule list, where the interior nodes are only the couple of dozen top-level domains, one build in 30 billion. Two ordinary rules colliding with each other is likelier, one build in 19 million and one in 600 thousand respectively, and only widens what one of the two names blocks.
+
+**Allowlists reverse the consequence.** These formats can be used for `allowlist-format` too, and there a false match does not block a name, it lets one through: a query that no allowlist rule covers bypasses the blocklist. Same odds, opposite direction, so prefer the exact `domain` formats for an allowlist unless memory forces otherwise.
+
 
 ### Configuration
 
@@ -33,11 +60,11 @@ Options:
 
 - `resolvers` - Array of upstream resolvers, only one is supported.
 - `blocklist-resolver` - Alternative resolver for queries matching the blocklist, rather than responding with NXDOMAIN. Optional.
-- `blocklist-format` - The format the blocklist is provided in. Only used if `blocklist-source` is not provided. Can be `regexp`, `domain`, `domain-subdomain`, or `hosts`. Defaults to `regexp`.
+- `blocklist-format` - The format the blocklist is provided in. Only used if `blocklist-source` is not provided. Can be `regexp`, `domain`, `domain-subdomain`, `domain-compact`, `domain-subdomain-compact`, or `hosts`. Defaults to `regexp`.
 - `blocklist-refresh` - Time interval (in seconds) in which external (remote or local) blocklists are reloaded. Optional.
 - `blocklist-source` - An array of blocklists, each with `format`, `source` and optionally `name`.
 - `allowlist-resolver` - Alternative resolver for queries matching the allowlist, rather than forwarding to the default resolver.
-- `allowlist-format` - The format the allowlist is provided in. Only used if `allowlist-source` is not provided. Can be `regexp`, `domain`, `domain-subdomain`, or `hosts`. Defaults to the value of `blocklist-format`, which is itself `regexp` by default.
+- `allowlist-format` - The format the allowlist is provided in. Only used if `allowlist-source` is not provided. Can be `regexp`, `domain`, `domain-subdomain`, `domain-compact`, `domain-subdomain-compact`, or `hosts`. Defaults to the value of `blocklist-format`, which is itself `regexp` by default.
 - `allowlist-refresh` - Time interval (in seconds) in which external allowlists are reloaded. Optional.
 - `allowlist-source` - An array of allowlists, each with `format`, `source`, and optionally `cache-dir` or `allow-failure`.
 - `edns0-ede` - Optional, include an extended error code in the response if it's blocked. Only used when the response is blocked, not when it's spoofed. The value is a struct with two keys, `code` (number) and `text` (string). Possible values for `code` are defined in [rfc8914](https://datatracker.ietf.org/doc/html/rfc8914) while `text` can carry additional information that is displayed by `dig` for example. The `text` value is a template that has access to a number of fields of query to allow customizing the response based on data in the query. See [Templates](templates.md#templates) for details. Simple placeholders in `text` would be `{{ .Question }}` for the question in the query or `{{ .ID }}` to be replaced with the query ID.


### PR DESCRIPTION
A domain blocklist keeps every label of every rule so a match can be verified
exactly. On a router carrying a million-entry list that exactness is worth less
than the memory it costs, and the rule a query matched is rebuilt from the
query itself rather than read back out of the database, so the labels need not
be there at all.

Two new formats, `domain-compact` and `domain-subdomain-compact`, accept the
same rules and match them the same way, but store a 60 bit fingerprint of each
node of the trie instead of its label, with the four rule flags in the bits the
fingerprint gives up. One 8 byte entry per node, sorted, with an index over the
top bits pointing at each bucket of about eight, so a lookup reads the index
and then a single cache line.

### Measured

Against the exact format it sits beside, on hagezi's ultimate list and a 2M
rule NRD-style list:

| list | retained | to build | lookup |
| --- | --- | --- | --- |
| ultimate, 274k rules | 11.1 -> 3.1 MB | 13 -> 9 MB | 0.97x to 1.11x |
| NRD-style, 2M rules | 72.3 -> 16.7 MB | 209 -> 37 MB | 0.92x to 1.33x |

The build column is what the build allocates above the rule list itself, which
on a small device is what a refresh has to fit alongside the database already
serving queries. Build time is the same as the exact format, a little quicker
if anything.

A build appends one entry per label of every rule, sorts them, and folds the
ones describing the same node together by or-ing their flags, so nothing has to
be looked up while the rules are read. Half of what that would append is a node
an earlier rule already recorded, the top level domains most of all since every
rule walks over one, so a small cache of the entries just written drops those
before they reach the slice. That takes a quarter off both the memory a build
needs and the sort at the end of it.

That is 11.2 bytes per rule and 8.4 bytes per rule respectively. Lookups are
1.1x to 1.3x faster where a query matches, since reading a bucket of eight
entries beats walking a probe run to compare a label, and a few percent slower
where it misses. Against the map trie of two releases ago, a two million rule
list now holds 16.7 MB rather than 233 MB.

### What a collision costs, and how likely it is

A name that is on the list can never be missed: it always hashes to its own
entry. What can happen is the reverse, a name nobody listed whose fingerprint
equals one that is, which is then answered as though a rule covered it.

The odds are the number of entries over 2^60 for each label looked up, and a
name is looked up one label at a time, so a three or four label query gets that
many chances:

| list size | chance per query | at 100 queries/second | at 1000 queries/second |
| --- | --- | --- | --- |
| 274 thousand rules | 1 in 800 billion | one every 260 years | one every 26 years |
| 2 million rules | 1 in 140 billion | one every 46 years | one every 5 years |

When it happens, one name that should have resolved is blocked instead. It is
recognisable: the rule named in the log is rebuilt from the query, so it is a
suffix that appears nowhere in the list. How long it lasts depends on the
configuration. The fingerprints are seeded afresh on every load, so a list with
`blocklist-refresh` set loses the collision at the next refresh and any list
loses it on a restart, but a list built once at startup keeps it for the life of
the process. The same seeding means a colliding name cannot be worked out in
advance by someone who wants a particular name blocked.

The entries cover every node of the rule tree, including the interior ones a
query passes through, `com` among them, so the worst case is larger than one
name: an interior node colliding with a rule that covers sub-domains blocks
everything beneath it. That is much rarer, since there are far fewer interior
nodes than rules. On the 274 thousand rule list it takes one build in 56
million for an interior node and one in 6 billion for a whole top-level domain;
on the 2 million rule list, where the interior nodes are just the couple of
dozen top-level domains, one build in 30 billion. Two ordinary rules colliding
is likelier, one build in 19 million and 600 thousand respectively, and only
widens what one of the two names blocks.

The consequence reverses for an allowlist, where a false match does not block a
name but lets one through, bypassing the blocklist. `doc/blocklists.md` says so
and recommends the exact formats there.

### Keeping the two formats honest

The rule syntax is now read in one place, `domainRules`, and what a node's
flags mean to a query standing on it in another, `domainRuleAt`, so the two
formats cannot drift apart in what they accept or in what they match. The
tables that document the semantics run against both formats rather than one.

Matching was also compared against the exact format over 12.9 million queries
drawn from three real lists: the apex, a sub-domain, a deeper sub-domain, the
parent and the upper-case form of every rule, along with names on no list at
all. No disagreement in either the verdict or the reported rule.

