### PR TITLE
Stream blocklist rules instead of holding every line

### DIFF
--- a/asn-db.go
+++ b/asn-db.go
@@ -32,24 +32,23 @@ func NewASNDB(name string, loader BlocklistLoader, geoDBFile string) (*ASNDB, er
 		return nil, fmt.Errorf("failed to open geo asn database file: %w", err)
 	}
 
-	rules, err := loader.Load()
-	if err != nil {
-		return nil, err
-	}
-
 	db := make(map[uint64]struct{})
-	for _, r := range rules {
+	err = loadRules(loader, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
-			continue
+			return nil
 		}
 		r = strings.Split(r, "#")[0] // possible comment at the end of the line
 		r = strings.TrimSpace(r)
 		value, err := strconv.ParseUint(r, 10, 64) // GeoNames ID
 		if err != nil {
-			return nil, fmt.Errorf("unable to parse asn id in rule '%s': %w", r, err)
+			return fmt.Errorf("unable to parse asn id in rule '%s': %w", r, err)
 		}
 		db[value] = struct{}{}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return &ASNDB{
 		name:      name,

--- a/asn-db.go
+++ b/asn-db.go
@@ -65,13 +65,14 @@ func NewASNDB(name string, loader BlocklistLoader, geoDBFile string) (*ASNDB, er
 
 func (m *ASNDB) Reload() (IPBlocklistDB, error) {
 	db, err := NewASNDB(m.name, m.loader, m.geoDBFile)
-	if errors.Is(err, ErrBlocklistUnchanged) {
+	if err != nil {
 		// The list could not be read, so the rules already loaded stand. They
 		// are immutable and shared with the instance carrying them on, but the
 		// map file is opened again so that it has a handle of its own to close.
 		geoDB, oerr := maxminddb.Open(m.geoDBFile)
 		if oerr != nil {
-			return nil, fmt.Errorf("failed to open geo asn database file: %w", oerr)
+			// Without a handle of its own there is nothing to carry them on with.
+			return nil, errors.Join(err, fmt.Errorf("failed to open geo asn database file: %w", oerr))
 		}
 		return &ASNDB{
 			name:      m.name,

--- a/asn-db.go
+++ b/asn-db.go
@@ -33,6 +33,8 @@ func NewASNDB(name string, loader BlocklistLoader, geoDBFile string) (*ASNDB, er
 	}
 
 	db := make(map[uint64]struct{})
+	// The map file is open from here on, so every way out of this function
+	// has to close it.
 	err = loadRules(loader, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
@@ -48,6 +50,7 @@ func NewASNDB(name string, loader BlocklistLoader, geoDBFile string) (*ASNDB, er
 		return nil
 	})
 	if err != nil {
+		geoDB.Close()
 		return nil, err
 	}
 	return &ASNDB{

--- a/asn-db.go
+++ b/asn-db.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -63,7 +64,24 @@ func NewASNDB(name string, loader BlocklistLoader, geoDBFile string) (*ASNDB, er
 }
 
 func (m *ASNDB) Reload() (IPBlocklistDB, error) {
-	return NewASNDB(m.name, m.loader, m.geoDBFile)
+	db, err := NewASNDB(m.name, m.loader, m.geoDBFile)
+	if errors.Is(err, ErrBlocklistUnchanged) {
+		// The list could not be read, so the rules already loaded stand. They
+		// are immutable and shared with the instance carrying them on, but the
+		// map file is opened again so that it has a handle of its own to close.
+		geoDB, oerr := maxminddb.Open(m.geoDBFile)
+		if oerr != nil {
+			return nil, fmt.Errorf("failed to open geo asn database file: %w", oerr)
+		}
+		return &ASNDB{
+			name:      m.name,
+			loader:    m.loader,
+			geoDB:     geoDB,
+			geoDBFile: m.geoDBFile,
+			db:        m.db,
+		}, err
+	}
+	return db, err
 }
 
 func (m *ASNDB) Match(ip net.IP) (*BlocklistMatch, bool) {
@@ -85,23 +103,6 @@ func (m *ASNDB) Match(ip net.IP) (*BlocklistMatch, bool) {
 		}, true
 	}
 	return nil, false
-}
-
-// reuse hands this database to a new group while the group it came from is
-// closed. The rules are immutable and shared, but the map file is opened again
-// so the copy has a handle of its own to close.
-func (m *ASNDB) reuse() (IPBlocklistDB, error) {
-	geoDB, err := maxminddb.Open(m.geoDBFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open geo asn database file: %w", err)
-	}
-	return &ASNDB{
-		name:      m.name,
-		loader:    m.loader,
-		geoDB:     geoDB,
-		geoDBFile: m.geoDBFile,
-		db:        m.db,
-	}, nil
 }
 
 func (m *ASNDB) Close() error {

--- a/asn-db.go
+++ b/asn-db.go
@@ -35,7 +35,7 @@ func NewASNDB(name string, loader BlocklistLoader, geoDBFile string) (*ASNDB, er
 	db := make(map[uint64]struct{})
 	// The map file is open from here on, so every way out of this function
 	// has to close it.
-	err = loadRules(loader, func() { clear(db) }, func(r string) error {
+	err = loadRules(loader, func() { db = make(map[uint64]struct{}) }, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
 			return nil

--- a/asn-db.go
+++ b/asn-db.go
@@ -35,7 +35,7 @@ func NewASNDB(name string, loader BlocklistLoader, geoDBFile string) (*ASNDB, er
 	db := make(map[uint64]struct{})
 	// The map file is open from here on, so every way out of this function
 	// has to close it.
-	err = loadRules(loader, func() { db = make(map[uint64]struct{}) }, func(r string) error {
+	err = loader.Load(func() { db = make(map[uint64]struct{}) }, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
 			return nil

--- a/asn-db.go
+++ b/asn-db.go
@@ -35,7 +35,7 @@ func NewASNDB(name string, loader BlocklistLoader, geoDBFile string) (*ASNDB, er
 	db := make(map[uint64]struct{})
 	// The map file is open from here on, so every way out of this function
 	// has to close it.
-	err = loadRules(loader, func(r string) error {
+	err = loadRules(loader, func() { clear(db) }, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
 			return nil

--- a/asn-db.go
+++ b/asn-db.go
@@ -66,12 +66,10 @@ func NewASNDB(name string, loader BlocklistLoader, geoDBFile string) (*ASNDB, er
 func (m *ASNDB) Reload() (IPBlocklistDB, error) {
 	db, err := NewASNDB(m.name, m.loader, m.geoDBFile)
 	if err != nil {
-		// The list could not be read, so the rules already loaded stand. They
-		// are immutable and shared with the instance carrying them on, but the
-		// map file is opened again so that it has a handle of its own to close.
+		// The rules already loaded stand. They are immutable and shared, but
+		// the map file is opened again for a handle of its own to close.
 		geoDB, oerr := maxminddb.Open(m.geoDBFile)
 		if oerr != nil {
-			// Without a handle of its own there is nothing to carry them on with.
 			return nil, errors.Join(err, fmt.Errorf("failed to open geo asn database file: %w", oerr))
 		}
 		return &ASNDB{

--- a/asn-db.go
+++ b/asn-db.go
@@ -87,6 +87,23 @@ func (m *ASNDB) Match(ip net.IP) (*BlocklistMatch, bool) {
 	return nil, false
 }
 
+// reuse hands this database to a new group while the group it came from is
+// closed. The rules are immutable and shared, but the map file is opened again
+// so the copy has a handle of its own to close.
+func (m *ASNDB) reuse() (IPBlocklistDB, error) {
+	geoDB, err := maxminddb.Open(m.geoDBFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open geo asn database file: %w", err)
+	}
+	return &ASNDB{
+		name:      m.name,
+		loader:    m.loader,
+		geoDB:     geoDB,
+		geoDBFile: m.geoDBFile,
+		db:        m.db,
+	}, nil
+}
+
 func (m *ASNDB) Close() error {
 	return m.geoDB.Close()
 }

--- a/blocklistdb-domain-compact.go
+++ b/blocklistdb-domain-compact.go
@@ -71,18 +71,10 @@ func NewDomainSubdomainCompactDB(name string, loader BlocklistLoader) (*DomainCo
 }
 
 func newDomainCompactDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainCompactDB, error) {
-	rules, err := loader.Load()
-	if err != nil {
-		return nil, err
-	}
 	f := domainFingerprints{seed: rand.Uint64()}
-
-	// With the repeats below dropped a list appends a little over one entry per
-	// rule, so start there with room to spare: growing the slice means holding
-	// the old one and the new one at once, which is where a build peaks.
-	entries := make([]uint64, 0, len(rules)+len(rules)/4)
+	var entries []uint64
 	recent := new(domainRecent)
-	err = domainRules(rules, includeSubdomains, func(domain string, flag uint8) error {
+	err := domainRules(loader, includeSubdomains, func(domain string, flag uint8) error {
 		// Walk the labels from the TLD inwards, hashing each suffix as it goes.
 		// Every node above the last one has a child by definition, which is
 		// what lets a query stop as soon as it reaches a node without one.

--- a/blocklistdb-domain-compact.go
+++ b/blocklistdb-domain-compact.go
@@ -74,7 +74,10 @@ func newDomainCompactDB(name string, loader BlocklistLoader, includeSubdomains b
 	f := domainFingerprints{seed: rand.Uint64()}
 	var entries []uint64
 	recent := new(domainRecent)
-	err := domainRules(loader, includeSubdomains, func(domain string, flag uint8) error {
+	reset := func() {
+		entries, recent = entries[:0], new(domainRecent)
+	}
+	err := domainRules(loader, includeSubdomains, reset, func(domain string, flag uint8) error {
 		// Walk the labels from the TLD inwards, hashing each suffix as it goes.
 		// Every node above the last one has a child by definition, which is
 		// what lets a query stop as soon as it reaches a node without one.

--- a/blocklistdb-domain-compact.go
+++ b/blocklistdb-domain-compact.go
@@ -75,7 +75,10 @@ func newDomainCompactDB(name string, loader BlocklistLoader, includeSubdomains b
 	var entries []uint64
 	recent := new(domainRecent)
 	reset := func() {
-		entries, recent = entries[:0], new(domainRecent)
+		// Not entries[:0]: an empty slice still points at the array behind it,
+		// and so does the clone build makes of it, which would keep every
+		// entry of a list that broke off reachable for good.
+		entries, recent = nil, new(domainRecent)
 	}
 	err := domainRules(loader, includeSubdomains, reset, func(domain string, flag uint8) error {
 		// Walk the labels from the TLD inwards, hashing each suffix as it goes.

--- a/blocklistdb-domain-compact.go
+++ b/blocklistdb-domain-compact.go
@@ -75,9 +75,8 @@ func newDomainCompactDB(name string, loader BlocklistLoader, includeSubdomains b
 	var entries []uint64
 	recent := new(domainRecent)
 	reset := func() {
-		// Not entries[:0]: an empty slice still points at the array behind it,
-		// and so does the clone build makes of it, which would keep every
-		// entry of a list that broke off reachable for good.
+		// Not entries[:0]: it still points at the array behind it, and so
+		// would the clone build makes of it.
 		entries, recent = nil, new(domainRecent)
 	}
 	err := domainRules(loader, includeSubdomains, reset, func(domain string, flag uint8) error {

--- a/blocklistdb-domain-compact.go
+++ b/blocklistdb-domain-compact.go
@@ -60,34 +60,25 @@ var _ BlocklistDB = &DomainCompactDB{}
 // NewDomainCompactDB returns a matcher for a list of domain rules that trades
 // exactness for memory. See DomainCompactDB.
 func NewDomainCompactDB(name string, loader BlocklistLoader) (*DomainCompactDB, error) {
-	return newDomainCompactDB(name, loader, false, 0)
+	return newDomainCompactDB(name, loader, false)
 }
 
 // NewDomainSubdomainCompactDB is like NewDomainCompactDB but treats bare
 // entries as matching the apex and all sub-domains, as NewDomainSubdomainDB
 // does.
 func NewDomainSubdomainCompactDB(name string, loader BlocklistLoader) (*DomainCompactDB, error) {
-	return newDomainCompactDB(name, loader, true, 0)
+	return newDomainCompactDB(name, loader, true)
 }
 
-// nodes is the number of entries the database this one replaces holds, which is
-// what a refresh builds into rather than growing towards. A list is streamed in,
-// so its size is not known up front, and every doubling of the slice copies
-// what is already in it while both halves are held at once. The first build of
-// all has no estimate and grows into what it needs.
-func newDomainCompactDB(name string, loader BlocklistLoader, includeSubdomains bool, nodes int) (*DomainCompactDB, error) {
+func newDomainCompactDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainCompactDB, error) {
 	f := domainFingerprints{seed: rand.Uint64()}
-	// A little over the last count: merging drops the entries a rule shares
-	// with the ones before it, so a build appends a few percent more than it
-	// keeps.
-	sized := func() []uint64 { return make([]uint64, 0, nodes+nodes/8) }
-	entries := sized()
+	var entries []uint64
 	recent := new(domainRecent)
 	reset := func() {
 		// Not entries[:0]: an empty slice still points at the array behind it,
 		// and so does the clone build makes of it, which would keep every
 		// entry of a list that broke off reachable for good.
-		entries, recent = sized(), new(domainRecent)
+		entries, recent = nil, new(domainRecent)
 	}
 	err := domainRules(loader, includeSubdomains, reset, func(domain string, flag uint8) error {
 		// Walk the labels from the TLD inwards, hashing each suffix as it goes.
@@ -120,7 +111,7 @@ func newDomainCompactDB(name string, loader BlocklistLoader, includeSubdomains b
 }
 
 func (m *DomainCompactDB) Reload() (BlocklistDB, error) {
-	return newDomainCompactDB(m.name, m.loader, m.includeSubdomains, len(m.fingerprints.entries))
+	return newDomainCompactDB(m.name, m.loader, m.includeSubdomains)
 }
 
 func (m *DomainCompactDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {

--- a/blocklistdb-domain-compact.go
+++ b/blocklistdb-domain-compact.go
@@ -60,25 +60,34 @@ var _ BlocklistDB = &DomainCompactDB{}
 // NewDomainCompactDB returns a matcher for a list of domain rules that trades
 // exactness for memory. See DomainCompactDB.
 func NewDomainCompactDB(name string, loader BlocklistLoader) (*DomainCompactDB, error) {
-	return newDomainCompactDB(name, loader, false)
+	return newDomainCompactDB(name, loader, false, 0)
 }
 
 // NewDomainSubdomainCompactDB is like NewDomainCompactDB but treats bare
 // entries as matching the apex and all sub-domains, as NewDomainSubdomainDB
 // does.
 func NewDomainSubdomainCompactDB(name string, loader BlocklistLoader) (*DomainCompactDB, error) {
-	return newDomainCompactDB(name, loader, true)
+	return newDomainCompactDB(name, loader, true, 0)
 }
 
-func newDomainCompactDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainCompactDB, error) {
+// nodes is the number of entries the database this one replaces holds, which is
+// what a refresh builds into rather than growing towards. A list is streamed in,
+// so its size is not known up front, and every doubling of the slice copies
+// what is already in it while both halves are held at once. The first build of
+// all has no estimate and grows into what it needs.
+func newDomainCompactDB(name string, loader BlocklistLoader, includeSubdomains bool, nodes int) (*DomainCompactDB, error) {
 	f := domainFingerprints{seed: rand.Uint64()}
-	var entries []uint64
+	// A little over the last count: merging drops the entries a rule shares
+	// with the ones before it, so a build appends a few percent more than it
+	// keeps.
+	sized := func() []uint64 { return make([]uint64, 0, nodes+nodes/8) }
+	entries := sized()
 	recent := new(domainRecent)
 	reset := func() {
 		// Not entries[:0]: an empty slice still points at the array behind it,
 		// and so does the clone build makes of it, which would keep every
 		// entry of a list that broke off reachable for good.
-		entries, recent = nil, new(domainRecent)
+		entries, recent = sized(), new(domainRecent)
 	}
 	err := domainRules(loader, includeSubdomains, reset, func(domain string, flag uint8) error {
 		// Walk the labels from the TLD inwards, hashing each suffix as it goes.
@@ -111,7 +120,7 @@ func newDomainCompactDB(name string, loader BlocklistLoader, includeSubdomains b
 }
 
 func (m *DomainCompactDB) Reload() (BlocklistDB, error) {
-	return newDomainCompactDB(m.name, m.loader, m.includeSubdomains)
+	return newDomainCompactDB(m.name, m.loader, m.includeSubdomains, len(m.fingerprints.entries))
 }
 
 func (m *DomainCompactDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {

--- a/blocklistdb-domain-compact_test.go
+++ b/blocklistdb-domain-compact_test.go
@@ -18,9 +18,9 @@ func TestDomainCompactMatchesExact(t *testing.T) {
 	for _, includeSubdomains := range []bool{false, true} {
 		rules := generateDomainRules(20000)
 		loader := NewStaticLoader(rules)
-		exact, err := newDomainDB("testlist", loader, includeSubdomains, 0, 0)
+		exact, err := newDomainDB("testlist", loader, includeSubdomains)
 		require.NoError(t, err)
-		compact, err := newDomainCompactDB("testlist", loader, includeSubdomains, 0)
+		compact, err := newDomainCompactDB("testlist", loader, includeSubdomains)
 		require.NoError(t, err)
 
 		var queries []string
@@ -51,9 +51,9 @@ func TestDomainCompactMatchesExact(t *testing.T) {
 func TestDomainCompactSeeded(t *testing.T) {
 	rules := generateDomainRules(1000)
 	loader := NewStaticLoader(rules)
-	first, err := newDomainCompactDB("testlist", loader, false, 0)
+	first, err := newDomainCompactDB("testlist", loader, false)
 	require.NoError(t, err)
-	second, err := newDomainCompactDB("testlist", loader, false, 0)
+	second, err := newDomainCompactDB("testlist", loader, false)
 	require.NoError(t, err)
 	require.NotEqual(t, first.fingerprints.seed, second.fingerprints.seed)
 	require.NotEqual(t, first.fingerprints.entries, second.fingerprints.entries)
@@ -75,7 +75,7 @@ func TestDomainCompactSeeded(t *testing.T) {
 func BenchmarkDomainCompactMatch(b *testing.B) {
 	for _, n := range []int{1000, 100000} {
 		rules := generateDomainRules(n)
-		db, err := newDomainCompactDB("testlist", NewStaticLoader(rules), false, 0)
+		db, err := newDomainCompactDB("testlist", NewStaticLoader(rules), false)
 		require.NoError(b, err)
 
 		hit := "www." + strings.TrimPrefix(strings.TrimPrefix(rules[len(rules)-1], "*."), ".")
@@ -99,7 +99,7 @@ func BenchmarkDomainCompactBuild(b *testing.B) {
 		b.Run(fmt.Sprintf("rules=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				if _, err := newDomainCompactDB("testlist", loader, false, 0); err != nil {
+				if _, err := newDomainCompactDB("testlist", loader, false); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/blocklistdb-domain-compact_test.go
+++ b/blocklistdb-domain-compact_test.go
@@ -18,9 +18,9 @@ func TestDomainCompactMatchesExact(t *testing.T) {
 	for _, includeSubdomains := range []bool{false, true} {
 		rules := generateDomainRules(20000)
 		loader := NewStaticLoader(rules)
-		exact, err := newDomainDB("testlist", loader, includeSubdomains)
+		exact, err := newDomainDB("testlist", loader, includeSubdomains, 0, 0)
 		require.NoError(t, err)
-		compact, err := newDomainCompactDB("testlist", loader, includeSubdomains)
+		compact, err := newDomainCompactDB("testlist", loader, includeSubdomains, 0)
 		require.NoError(t, err)
 
 		var queries []string
@@ -51,9 +51,9 @@ func TestDomainCompactMatchesExact(t *testing.T) {
 func TestDomainCompactSeeded(t *testing.T) {
 	rules := generateDomainRules(1000)
 	loader := NewStaticLoader(rules)
-	first, err := newDomainCompactDB("testlist", loader, false)
+	first, err := newDomainCompactDB("testlist", loader, false, 0)
 	require.NoError(t, err)
-	second, err := newDomainCompactDB("testlist", loader, false)
+	second, err := newDomainCompactDB("testlist", loader, false, 0)
 	require.NoError(t, err)
 	require.NotEqual(t, first.fingerprints.seed, second.fingerprints.seed)
 	require.NotEqual(t, first.fingerprints.entries, second.fingerprints.entries)
@@ -75,7 +75,7 @@ func TestDomainCompactSeeded(t *testing.T) {
 func BenchmarkDomainCompactMatch(b *testing.B) {
 	for _, n := range []int{1000, 100000} {
 		rules := generateDomainRules(n)
-		db, err := newDomainCompactDB("testlist", NewStaticLoader(rules), false)
+		db, err := newDomainCompactDB("testlist", NewStaticLoader(rules), false, 0)
 		require.NoError(b, err)
 
 		hit := "www." + strings.TrimPrefix(strings.TrimPrefix(rules[len(rules)-1], "*."), ".")
@@ -99,7 +99,7 @@ func BenchmarkDomainCompactBuild(b *testing.B) {
 		b.Run(fmt.Sprintf("rules=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				if _, err := newDomainCompactDB("testlist", loader, false); err != nil {
+				if _, err := newDomainCompactDB("testlist", loader, false, 0); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/blocklistdb-domain-trie.go
+++ b/blocklistdb-domain-trie.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/bits"
+	"slices"
 )
 
 // The longest label a domain name can carry. A rule with anything longer could
@@ -145,11 +146,20 @@ type domainBuilder struct {
 	parents []uint32
 }
 
-func newDomainBuilder() *domainBuilder {
+// newDomainBuilder starts a trie of about nodes nodes holding about blob bytes
+// of long labels. A list is streamed in, so its size is not known up front; the
+// build it is replacing is the estimate, and the first one of all has none and
+// grows into what it needs.
+func newDomainBuilder(nodes, blob int) *domainBuilder {
 	b := &domainBuilder{}
-	b.nodes = make([]domainNode, 1) // node 0 is the root
-	b.parents = make([]uint32, 1)
-	b.rebuild(64)
+	b.nodes = make([]domainNode, 1, nodes+1) // node 0 is the root
+	b.parents = make([]uint32, 1, nodes+1)
+	b.blob = make([]byte, 0, blob)
+	size := domainTableSize(uint64(nodes)) + 8
+	if size < 64 {
+		size = 64
+	}
+	b.rebuild(size)
 	return b
 }
 
@@ -195,11 +205,24 @@ func (b *domainBuilder) rebuild(size uint64) {
 }
 
 // done returns the finished trie, sized to what it holds rather than to the
-// rule count it was guessed from.
+// estimate it was started from or the doubling it grew by. Anything left over
+// would be held for as long as the trie serves queries.
 func (b *domainBuilder) done() domainTrie {
 	if want := domainTableSize(uint64(len(b.nodes))) + 8; uint64(len(b.slots)) > want*4/3 {
 		b.rebuild(want)
 	}
+	if cap(b.nodes) > len(b.nodes)+len(b.nodes)/3+8 {
+		b.nodes = slices.Clone(b.nodes)
+	}
+	if cap(b.blob) > len(b.blob)+len(b.blob)/3 {
+		b.blob = slices.Clone(b.blob)
+	}
 	b.parents = nil
 	return b.domainTrie
+}
+
+// sizes says what the trie holds, which is what the next build of the same list
+// starts from.
+func (t *domainTrie) sizes() (nodes, blob int) {
+	return len(t.nodes), len(t.blob)
 }

--- a/blocklistdb-domain-trie.go
+++ b/blocklistdb-domain-trie.go
@@ -196,8 +196,7 @@ func (b *domainBuilder) rebuild(size uint64) {
 }
 
 // done returns the finished trie, sized to what it holds rather than to the
-// doubling it grew by. Anything left over would be held for as long as the trie
-// serves queries.
+// doubling it grew by, which it would otherwise hold while it serves queries.
 func (b *domainBuilder) done() domainTrie {
 	if want := domainTableSize(uint64(len(b.nodes))) + 8; uint64(len(b.slots)) > want*4/3 {
 		b.rebuild(want)

--- a/blocklistdb-domain-trie.go
+++ b/blocklistdb-domain-trie.go
@@ -146,20 +146,11 @@ type domainBuilder struct {
 	parents []uint32
 }
 
-// newDomainBuilder starts a trie of about nodes nodes holding about blob bytes
-// of long labels. A list is streamed in, so its size is not known up front; the
-// build it is replacing is the estimate, and the first one of all has none and
-// grows into what it needs.
-func newDomainBuilder(nodes, blob int) *domainBuilder {
+func newDomainBuilder() *domainBuilder {
 	b := &domainBuilder{}
-	b.nodes = make([]domainNode, 1, nodes+1) // node 0 is the root
-	b.parents = make([]uint32, 1, nodes+1)
-	b.blob = make([]byte, 0, blob)
-	size := domainTableSize(uint64(nodes)) + 8
-	if size < 64 {
-		size = 64
-	}
-	b.rebuild(size)
+	b.nodes = make([]domainNode, 1) // node 0 is the root
+	b.parents = make([]uint32, 1)
+	b.rebuild(64)
 	return b
 }
 
@@ -205,8 +196,8 @@ func (b *domainBuilder) rebuild(size uint64) {
 }
 
 // done returns the finished trie, sized to what it holds rather than to the
-// estimate it was started from or the doubling it grew by. Anything left over
-// would be held for as long as the trie serves queries.
+// doubling it grew by. Anything left over would be held for as long as the trie
+// serves queries.
 func (b *domainBuilder) done() domainTrie {
 	if want := domainTableSize(uint64(len(b.nodes))) + 8; uint64(len(b.slots)) > want*4/3 {
 		b.rebuild(want)
@@ -219,10 +210,4 @@ func (b *domainBuilder) done() domainTrie {
 	}
 	b.parents = nil
 	return b.domainTrie
-}
-
-// sizes says what the trie holds, which is what the next build of the same list
-// starts from.
-func (t *domainTrie) sizes() (nodes, blob int) {
-	return len(t.nodes), len(t.blob)
 }

--- a/blocklistdb-domain-trie.go
+++ b/blocklistdb-domain-trie.go
@@ -145,11 +145,11 @@ type domainBuilder struct {
 	parents []uint32
 }
 
-func newDomainBuilder(rules int) *domainBuilder {
+func newDomainBuilder() *domainBuilder {
 	b := &domainBuilder{}
-	b.nodes = make([]domainNode, 1, rules+1) // node 0 is the root
-	b.parents = make([]uint32, 1, rules+1)
-	b.rebuild(domainTableSize(uint64(rules)) + 8)
+	b.nodes = make([]domainNode, 1) // node 0 is the root
+	b.parents = make([]uint32, 1)
+	b.rebuild(64)
 	return b
 }
 

--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -80,7 +80,7 @@ func NewDomainSubdomainDB(name string, loader BlocklistLoader) (*DomainDB, error
 
 func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainDB, error) {
 	b := newDomainBuilder()
-	err := domainRules(loader, includeSubdomains, func(domain string, flag uint8) error {
+	err := domainRules(loader, includeSubdomains, func() { b = newDomainBuilder() }, func(domain string, flag uint8) error {
 		// Walk the labels from the TLD inwards, building the path as needed.
 		n := uint32(0)
 		end := len(domain)
@@ -108,8 +108,8 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 // domainRules interprets the rules of a list, handing each one to record as the
 // domain it applies to and the flag it sets there. Both storage formats build
 // from this, so the syntax is read in one place.
-func domainRules(loader BlocklistLoader, includeSubdomains bool, record func(domain string, flag uint8) error) error {
-	return loadRules(loader, func(r string) error {
+func domainRules(loader BlocklistLoader, includeSubdomains bool, reset func(), record func(domain string, flag uint8) error) error {
+	return loadRules(loader, reset, func(r string) error {
 		// Strip a trailing dot in case the list holds FQDNs, and force the
 		// rule to lower case since queries are matched in lower case.
 		r = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(r), "."))

--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -69,18 +69,21 @@ var _ BlocklistDB = &DomainDB{}
 
 // NewDomainDB returns a new instance of a matcher for a list of domain rules.
 func NewDomainDB(name string, loader BlocklistLoader) (*DomainDB, error) {
-	return newDomainDB(name, loader, false)
+	return newDomainDB(name, loader, false, 0, 0)
 }
 
 // NewDomainSubdomainDB is like NewDomainDB but treats bare entries as matching
 // the apex and all sub-domains. See DomainDB for details.
 func NewDomainSubdomainDB(name string, loader BlocklistLoader) (*DomainDB, error) {
-	return newDomainDB(name, loader, true)
+	return newDomainDB(name, loader, true, 0, 0)
 }
 
-func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainDB, error) {
-	b := newDomainBuilder()
-	err := domainRules(loader, includeSubdomains, func() { b = newDomainBuilder() }, func(domain string, flag uint8) error {
+// nodes and blob are the size of the trie this one is replacing, which is what
+// a refresh builds into rather than growing towards. See newDomainBuilder.
+func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool, nodes, blob int) (*DomainDB, error) {
+	b := newDomainBuilder(nodes, blob)
+	reset := func() { b = newDomainBuilder(nodes, blob) }
+	err := domainRules(loader, includeSubdomains, reset, func(domain string, flag uint8) error {
 		// Walk the labels from the TLD inwards, building the path as needed.
 		n := uint32(0)
 		end := len(domain)
@@ -162,7 +165,8 @@ func domainRules(loader BlocklistLoader, includeSubdomains bool, reset func(), r
 }
 
 func (m *DomainDB) Reload() (BlocklistDB, error) {
-	return newDomainDB(m.name, m.loader, m.includeSubdomains)
+	nodes, blob := m.trie.sizes()
+	return newDomainDB(m.name, m.loader, m.includeSubdomains, nodes, blob)
 }
 
 func (m *DomainDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {

--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -109,7 +109,7 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 // domain it applies to and the flag it sets there. Both storage formats build
 // from this, so the syntax is read in one place.
 func domainRules(loader BlocklistLoader, includeSubdomains bool, reset func(), record func(domain string, flag uint8) error) error {
-	return loadRules(loader, reset, func(r string) error {
+	return loader.Load(reset, func(r string) error {
 		// Strip a trailing dot in case the list holds FQDNs, and force the
 		// rule to lower case since queries are matched in lower case.
 		r = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(r), "."))

--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -79,12 +79,8 @@ func NewDomainSubdomainDB(name string, loader BlocklistLoader) (*DomainDB, error
 }
 
 func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainDB, error) {
-	rules, err := loader.Load()
-	if err != nil {
-		return nil, err
-	}
-	b := newDomainBuilder(len(rules))
-	err = domainRules(rules, includeSubdomains, func(domain string, flag uint8) error {
+	b := newDomainBuilder()
+	err := domainRules(loader, includeSubdomains, func(domain string, flag uint8) error {
 		// Walk the labels from the TLD inwards, building the path as needed.
 		n := uint32(0)
 		end := len(domain)
@@ -112,26 +108,26 @@ func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*
 // domainRules interprets the rules of a list, handing each one to record as the
 // domain it applies to and the flag it sets there. Both storage formats build
 // from this, so the syntax is read in one place.
-func domainRules(rules []string, includeSubdomains bool, record func(domain string, flag uint8) error) error {
-	for _, r := range rules {
+func domainRules(loader BlocklistLoader, includeSubdomains bool, record func(domain string, flag uint8) error) error {
+	return loadRules(loader, func(r string) error {
 		// Strip a trailing dot in case the list holds FQDNs, and force the
 		// rule to lower case since queries are matched in lower case.
 		r = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(r), "."))
 		if r == "" {
-			continue
+			return nil
 		}
 
 		// A bare wildcard only ever applied to the labels under it, of which
 		// there are none here, so it's not an error, just nothing to record.
 		if r == "*" {
-			continue
+			return nil
 		}
 
 		// Lists carry comment lines and other noise, and a name with a label
 		// over the DNS limit could never be queried anyway, so such a rule is
 		// skipped rather than failing the list it came in.
 		if hasOverlongLabel(r) {
-			continue
+			return nil
 		}
 
 		// The prefix decides what the rule matches, the remainder is the base
@@ -161,11 +157,8 @@ func domainRules(rules []string, includeSubdomains bool, record func(domain stri
 			return fmt.Errorf("invalid blocklist item: '%s'", r[start:end])
 		}
 
-		if err := record(r, flag); err != nil {
-			return err
-		}
-	}
-	return nil
+		return record(r, flag)
+	})
 }
 
 func (m *DomainDB) Reload() (BlocklistDB, error) {

--- a/blocklistdb-domain.go
+++ b/blocklistdb-domain.go
@@ -69,20 +69,18 @@ var _ BlocklistDB = &DomainDB{}
 
 // NewDomainDB returns a new instance of a matcher for a list of domain rules.
 func NewDomainDB(name string, loader BlocklistLoader) (*DomainDB, error) {
-	return newDomainDB(name, loader, false, 0, 0)
+	return newDomainDB(name, loader, false)
 }
 
 // NewDomainSubdomainDB is like NewDomainDB but treats bare entries as matching
 // the apex and all sub-domains. See DomainDB for details.
 func NewDomainSubdomainDB(name string, loader BlocklistLoader) (*DomainDB, error) {
-	return newDomainDB(name, loader, true, 0, 0)
+	return newDomainDB(name, loader, true)
 }
 
-// nodes and blob are the size of the trie this one is replacing, which is what
-// a refresh builds into rather than growing towards. See newDomainBuilder.
-func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool, nodes, blob int) (*DomainDB, error) {
-	b := newDomainBuilder(nodes, blob)
-	reset := func() { b = newDomainBuilder(nodes, blob) }
+func newDomainDB(name string, loader BlocklistLoader, includeSubdomains bool) (*DomainDB, error) {
+	b := newDomainBuilder()
+	reset := func() { b = newDomainBuilder() }
 	err := domainRules(loader, includeSubdomains, reset, func(domain string, flag uint8) error {
 		// Walk the labels from the TLD inwards, building the path as needed.
 		n := uint32(0)
@@ -165,8 +163,7 @@ func domainRules(loader BlocklistLoader, includeSubdomains bool, reset func(), r
 }
 
 func (m *DomainDB) Reload() (BlocklistDB, error) {
-	nodes, blob := m.trie.sizes()
-	return newDomainDB(m.name, m.loader, m.includeSubdomains, nodes, blob)
+	return newDomainDB(m.name, m.loader, m.includeSubdomains)
 }
 
 func (m *DomainDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) {

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -3,8 +3,6 @@ package rdns
 import (
 	"fmt"
 	"math/rand"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -537,33 +535,4 @@ func TestDomainDBSharedLabels(t *testing.T) {
 			}
 		})
 	}
-}
-
-// The trie a build hands back is sized to what it holds, so a list that shrank
-// does not leave the database holding what the larger one needed.
-func TestDomainDBShrink(t *testing.T) {
-	dir := t.TempDir()
-	name := filepath.Join(dir, "list.txt")
-	var big strings.Builder
-	for i := range 20000 {
-		fmt.Fprintf(&big, "host%d.example.com\n", i)
-	}
-	require.NoError(t, os.WriteFile(name, []byte(big.String()), 0644))
-
-	db, err := NewDomainDB("testlist", NewFileLoader(name, FileLoaderOptions{}))
-	require.NoError(t, err)
-	require.Greater(t, cap(db.trie.nodes), 20000)
-
-	require.NoError(t, os.WriteFile(name, []byte("only.example.com\n"), 0644))
-	reloaded, err := db.Reload()
-	require.NoError(t, err)
-
-	trie := reloaded.(*DomainDB).trie
-	require.Less(t, cap(trie.nodes), 100, "the trie kept the nodes the larger list needed")
-	require.Less(t, len(trie.slots), 100, "the table kept the size the larger list needed")
-
-	msg := new(dns.Msg)
-	msg.SetQuestion("only.example.com.", dns.TypeA)
-	_, _, _, ok := reloaded.Match(msg)
-	require.True(t, ok)
 }

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -536,3 +536,20 @@ func TestDomainDBSharedLabels(t *testing.T) {
 		})
 	}
 }
+
+// A trie grows by doubling, so the array and the table it grew into would be
+// held for as long as it serves queries. What it hands back is sized to what
+// it holds.
+func TestDomainDBTrimmed(t *testing.T) {
+	rules := make([]string, 0, 20000)
+	for i := range 20000 {
+		rules = append(rules, fmt.Sprintf("host%d.example.com", i))
+	}
+	db, err := NewDomainDB("testlist", NewStaticLoader(rules))
+	require.NoError(t, err)
+
+	nodes := len(db.trie.nodes)
+	require.LessOrEqual(t, cap(db.trie.nodes), nodes+nodes/3+8, "the trie kept the array it grew into")
+	require.LessOrEqual(t, uint64(len(db.trie.slots)), domainTableSize(uint64(nodes))*4/3+8,
+		"the trie kept the table it doubled into")
+}

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -3,6 +3,8 @@ package rdns
 import (
 	"fmt"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -16,9 +18,9 @@ import (
 func domainFormats(t *testing.T, rules []string, includeSubdomains bool) map[string]BlocklistDB {
 	t.Helper()
 	loader := NewStaticLoader(rules)
-	exact, err := newDomainDB("testlist", loader, includeSubdomains)
+	exact, err := newDomainDB("testlist", loader, includeSubdomains, 0, 0)
 	require.NoError(t, err)
-	compact, err := newDomainCompactDB("testlist", loader, includeSubdomains)
+	compact, err := newDomainCompactDB("testlist", loader, includeSubdomains, 0)
 	require.NoError(t, err)
 	return map[string]BlocklistDB{"exact": exact, "compact": compact}
 }
@@ -388,7 +390,7 @@ func TestDomainDBGenerated(t *testing.T) {
 func BenchmarkDomainDBMatch(b *testing.B) {
 	for _, n := range []int{1000, 100000} {
 		rules := generateDomainRules(n)
-		db, err := newDomainDB("testlist", NewStaticLoader(rules), false)
+		db, err := newDomainDB("testlist", NewStaticLoader(rules), false, 0, 0)
 		require.NoError(b, err)
 
 		// A name that matches the last rule loaded, one that shares its TLD
@@ -414,7 +416,7 @@ func BenchmarkDomainDBBuild(b *testing.B) {
 		b.Run(fmt.Sprintf("rules=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				if _, err := newDomainDB("testlist", loader, false); err != nil {
+				if _, err := newDomainDB("testlist", loader, false, 0, 0); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -535,4 +537,33 @@ func TestDomainDBSharedLabels(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A refresh builds into the size of the build before it. A list that shrank
+// must not leave the database holding what the larger one needed.
+func TestDomainDBShrink(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "list.txt")
+	var big strings.Builder
+	for i := range 20000 {
+		fmt.Fprintf(&big, "host%d.example.com\n", i)
+	}
+	require.NoError(t, os.WriteFile(name, []byte(big.String()), 0644))
+
+	db, err := NewDomainDB("testlist", NewFileLoader(name, FileLoaderOptions{}))
+	require.NoError(t, err)
+	require.Greater(t, cap(db.trie.nodes), 20000)
+
+	require.NoError(t, os.WriteFile(name, []byte("only.example.com\n"), 0644))
+	reloaded, err := db.Reload()
+	require.NoError(t, err)
+
+	trie := reloaded.(*DomainDB).trie
+	require.Less(t, cap(trie.nodes), 100, "the trie kept the nodes the larger list needed")
+	require.Less(t, len(trie.slots), 100, "the table kept the size the larger list needed")
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("only.example.com.", dns.TypeA)
+	_, _, _, ok := reloaded.Match(msg)
+	require.True(t, ok)
 }

--- a/blocklistdb-domain_test.go
+++ b/blocklistdb-domain_test.go
@@ -18,9 +18,9 @@ import (
 func domainFormats(t *testing.T, rules []string, includeSubdomains bool) map[string]BlocklistDB {
 	t.Helper()
 	loader := NewStaticLoader(rules)
-	exact, err := newDomainDB("testlist", loader, includeSubdomains, 0, 0)
+	exact, err := newDomainDB("testlist", loader, includeSubdomains)
 	require.NoError(t, err)
-	compact, err := newDomainCompactDB("testlist", loader, includeSubdomains, 0)
+	compact, err := newDomainCompactDB("testlist", loader, includeSubdomains)
 	require.NoError(t, err)
 	return map[string]BlocklistDB{"exact": exact, "compact": compact}
 }
@@ -390,7 +390,7 @@ func TestDomainDBGenerated(t *testing.T) {
 func BenchmarkDomainDBMatch(b *testing.B) {
 	for _, n := range []int{1000, 100000} {
 		rules := generateDomainRules(n)
-		db, err := newDomainDB("testlist", NewStaticLoader(rules), false, 0, 0)
+		db, err := newDomainDB("testlist", NewStaticLoader(rules), false)
 		require.NoError(b, err)
 
 		// A name that matches the last rule loaded, one that shares its TLD
@@ -416,7 +416,7 @@ func BenchmarkDomainDBBuild(b *testing.B) {
 		b.Run(fmt.Sprintf("rules=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				if _, err := newDomainDB("testlist", loader, false, 0, 0); err != nil {
+				if _, err := newDomainDB("testlist", loader, false); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -539,8 +539,8 @@ func TestDomainDBSharedLabels(t *testing.T) {
 	}
 }
 
-// A refresh builds into the size of the build before it. A list that shrank
-// must not leave the database holding what the larger one needed.
+// The trie a build hands back is sized to what it holds, so a list that shrank
+// does not leave the database holding what the larger one needed.
 func TestDomainDBShrink(t *testing.T) {
 	dir := t.TempDir()
 	name := filepath.Join(dir, "list.txt")

--- a/blocklistdb-hosts.go
+++ b/blocklistdb-hosts.go
@@ -38,7 +38,7 @@ func NewHostsDB(name string, loader BlocklistLoader) (*HostsDB, error) {
 		filters = make(map[string]ipRecords)
 		ptrMap = make(map[string][]string)
 	}
-	err := loadRules(loader, reset, func(r string) error {
+	err := loader.Load(reset, func(r string) error {
 		r = strings.TrimSpace(r)
 		fields := strings.Fields(r)
 		if len(fields) == 0 {

--- a/blocklistdb-hosts.go
+++ b/blocklistdb-hosts.go
@@ -31,7 +31,7 @@ var _ BlocklistDB = &HostsDB{}
 func NewHostsDB(name string, loader BlocklistLoader) (*HostsDB, error) {
 	filters := make(map[string]ipRecords)
 	ptrMap := make(map[string][]string)
-	err := loadRules(loader, func(r string) error {
+	err := loadRules(loader, func() { clear(filters); clear(ptrMap) }, func(r string) error {
 		r = strings.TrimSpace(r)
 		fields := strings.Fields(r)
 		if len(fields) == 0 {

--- a/blocklistdb-hosts.go
+++ b/blocklistdb-hosts.go
@@ -31,7 +31,14 @@ var _ BlocklistDB = &HostsDB{}
 func NewHostsDB(name string, loader BlocklistLoader) (*HostsDB, error) {
 	filters := make(map[string]ipRecords)
 	ptrMap := make(map[string][]string)
-	err := loadRules(loader, func() { clear(filters); clear(ptrMap) }, func(r string) error {
+	// Fresh maps rather than clear(), which empties a map without giving up
+	// the buckets it grew: a list that broke off part way through would leave
+	// its memory behind in the database that goes on serving queries.
+	reset := func() {
+		filters = make(map[string]ipRecords)
+		ptrMap = make(map[string][]string)
+	}
+	err := loadRules(loader, reset, func(r string) error {
 		r = strings.TrimSpace(r)
 		fields := strings.Fields(r)
 		if len(fields) == 0 {

--- a/blocklistdb-hosts.go
+++ b/blocklistdb-hosts.go
@@ -29,25 +29,21 @@ var _ BlocklistDB = &HostsDB{}
 
 // NewHostsDB returns a new instance of a matcher for a list of hosts-file entries.
 func NewHostsDB(name string, loader BlocklistLoader) (*HostsDB, error) {
-	rules, err := loader.Load()
-	if err != nil {
-		return nil, err
-	}
 	filters := make(map[string]ipRecords)
 	ptrMap := make(map[string][]string)
-	for _, r := range rules {
+	err := loadRules(loader, func(r string) error {
 		r = strings.TrimSpace(r)
 		fields := strings.Fields(r)
 		if len(fields) == 0 {
-			continue
+			return nil
 		}
 		ipString := fields[0]
 		names := fields[1:]
 		if strings.HasPrefix(ipString, "#") {
-			continue
+			return nil
 		}
 		if len(names) == 0 {
-			continue
+			return nil
 		}
 		ip := net.ParseIP(ipString)
 		var isIP4 bool
@@ -75,9 +71,13 @@ func NewHostsDB(name string, loader BlocklistLoader) (*HostsDB, error) {
 		}
 		reverseAddr, err := dns.ReverseAddr(ipString)
 		if err != nil {
-			continue
+			return nil
 		}
 		ptrMap[reverseAddr] = append(ptrMap[reverseAddr], names...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return &HostsDB{name, filters, ptrMap, loader}, nil
 }

--- a/blocklistdb-hosts.go
+++ b/blocklistdb-hosts.go
@@ -32,8 +32,7 @@ func NewHostsDB(name string, loader BlocklistLoader) (*HostsDB, error) {
 	filters := make(map[string]ipRecords)
 	ptrMap := make(map[string][]string)
 	// Fresh maps rather than clear(), which empties a map without giving up
-	// the buckets it grew: a list that broke off part way through would leave
-	// its memory behind in the database that goes on serving queries.
+	// the buckets it grew from a list that broke off.
 	reset := func() {
 		filters = make(map[string]ipRecords)
 		ptrMap = make(map[string][]string)

--- a/blocklistdb-multi.go
+++ b/blocklistdb-multi.go
@@ -21,7 +21,7 @@ func NewMultiDB(dbs ...BlocklistDB) (MultiDB, error) {
 
 func (m MultiDB) Reload() (BlocklistDB, error) {
 	// A list that could not be read keeps the rules it already has, which is
-	// what its loader means by errBlocklistUnchanged, while the lists beside
+	// what its loader means by ErrBlocklistUnchanged, while the lists beside
 	// it still refresh. Only when none of them moved is there nothing to swap
 	// in.
 	newDBs := make([]BlocklistDB, 0, len(m.dbs))
@@ -29,7 +29,7 @@ func (m MultiDB) Reload() (BlocklistDB, error) {
 	for _, db := range m.dbs {
 		n, err := db.Reload()
 		switch {
-		case errors.Is(err, errBlocklistUnchanged):
+		case errors.Is(err, ErrBlocklistUnchanged):
 			unchanged++
 			n = db
 		case err != nil:
@@ -38,7 +38,7 @@ func (m MultiDB) Reload() (BlocklistDB, error) {
 		newDBs = append(newDBs, n)
 	}
 	if unchanged == len(m.dbs) {
-		return nil, errBlocklistUnchanged
+		return nil, ErrBlocklistUnchanged
 	}
 	return NewMultiDB(newDBs...)
 }

--- a/blocklistdb-multi.go
+++ b/blocklistdb-multi.go
@@ -25,19 +25,20 @@ func (m MultiDB) Reload() (BlocklistDB, error) {
 	// it still refresh. Only when none of them moved is there nothing to swap
 	// in.
 	newDBs := make([]BlocklistDB, 0, len(m.dbs))
-	unchanged := 0
+	changed := false
 	for _, db := range m.dbs {
 		n, err := db.Reload()
 		switch {
 		case errors.Is(err, ErrBlocklistUnchanged):
-			unchanged++
 			n = db
 		case err != nil:
 			return nil, err
+		default:
+			changed = true
 		}
 		newDBs = append(newDBs, n)
 	}
-	if unchanged == len(m.dbs) {
+	if !changed {
 		return nil, ErrBlocklistUnchanged
 	}
 	return NewMultiDB(newDBs...)

--- a/blocklistdb-multi.go
+++ b/blocklistdb-multi.go
@@ -1,7 +1,6 @@
 package rdns
 
 import (
-	"errors"
 	"net"
 
 	"github.com/miekg/dns"
@@ -20,26 +19,18 @@ func NewMultiDB(dbs ...BlocklistDB) (MultiDB, error) {
 }
 
 func (m MultiDB) Reload() (BlocklistDB, error) {
-	// A list that could not be read keeps the rules it already has, which is
-	// what its loader means by ErrBlocklistUnchanged, while the lists beside
-	// it still refresh. Only when none of them moved is there nothing to swap
-	// in.
+	// A list that could not be read keeps the rules it already has while the
+	// lists beside it refresh. These databases hold nothing that closing
+	// releases, so the one already serving a list carries straight over.
 	newDBs := make([]BlocklistDB, 0, len(m.dbs))
-	changed := false
 	for _, db := range m.dbs {
 		n, err := db.Reload()
-		switch {
-		case errors.Is(err, ErrBlocklistUnchanged):
+		if err != nil {
+			Log.Warn("failed to load rules, continuing with the ones already loaded",
+				"error", err)
 			n = db
-		case err != nil:
-			return nil, err
-		default:
-			changed = true
 		}
 		newDBs = append(newDBs, n)
-	}
-	if !changed {
-		return nil, ErrBlocklistUnchanged
 	}
 	return NewMultiDB(newDBs...)
 }

--- a/blocklistdb-multi.go
+++ b/blocklistdb-multi.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"errors"
 	"net"
 
 	"github.com/miekg/dns"
@@ -19,13 +20,25 @@ func NewMultiDB(dbs ...BlocklistDB) (MultiDB, error) {
 }
 
 func (m MultiDB) Reload() (BlocklistDB, error) {
-	var newDBs []BlocklistDB
+	// A list that could not be read keeps the rules it already has, which is
+	// what its loader means by errBlocklistUnchanged, while the lists beside
+	// it still refresh. Only when none of them moved is there nothing to swap
+	// in.
+	newDBs := make([]BlocklistDB, 0, len(m.dbs))
+	unchanged := 0
 	for _, db := range m.dbs {
 		n, err := db.Reload()
-		if err != nil {
+		switch {
+		case errors.Is(err, errBlocklistUnchanged):
+			unchanged++
+			n = db
+		case err != nil:
 			return nil, err
 		}
 		newDBs = append(newDBs, n)
+	}
+	if unchanged == len(m.dbs) {
+		return nil, errBlocklistUnchanged
 	}
 	return NewMultiDB(newDBs...)
 }

--- a/blocklistdb-regexp.go
+++ b/blocklistdb-regexp.go
@@ -20,7 +20,7 @@ var _ BlocklistDB = &RegexpDB{}
 // NewRegexpDB returns a new instance of a matcher for a list of regular expressions.
 func NewRegexpDB(name string, loader BlocklistLoader) (*RegexpDB, error) {
 	var filters []*regexp.Regexp
-	err := loadRules(loader, func() { filters = nil }, func(r string) error {
+	err := loader.Load(func() { filters = nil }, func(r string) error {
 		r = strings.TrimSpace(r)
 		if r == "" || strings.HasPrefix(r, "#") {
 			return nil

--- a/blocklistdb-regexp.go
+++ b/blocklistdb-regexp.go
@@ -19,23 +19,22 @@ var _ BlocklistDB = &RegexpDB{}
 
 // NewRegexpDB returns a new instance of a matcher for a list of regular expressions.
 func NewRegexpDB(name string, loader BlocklistLoader) (*RegexpDB, error) {
-	rules, err := loader.Load()
-	if err != nil {
-		return nil, err
-	}
 	var filters []*regexp.Regexp
-	for _, r := range rules {
+	err := loadRules(loader, func(r string) error {
 		r = strings.TrimSpace(r)
 		if r == "" || strings.HasPrefix(r, "#") {
-			continue
+			return nil
 		}
 		re, err := regexp.Compile(r)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		filters = append(filters, re)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-
 	return &RegexpDB{name, filters, loader}, nil
 }
 

--- a/blocklistdb-regexp.go
+++ b/blocklistdb-regexp.go
@@ -20,7 +20,7 @@ var _ BlocklistDB = &RegexpDB{}
 // NewRegexpDB returns a new instance of a matcher for a list of regular expressions.
 func NewRegexpDB(name string, loader BlocklistLoader) (*RegexpDB, error) {
 	var filters []*regexp.Regexp
-	err := loadRules(loader, func(r string) error {
+	err := loadRules(loader, func() { filters = nil }, func(r string) error {
 		r = strings.TrimSpace(r)
 		if r == "" || strings.HasPrefix(r, "#") {
 			return nil

--- a/blocklistdb.go
+++ b/blocklistdb.go
@@ -66,6 +66,10 @@ func refreshDatabase[T reloadable[T]](id, what string, refresh time.Duration, mu
 		reloaded, err := (*db).Reload()
 		if errors.Is(err, ErrBlocklistUnchanged) {
 			log.Debug("keeping the " + what + " already loaded")
+			// The rules are the ones already being served, so the database
+			// carrying them on is of no use here. It owns what it holds, and
+			// nothing else will close it.
+			closeDatabase(reloaded)
 			continue
 		}
 		if err != nil {
@@ -76,8 +80,15 @@ func refreshDatabase[T reloadable[T]](id, what string, refresh time.Duration, mu
 		old := *db
 		*db = reloaded
 		mu.Unlock()
-		if closer, ok := any(old).(io.Closer); ok {
-			closer.Close()
-		}
+		closeDatabase(old)
+	}
+}
+
+// closeDatabase releases what a database holds, for the databases that hold
+// anything. The location ones own a memory-mapped file, the rest own nothing
+// and say so by not being closeable at all.
+func closeDatabase[T any](db T) {
+	if closer, ok := any(db).(io.Closer); ok {
+		closer.Close()
 	}
 }

--- a/blocklistdb.go
+++ b/blocklistdb.go
@@ -64,7 +64,7 @@ func refreshDatabase[T reloadable[T]](id, what string, refresh time.Duration, mu
 		time.Sleep(refresh)
 		log.Debug("reloading " + what)
 		reloaded, err := (*db).Reload()
-		if errors.Is(err, errBlocklistUnchanged) {
+		if errors.Is(err, ErrBlocklistUnchanged) {
 			log.Debug("keeping the " + what + " already loaded")
 			continue
 		}

--- a/blocklistdb.go
+++ b/blocklistdb.go
@@ -66,10 +66,7 @@ func refreshDatabase[T reloadable[T]](id, what string, refresh time.Duration, mu
 		if err != nil {
 			log.Warn("failed to load rules, continuing with the ones already loaded",
 				"error", err)
-			// Those rules are the ones already being served, so a database
-			// handed back with the error is of no use here. It owns what it
-			// holds, and nothing else will close it.
-			closeDatabase(reloaded)
+			closeDatabase(reloaded) // those rules are already being served
 			continue
 		}
 		mu.Lock()
@@ -80,9 +77,8 @@ func refreshDatabase[T reloadable[T]](id, what string, refresh time.Duration, mu
 	}
 }
 
-// closeDatabase releases what a database holds, for the databases that hold
-// anything. The location ones own a memory-mapped file, the rest own nothing
-// and say so by not being closeable at all.
+// closeDatabase releases what a database holds, for those that hold anything:
+// the location databases own a memory-mapped file, the rest own nothing.
 func closeDatabase[T any](db T) {
 	if closer, ok := any(db).(io.Closer); ok {
 		closer.Close()

--- a/blocklistdb.go
+++ b/blocklistdb.go
@@ -1,7 +1,6 @@
 package rdns
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -64,16 +63,13 @@ func refreshDatabase[T reloadable[T]](id, what string, refresh time.Duration, mu
 		time.Sleep(refresh)
 		log.Debug("reloading " + what)
 		reloaded, err := (*db).Reload()
-		if errors.Is(err, ErrBlocklistUnchanged) {
-			log.Debug("keeping the " + what + " already loaded")
-			// The rules are the ones already being served, so the database
-			// carrying them on is of no use here. It owns what it holds, and
-			// nothing else will close it.
-			closeDatabase(reloaded)
-			continue
-		}
 		if err != nil {
-			log.Error("failed to load rules", "error", err)
+			log.Warn("failed to load rules, continuing with the ones already loaded",
+				"error", err)
+			// Those rules are the ones already being served, so a database
+			// handed back with the error is of no use here. It owns what it
+			// holds, and nothing else will close it.
+			closeDatabase(reloaded)
 			continue
 		}
 		mu.Lock()

--- a/blocklistdb.go
+++ b/blocklistdb.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -63,6 +64,10 @@ func refreshDatabase[T reloadable[T]](id, what string, refresh time.Duration, mu
 		time.Sleep(refresh)
 		log.Debug("reloading " + what)
 		reloaded, err := (*db).Reload()
+		if errors.Is(err, errBlocklistUnchanged) {
+			log.Debug("keeping the " + what + " already loaded")
+			continue
+		}
 		if err != nil {
 			log.Error("failed to load rules", "error", err)
 			continue

--- a/blocklistdb_test.go
+++ b/blocklistdb_test.go
@@ -84,24 +84,6 @@ func (d *closingDB) Close() error {
 	return nil
 }
 
-// The reloaded database replaces the one in use.
-func TestRefreshDatabaseSwaps(t *testing.T) {
-	var reloads, closes atomic.Int64
-	var mu sync.RWMutex
-	var db BlocklistDB = &countingDB{reloads: &reloads, closes: &closes, gate: openGate(t)}
-
-	go refreshDatabase("test", "blocklist", time.Millisecond, &mu, &db)
-
-	require.Eventually(t, func() bool {
-		mu.RLock()
-		defer mu.RUnlock()
-		return db.(*countingDB).generation > 2
-	}, time.Second, time.Millisecond)
-
-	// Nothing to close on a database that holds no resources.
-	require.Zero(t, closes.Load())
-}
-
 // A database holding a resource is closed, but only after it has been replaced.
 func TestRefreshDatabaseClosesReplaced(t *testing.T) {
 	var reloads, closes atomic.Int64
@@ -230,23 +212,18 @@ func TestMultiIPDBReloadUnreadableSource(t *testing.T) {
 		require.True(t, ok, "address %s", ip)
 	}
 
-	// Closing the group it came from must leave the carried database working.
-	require.NoError(t, multi.Close())
-	_, ok := reloaded.Match(net.ParseIP("10.1.2.3"))
-	require.True(t, ok, "the carried database was closed with the old group")
-
 	// With every source unreadable the group still reloads, holding the rules
 	// each of its sources already had.
 	onlyFailing, err := NewMultiIPDB(unreadable)
 	require.NoError(t, err)
 	kept, err := onlyFailing.Reload()
 	require.NoError(t, err)
-	_, ok = kept.Match(net.ParseIP("10.1.2.3"))
+	_, ok := kept.Match(net.ParseIP("10.1.2.3"))
 	require.True(t, ok, "the group dropped the rules it was serving")
 }
 
 // A database that owns something closing releases, as the location databases
-// own a memory-mapped file. Its list is never readable, so every reload hands
+// own their memory-mapped file. Its list never reads, so every reload hands
 // the rules on in a new instance.
 type handleIPDB struct {
 	ip     net.IP
@@ -292,12 +269,6 @@ func TestMultiIPDBOwnershipOnReload(t *testing.T) {
 	require.True(t, owner.closed, "the old group left its own database open")
 	require.False(t, carried.closed, "the old group closed the database it handed on")
 
-	for _, ip := range []string{"10.0.0.1", "192.168.1.1"} {
-		_, ok := reloaded.Match(net.ParseIP(ip))
-		require.True(t, ok, "address %s", ip)
-	}
-
-	// And the new group owns what it holds, in its turn.
-	require.NoError(t, reloaded.Close())
-	require.True(t, carried.closed, "the group left its database open")
+	_, ok := reloaded.Match(net.ParseIP("10.0.0.1"))
+	require.True(t, ok, "the rules handed on are not being served")
 }

--- a/blocklistdb_test.go
+++ b/blocklistdb_test.go
@@ -176,9 +176,7 @@ func TestMultiDBReloadUnchanged(t *testing.T) {
 }
 
 // The IP group behaves like the name-based one: a source that cannot be read
-// keeps its rules while the sources beside it refresh. It cannot carry the
-// database itself across, since it closes what it replaces, so it carries a
-// copy that owns whatever needs closing.
+// keeps its rules while the sources beside it refresh.
 func TestMultiIPDBReloadUnchanged(t *testing.T) {
 	dir := t.TempDir()
 	name := filepath.Join(dir, "list.txt")
@@ -206,8 +204,69 @@ func TestMultiIPDBReloadUnchanged(t *testing.T) {
 	_, ok := reloaded.Match(net.ParseIP("10.1.2.3"))
 	require.True(t, ok, "the carried database was closed with the old group")
 
+	// With every source unreadable the group says so, and still hands back a
+	// database holding the rules it was already serving.
 	onlyFailing, err := NewMultiIPDB(unreadable)
 	require.NoError(t, err)
-	_, err = onlyFailing.Reload()
+	kept, err := onlyFailing.Reload()
 	require.ErrorIs(t, err, ErrBlocklistUnchanged)
+	_, ok = kept.Match(net.ParseIP("10.1.2.3"))
+	require.True(t, ok, "the group reported unchanged without the rules to go with it")
+}
+
+// A database that owns something closing releases, as the location databases
+// own a memory-mapped file. Its list is never readable, so every reload hands
+// the rules on in a new instance.
+type handleIPDB struct {
+	ip     net.IP
+	closed bool
+	next   *handleIPDB // what the last reload handed on to
+}
+
+func (m *handleIPDB) Reload() (IPBlocklistDB, error) {
+	m.next = &handleIPDB{ip: m.ip}
+	return m.next, ErrBlocklistUnchanged
+}
+
+func (m *handleIPDB) Match(ip net.IP) (*BlocklistMatch, bool) {
+	if m.closed {
+		panic("matched against a database that was closed")
+	}
+	return &BlocklistMatch{List: "handle"}, ip.Equal(m.ip)
+}
+
+func (m *handleIPDB) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *handleIPDB) String() string { return "handle" }
+
+// The group is closed once the group replacing it is in place, so what it
+// hands on has to be a database of its own rather than one it is about to
+// close.
+func TestMultiIPDBOwnershipOnReload(t *testing.T) {
+	owner := &handleIPDB{ip: net.ParseIP("10.0.0.1")}
+	steady, err := NewCidrDB("steady", NewStaticLoader([]string{"192.168.0.0/16"}))
+	require.NoError(t, err)
+	multi, err := NewMultiIPDB(owner, steady)
+	require.NoError(t, err)
+
+	reloaded, err := multi.Reload()
+	require.NoError(t, err, "one unreadable source must not stall the group")
+	carried := owner.next
+	require.NotNil(t, carried, "the group dropped what its database handed on")
+
+	require.NoError(t, multi.Close())
+	require.True(t, owner.closed, "the old group left its own database open")
+	require.False(t, carried.closed, "the old group closed the database it handed on")
+
+	for _, ip := range []string{"10.0.0.1", "192.168.1.1"} {
+		_, ok := reloaded.Match(net.ParseIP(ip))
+		require.True(t, ok, "address %s", ip)
+	}
+
+	// And the new group owns what it holds, in its turn.
+	require.NoError(t, reloaded.Close())
+	require.True(t, carried.closed, "the group left its database open")
 }

--- a/blocklistdb_test.go
+++ b/blocklistdb_test.go
@@ -172,7 +172,7 @@ func TestMultiDBReloadUnchanged(t *testing.T) {
 	onlyFailing, err := NewMultiDB(unreadable)
 	require.NoError(t, err)
 	_, err = onlyFailing.Reload()
-	require.ErrorIs(t, err, errBlocklistUnchanged)
+	require.ErrorIs(t, err, ErrBlocklistUnchanged)
 }
 
 // The IP group behaves like the name-based one: a source that cannot be read
@@ -209,5 +209,5 @@ func TestMultiIPDBReloadUnchanged(t *testing.T) {
 	onlyFailing, err := NewMultiIPDB(unreadable)
 	require.NoError(t, err)
 	_, err = onlyFailing.Reload()
-	require.ErrorIs(t, err, errBlocklistUnchanged)
+	require.ErrorIs(t, err, ErrBlocklistUnchanged)
 }

--- a/blocklistdb_test.go
+++ b/blocklistdb_test.go
@@ -174,3 +174,40 @@ func TestMultiDBReloadUnchanged(t *testing.T) {
 	_, err = onlyFailing.Reload()
 	require.ErrorIs(t, err, errBlocklistUnchanged)
 }
+
+// The IP group behaves like the name-based one: a source that cannot be read
+// keeps its rules while the sources beside it refresh. It cannot carry the
+// database itself across, since it closes what it replaces, so it carries a
+// copy that owns whatever needs closing.
+func TestMultiIPDBReloadUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "list.txt")
+	require.NoError(t, os.WriteFile(name, []byte("10.0.0.0/8\n"), 0644))
+
+	failing := NewFileLoader(name, FileLoaderOptions{AllowFailure: true})
+	unreadable, err := NewCidrDB("unreadable", failing)
+	require.NoError(t, err)
+	steady, err := NewCidrDB("steady", NewStaticLoader([]string{"192.168.0.0/16"}))
+	require.NoError(t, err)
+
+	multi, err := NewMultiIPDB(unreadable, steady)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Remove(name))
+	reloaded, err := multi.Reload()
+	require.NoError(t, err, "one unreadable source must not stall the group")
+	for _, ip := range []string{"10.1.2.3", "192.168.1.1"} {
+		_, ok := reloaded.Match(net.ParseIP(ip))
+		require.True(t, ok, "address %s", ip)
+	}
+
+	// Closing the group it came from must leave the carried database working.
+	require.NoError(t, multi.Close())
+	_, ok := reloaded.Match(net.ParseIP("10.1.2.3"))
+	require.True(t, ok, "the carried database was closed with the old group")
+
+	onlyFailing, err := NewMultiIPDB(unreadable)
+	require.NoError(t, err)
+	_, err = onlyFailing.Reload()
+	require.ErrorIs(t, err, errBlocklistUnchanged)
+}

--- a/blocklistdb_test.go
+++ b/blocklistdb_test.go
@@ -228,10 +228,14 @@ func TestMultiIPDBReloadUnreadableSource(t *testing.T) {
 type handleIPDB struct {
 	ip     net.IP
 	closed bool
+	broken bool        // cannot hand its rules on, as a lost map file leaves it
 	next   *handleIPDB // what the last reload handed on to
 }
 
 func (m *handleIPDB) Reload() (IPBlocklistDB, error) {
+	if m.broken {
+		return nil, errors.New("the list could not be read")
+	}
 	m.next = &handleIPDB{ip: m.ip}
 	return m.next, errors.New("the list could not be read")
 }
@@ -271,4 +275,19 @@ func TestMultiIPDBOwnershipOnReload(t *testing.T) {
 
 	_, ok := reloaded.Match(net.ParseIP("10.0.0.1"))
 	require.True(t, ok, "the rules handed on are not being served")
+}
+
+// A group that cannot hand its rules on hands back nothing, so the group
+// around it keeps what it has rather than installing an empty one.
+func TestMultiIPDBNestedFailure(t *testing.T) {
+	inner, err := NewMultiIPDB(&handleIPDB{ip: net.ParseIP("10.0.0.1"), broken: true})
+	require.NoError(t, err)
+	steady, err := NewCidrDB("steady", NewStaticLoader([]string{"192.168.0.0/16"}))
+	require.NoError(t, err)
+	outer, err := NewMultiIPDB(inner, steady)
+	require.NoError(t, err)
+
+	reloaded, err := outer.Reload()
+	require.Error(t, err)
+	require.Nil(t, reloaded, "an empty group must not pass as the rules already loaded")
 }

--- a/blocklistdb_test.go
+++ b/blocklistdb_test.go
@@ -139,10 +139,36 @@ func TestRefreshDatabaseKeepsFailedDatabase(t *testing.T) {
 	require.Same(t, original, db)
 }
 
+// A rule the database will not take is a failure like any other. With
+// AllowFailure a list that has never loaded starts empty rather than keeping
+// the process from starting; once it has loaded, the rules it is serving stay.
+func TestBlocklistRuleErrorAllowFailure(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "list.txt")
+	require.NoError(t, os.WriteFile(name, []byte("a*b.example.com\n"), 0644))
+
+	loader := NewFileLoader(name, FileLoaderOptions{AllowFailure: true})
+	db, err := NewDomainDB("testlist", loader)
+	require.NoError(t, err, "a rule the database refuses must not keep it from starting")
+	msg := new(dns.Msg)
+	msg.SetQuestion("ab.example.com.", dns.TypeA)
+	_, _, _, ok := db.Match(msg)
+	require.False(t, ok, "a list that failed to load must hold none of it")
+
+	require.NoError(t, os.WriteFile(name, []byte("good.example.com\n"), 0644))
+	reloaded, err := db.Reload()
+	require.NoError(t, err)
+
+	// The list has loaded now, so a rule the database refuses is an error and
+	// the rules already serving are what stays.
+	require.NoError(t, os.WriteFile(name, []byte("a*b.example.com\n"), 0644))
+	_, err = reloaded.Reload()
+	require.Error(t, err, "a list the database refused must not pass as loaded")
+}
+
 // A source that cannot be read holds the rules it has while the sources beside
-// it carry on refreshing. Only when none of them can be read is there nothing
-// to swap in.
-func TestMultiDBReloadUnchanged(t *testing.T) {
+// it carry on refreshing.
+func TestMultiDBReloadUnreadableSource(t *testing.T) {
 	dir := t.TempDir()
 	name := filepath.Join(dir, "list.txt")
 	require.NoError(t, os.WriteFile(name, []byte("gone.example.com\n"), 0644))
@@ -156,8 +182,8 @@ func TestMultiDBReloadUnchanged(t *testing.T) {
 	multi, err := NewMultiDB(unreadable, steady)
 	require.NoError(t, err)
 
-	// The file is gone, so that source reports nothing to change. The group
-	// still reloads, and both sets of rules still match.
+	// The file is gone, so that source fails to load. The group still
+	// reloads, and both sets of rules still match.
 	require.NoError(t, os.Remove(name))
 	reloaded, err := multi.Reload()
 	require.NoError(t, err, "one unreadable source must not stall the group")
@@ -168,16 +194,21 @@ func TestMultiDBReloadUnchanged(t *testing.T) {
 		require.True(t, ok, "query %s", q)
 	}
 
-	// With every source unreadable there is nothing new to install.
+	// With every source unreadable the group still reloads, holding the rules
+	// each of its sources already had.
 	onlyFailing, err := NewMultiDB(unreadable)
 	require.NoError(t, err)
-	_, err = onlyFailing.Reload()
-	require.ErrorIs(t, err, ErrBlocklistUnchanged)
+	kept, err := onlyFailing.Reload()
+	require.NoError(t, err)
+	msg := new(dns.Msg)
+	msg.SetQuestion("gone.example.com.", dns.TypeA)
+	_, _, _, ok := kept.Match(msg)
+	require.True(t, ok, "the group dropped the rules it was serving")
 }
 
 // The IP group behaves like the name-based one: a source that cannot be read
 // keeps its rules while the sources beside it refresh.
-func TestMultiIPDBReloadUnchanged(t *testing.T) {
+func TestMultiIPDBReloadUnreadableSource(t *testing.T) {
 	dir := t.TempDir()
 	name := filepath.Join(dir, "list.txt")
 	require.NoError(t, os.WriteFile(name, []byte("10.0.0.0/8\n"), 0644))
@@ -204,14 +235,14 @@ func TestMultiIPDBReloadUnchanged(t *testing.T) {
 	_, ok := reloaded.Match(net.ParseIP("10.1.2.3"))
 	require.True(t, ok, "the carried database was closed with the old group")
 
-	// With every source unreadable the group says so, and still hands back a
-	// database holding the rules it was already serving.
+	// With every source unreadable the group still reloads, holding the rules
+	// each of its sources already had.
 	onlyFailing, err := NewMultiIPDB(unreadable)
 	require.NoError(t, err)
 	kept, err := onlyFailing.Reload()
-	require.ErrorIs(t, err, ErrBlocklistUnchanged)
+	require.NoError(t, err)
 	_, ok = kept.Match(net.ParseIP("10.1.2.3"))
-	require.True(t, ok, "the group reported unchanged without the rules to go with it")
+	require.True(t, ok, "the group dropped the rules it was serving")
 }
 
 // A database that owns something closing releases, as the location databases
@@ -225,7 +256,7 @@ type handleIPDB struct {
 
 func (m *handleIPDB) Reload() (IPBlocklistDB, error) {
 	m.next = &handleIPDB{ip: m.ip}
-	return m.next, ErrBlocklistUnchanged
+	return m.next, errors.New("the list could not be read")
 }
 
 func (m *handleIPDB) Match(ip net.IP) (*BlocklistMatch, bool) {

--- a/blocklistdb_test.go
+++ b/blocklistdb_test.go
@@ -3,6 +3,8 @@ package rdns
 import (
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -135,4 +137,40 @@ func TestRefreshDatabaseKeepsFailedDatabase(t *testing.T) {
 	mu.RLock()
 	defer mu.RUnlock()
 	require.Same(t, original, db)
+}
+
+// A source that cannot be read holds the rules it has while the sources beside
+// it carry on refreshing. Only when none of them can be read is there nothing
+// to swap in.
+func TestMultiDBReloadUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "list.txt")
+	require.NoError(t, os.WriteFile(name, []byte("gone.example.com\n"), 0644))
+
+	failing := NewFileLoader(name, FileLoaderOptions{AllowFailure: true})
+	unreadable, err := NewDomainDB("unreadable", failing)
+	require.NoError(t, err)
+	steady, err := NewDomainDB("steady", NewStaticLoader([]string{"kept.example.com"}))
+	require.NoError(t, err)
+
+	multi, err := NewMultiDB(unreadable, steady)
+	require.NoError(t, err)
+
+	// The file is gone, so that source reports nothing to change. The group
+	// still reloads, and both sets of rules still match.
+	require.NoError(t, os.Remove(name))
+	reloaded, err := multi.Reload()
+	require.NoError(t, err, "one unreadable source must not stall the group")
+	for _, q := range []string{"gone.example.com.", "kept.example.com."} {
+		msg := new(dns.Msg)
+		msg.SetQuestion(q, dns.TypeA)
+		_, _, _, ok := reloaded.Match(msg)
+		require.True(t, ok, "query %s", q)
+	}
+
+	// With every source unreadable there is nothing new to install.
+	onlyFailing, err := NewMultiDB(unreadable)
+	require.NoError(t, err)
+	_, err = onlyFailing.Reload()
+	require.ErrorIs(t, err, errBlocklistUnchanged)
 }

--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -1,14 +1,12 @@
 package rdns
 
 import (
-	"bufio"
 	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"path/filepath"
 	"time"
 )
@@ -43,54 +41,37 @@ func NewHTTPLoader(url string, opt HTTPLoaderOptions) *HTTPLoader {
 }
 
 // Load passes the rules on as they arrive over the wire, so a list of millions
-// of them is never held in memory as a whole. See FileLoader.Load for what a
-// failure means, which is the same here.
+// of them is never held in memory as a whole. See listFailed for what a list
+// that could not be read means.
 func (l *HTTPLoader) Load(reset func(), fn func(rule string) error) error {
 	log := Log.With("url", l.url)
 	log.Debug("loading blocklist")
 
 	start := time.Now()
-	err := l.read(log, reset, fn)
-	if err == nil {
-		l.loaded = true
-		log.With("load-time", time.Since(start)).Debug("completed loading blocklist")
-		return nil
+	if err := l.read(log, reset, fn); err != nil {
+		return listFailed(log, l.opt.AllowFailure, l.loaded, reset, err)
 	}
-	if !l.opt.AllowFailure || !loadFailure(err) {
-		return err
-	}
-	if l.loaded {
-		log.Warn("failed to load blocklist, continuing with the previous ruleset",
-			"error", err)
-		return ErrBlocklistUnchanged
-	}
-	log.Warn("failed to load blocklist, continuing without it", "error", err)
-	reset()
+	l.loaded = true
+	log.With("load-time", time.Since(start)).Debug("completed loading blocklist")
 	return nil
 }
 
 func (l *HTTPLoader) read(log *slog.Logger, reset func(), fn func(rule string) error) error {
 	// If a cache-dir was given, try to load the list from disk on first load,
-	// and fall back to the network when that fails. A cached copy that breaks
-	// off part way through has already handed some of itself over, so drop
-	// that before the list arrives again from upstream.
+	// and fall back to the network when that fails. Whatever a cached copy
+	// handed over before it broke off is dropped first, so the list that
+	// arrives from upstream is the only one built.
 	if l.fromDisk {
 		l.fromDisk = false
-		var served int
-		err := l.readFile(l.cacheFilename(), func(rule string) error {
-			served++
-			return fn(rule)
-		})
+		err := readRulesFile(l.cacheFilename(), fn)
 		if err == nil {
 			log.Debug("loaded blocklist from cache-dir")
 			return nil
 		}
-		if !loadFailure(err) {
+		if isRuleError(err) {
 			return err // the database refused a rule, another copy will not help
 		}
-		if served > 0 {
-			reset()
-		}
+		reset()
 		log.Warn("unable to load cached list from disk, loading from upstream",
 			"error", err)
 	}
@@ -150,45 +131,22 @@ func (l *HTTPLoader) read(log *slog.Logger, reset func(), fn func(rule string) e
 	return nil
 }
 
-func (l *HTTPLoader) readFile(name string, fn func(rule string) error) error {
-	f, err := os.Open(name)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	return scanRules(f, fn)
-}
-
-// cacheWhileReading passes every rule read from r to fn and copies what it
-// reads into w along the way, keeping the two failures apart. A cache that
-// cannot be written must not look like a list that broke off, and it otherwise
-// would: io.TeeReader hands a write error back as a read error, and the cache
-// file is buffered, so it flushes part way through a list of any size.
+// cacheWhileReading passes every rule read from r to fn and writes it to w on
+// the way past, keeping the two failures apart. A cache that cannot be written
+// must not look like a list that broke off, so the write error is kept here
+// rather than raised where the read would report it.
 func cacheWhileReading(r io.Reader, w io.Writer, fn func(rule string) error) (scanErr, cacheErr error) {
-	cache := writerFunc(func(p []byte) (int, error) {
+	write := func(s string) {
 		if cacheErr == nil {
-			_, cacheErr = w.Write(p)
-		}
-		return len(p), nil
-	})
-	scanErr = scanRules(io.TeeReader(r, cache), fn)
-	return scanErr, cacheErr
-}
-
-// writerFunc is an io.Writer made from a function.
-type writerFunc func(p []byte) (int, error)
-
-func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
-
-// scanRules passes every line of r to fn as a rule.
-func scanRules(r io.Reader, fn func(rule string) error) error {
-	scanner := bufio.NewScanner(r)
-	for scanner.Scan() {
-		if err := fn(scanner.Text()); err != nil {
-			return ruleError{err}
+			_, cacheErr = io.WriteString(w, s)
 		}
 	}
-	return scanner.Err()
+	scanErr = scanRules(r, func(rule string) error {
+		write(rule)
+		write("\n")
+		return fn(rule)
+	})
+	return scanErr, cacheErr
 }
 
 // Returns the name of the list cache file, which is the SHA256 of url in the cache-dir.

--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -55,9 +55,8 @@ func (l *HTTPLoader) Load() ([]string, error) {
 }
 
 // loadEach passes the rules on as they arrive over the wire, so a list of
-// millions of them is never held in memory as a whole. A failed load with
-// AllowFailure set leaves whatever database is already serving queries in
-// place, or starts with an empty one when nothing has loaded yet.
+// millions of them is never held in memory as a whole. See FileLoader.loadEach
+// for what a failure means, which is the same here.
 func (l *HTTPLoader) loadEach(fn func(rule string) error) error {
 	log := Log.With("url", l.url)
 	log.Debug("loading blocklist")

--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -63,13 +63,23 @@ func (l *HTTPLoader) loadEach(fn func(rule string) error) error {
 	log.Debug("loading blocklist")
 
 	start := time.Now()
-	err := l.read(log, fn)
+	var served int
+	err := l.read(log, func(rule string) error {
+		served++
+		return fn(rule)
+	})
 	if err == nil {
 		l.loaded = true
 		log.With("load-time", time.Since(start)).Debug("completed loading blocklist")
 		return nil
 	}
 	if !l.opt.AllowFailure || !loadFailure(err) {
+		return err
+	}
+	if served > 0 {
+		// Part of the list is already through, so there is nothing to carry on
+		// with: the database being built holds a fragment of the rules and has
+		// to be thrown away rather than served.
 		return err
 	}
 	if !l.loaded { // nothing loaded yet, carry on with an empty list
@@ -127,9 +137,22 @@ func (l *HTTPLoader) read(log *slog.Logger, fn func(rule string) error) error {
 	// write afterwards. The file is only renamed into place if the whole body
 	// arrives, so a failed download leaves the previous cache alone.
 	log.Debug("writing rules to cache-dir")
-	return writeFileAtomic(l.cacheFilename(), func(w io.Writer) error {
-		return scanRules(io.TeeReader(resp.Body, w), fn)
+	var served int
+	err = writeFileAtomic(l.cacheFilename(), func(w io.Writer) error {
+		return scanRules(io.TeeReader(resp.Body, w), func(rule string) error {
+			served++
+			return fn(rule)
+		})
 	})
+
+	// A cache that cannot be written is worth a warning, not a failed load, so
+	// long as nothing has been read yet: the body is still there to be read
+	// without it. Once rules are through, the failure is the read itself.
+	if err != nil && served == 0 && loadFailure(err) {
+		log.Warn("failed to write rules to cache-dir", "error", err)
+		return scanRules(resp.Body, fn)
+	}
+	return err
 }
 
 func (l *HTTPLoader) readFile(name string, fn func(rule string) error) error {

--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -66,11 +66,7 @@ func (l *HTTPLoader) loadEach(fn func(rule string) error) error {
 	log.Debug("loading blocklist")
 
 	start := time.Now()
-	var served int
-	err := l.read(log, func(rule string) error {
-		served++
-		return fn(rule)
-	})
+	err := l.read(log, fn)
 	if err == nil {
 		l.loaded = true
 		log.With("load-time", time.Since(start)).Debug("completed loading blocklist")
@@ -134,22 +130,31 @@ func (l *HTTPLoader) read(log *slog.Logger, fn func(rule string) error) error {
 	// write afterwards. The file is only renamed into place if the whole body
 	// arrives, so a failed download leaves the previous cache alone.
 	log.Debug("writing rules to cache-dir")
-	var served int
+	var scanErr error
+	var opened bool
 	err = writeFileAtomic(l.cacheFilename(), func(w io.Writer) error {
-		return scanRules(io.TeeReader(resp.Body, w), func(rule string) error {
-			served++
-			return fn(rule)
-		})
+		opened = true
+		scanErr = scanRules(io.TeeReader(resp.Body, w), fn)
+		return scanErr
 	})
 
-	// A cache that cannot be written is worth a warning, not a failed load, so
-	// long as nothing has been read yet: the body is still there to be read
-	// without it. Once rules are through, the failure is the read itself.
-	if err != nil && served == 0 && loadFailure(err) {
-		log.Warn("failed to write rules to cache-dir", "error", err)
+	// A cache that cannot be written is worth reporting, not failing the load
+	// over: the rules are in hand either way. The two have to be told apart by
+	// which one failed rather than by how far the read got, because the file
+	// is buffered and its flush, sync and rename all happen after the body has
+	// been read and every rule passed on.
+	switch {
+	case !opened:
+		// Nothing has been read yet, so the body is still there to take
+		// without a cache to write it to.
+		log.Error("failed to write rules to cache-dir", "error", err)
 		return scanRules(resp.Body, fn)
+	case scanErr != nil:
+		return scanErr
+	case err != nil:
+		log.Error("failed to write rules to cache-dir", "error", err)
 	}
-	return err
+	return nil
 }
 
 func (l *HTTPLoader) readFile(name string, fn func(rule string) error) error {

--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -40,9 +40,8 @@ func NewHTTPLoader(url string, opt HTTPLoaderOptions) *HTTPLoader {
 	return l
 }
 
-// Load passes the rules on as they arrive over the wire, so a list of millions
-// of them is never held in memory as a whole. See listFailed for what a list
-// that could not be read means.
+// Load passes the rules on as they arrive. See listFailed for a list that
+// could not be read.
 func (l *HTTPLoader) Load(reset func(), fn func(rule string) error) error {
 	log := Log.With("url", l.url)
 	log.Debug("loading blocklist")
@@ -57,10 +56,9 @@ func (l *HTTPLoader) Load(reset func(), fn func(rule string) error) error {
 }
 
 func (l *HTTPLoader) read(log *slog.Logger, reset func(), fn func(rule string) error) error {
-	// If a cache-dir was given, try to load the list from disk on first load,
-	// and fall back to the network when that fails. Whatever a cached copy
-	// handed over before it broke off is dropped first, so the list that
-	// arrives from upstream is the only one built.
+	// With a cache-dir, the first load comes from disk and falls back to the
+	// network. Whatever the cached copy handed over is dropped first, so the
+	// list from upstream is the only one built.
 	if l.fromDisk {
 		l.fromDisk = false
 		err := readRulesFile(l.cacheFilename(), fn)
@@ -93,9 +91,8 @@ func (l *HTTPLoader) read(log *slog.Logger, reset func(), fn func(rule string) e
 		return scanRules(resp.Body, fn)
 	}
 
-	// Write the list to the cache as it is read rather than keeping it to
-	// write afterwards. The file is only renamed into place if the whole body
-	// arrives, so a failed download leaves the previous cache alone.
+	// The list is cached as it is read. The file is only renamed into place if
+	// the whole body arrives, so a failed download leaves the cache alone.
 	log.Debug("writing rules to cache-dir")
 	var scanErr error
 	var opened bool
@@ -110,14 +107,11 @@ func (l *HTTPLoader) read(log *slog.Logger, reset func(), fn func(rule string) e
 	})
 
 	// A cache that cannot be written is worth reporting, not failing the load
-	// over: the rules are in hand either way. The two have to be told apart by
-	// which one failed rather than by how far the read got, because the file
-	// is buffered and its flush, sync and rename all happen after the body has
-	// been read and every rule passed on.
+	// over. Which of the two failed cannot be told from how far the read got,
+	// since the flush, sync and rename all happen after the last rule.
 	switch {
 	case !opened:
-		// Nothing has been read yet, so the body is still there to take
-		// without a cache to write it to.
+		// Nothing read yet, so the body is still there to take.
 		log.Error("failed to write rules to cache-dir", "error", err)
 		return scanRules(resp.Body, fn)
 	case scanErr != nil:
@@ -129,9 +123,8 @@ func (l *HTTPLoader) read(log *slog.Logger, reset func(), fn func(rule string) e
 }
 
 // cacheWhileReading passes every rule read from r to fn and writes it to w on
-// the way past, keeping the two failures apart. A cache that cannot be written
-// must not look like a list that broke off, so the write error is kept here
-// rather than raised where the read would report it.
+// the way past, returning the read and write failures apart from one another
+// so that an unwritable cache never looks like a list that broke off.
 func cacheWhileReading(r io.Reader, w io.Writer, fn func(rule string) error) (scanErr, cacheErr error) {
 	write := func(s string) {
 		if cacheErr == nil {

--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,10 +15,10 @@ import (
 
 // HTTPLoader reads blocklist rules from a server via HTTP(S).
 type HTTPLoader struct {
-	url         string
-	opt         HTTPLoaderOptions
-	fromDisk    bool
-	lastSuccess []string
+	url      string
+	opt      HTTPLoaderOptions
+	fromDisk bool
+	loaded   bool // a load has succeeded before, so there is a ruleset to keep
 }
 
 // HTTPLoaderOptions holds options for HTTP blocklist loaders.
@@ -28,12 +29,15 @@ type HTTPLoaderOptions struct {
 	AllowFailure bool
 }
 
-var _ BlocklistLoader = &HTTPLoader{}
+var (
+	_ BlocklistLoader = &HTTPLoader{}
+	_ streamingLoader = &HTTPLoader{}
+)
 
 const httpTimeout = 30 * time.Minute
 
 func NewHTTPLoader(url string, opt HTTPLoaderOptions) *HTTPLoader {
-	l := &HTTPLoader{url, opt, opt.CacheDir != "", nil}
+	l := &HTTPLoader{url, opt, opt.CacheDir != "", false}
 	if opt.CacheDir != "" {
 		// Clean up temp files left behind by a run that was killed mid-write.
 		removeStaleTempFiles(opt.CacheDir)
@@ -41,36 +45,59 @@ func NewHTTPLoader(url string, opt HTTPLoaderOptions) *HTTPLoader {
 	return l
 }
 
-func (l *HTTPLoader) Load() (rules []string, err error) {
+func (l *HTTPLoader) Load() ([]string, error) {
+	var rules []string
+	err := l.loadEach(func(rule string) error {
+		rules = append(rules, rule)
+		return nil
+	})
+	return rules, err
+}
+
+// loadEach passes the rules on as they arrive over the wire, so a list of
+// millions of them is never held in memory as a whole. A failed load with
+// AllowFailure set leaves whatever database is already serving queries in
+// place, or starts with an empty one when nothing has loaded yet.
+func (l *HTTPLoader) loadEach(fn func(rule string) error) error {
 	log := Log.With("url", l.url)
 	log.Debug("loading blocklist")
 
-	// If AllowFailure is enabled, return the last successfully loaded list
-	// and nil. Without it there's nothing to fall back to, so the rules are
-	// not kept: for a large list that copy would be held for the life of the
-	// process.
-	defer func() {
-		if !l.opt.AllowFailure {
-			return
-		}
-		if err != nil {
-			log.Warn("failed to load blocklist, continuing with previous ruleset",
-				"error", err)
-			rules = l.lastSuccess
-			err = nil
-			return
-		}
-		l.lastSuccess = rules
-	}()
+	start := time.Now()
+	err := l.read(log, fn)
+	if err == nil {
+		l.loaded = true
+		log.With("load-time", time.Since(start)).Debug("completed loading blocklist")
+		return nil
+	}
+	if !l.opt.AllowFailure || !loadFailure(err) {
+		return err
+	}
+	if !l.loaded { // nothing loaded yet, carry on with an empty list
+		log.Warn("failed to load blocklist, continuing without it", "error", err)
+		return nil
+	}
+	log.Warn("failed to load blocklist, continuing with the previous ruleset",
+		"error", err)
+	return errBlocklistUnchanged
+}
 
-	// If a cache-dir was given, try to load the list from disk on first load
+func (l *HTTPLoader) read(log *slog.Logger, fn func(rule string) error) error {
+	// If a cache-dir was given, try to load the list from disk on first load.
+	// Only fall back to the network if nothing was passed on yet, since the
+	// rules already handed over cannot be taken back.
 	if l.fromDisk {
-		start := time.Now()
 		l.fromDisk = false
-		rules, err := l.loadFromDisk()
+		var served int
+		err := l.readFile(l.cacheFilename(), func(rule string) error {
+			served++
+			return fn(rule)
+		})
 		if err == nil {
-			log.With("load-time", time.Since(start)).Debug("loaded blocklist from cache-dir")
-			return rules, err
+			log.Debug("loaded blocklist from cache-dir")
+			return nil
+		}
+		if served > 0 || !loadFailure(err) {
+			return err
 		}
 		log.Warn("unable to load cached list from disk, loading from upstream",
 			"error", err)
@@ -81,64 +108,48 @@ func (l *HTTPLoader) Load() (rules []string, err error) {
 
 	req, err := http.NewRequestWithContext(ctx, "GET", l.url, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("got unexpected status code %d from %s", resp.StatusCode, l.url)
+		return fmt.Errorf("got unexpected status code %d from %s", resp.StatusCode, l.url)
 	}
 
-	start := time.Now()
-	scanner := bufio.NewScanner(resp.Body)
-	for scanner.Scan() {
-		rules = append(rules, scanner.Text())
+	if l.opt.CacheDir == "" {
+		return scanRules(resp.Body, fn)
 	}
-	log.With("load-time", time.Since(start)).Debug("completed loading blocklist")
 
-	// Cache the content to disk if the read from the remote server was successful
-	if scanner.Err() == nil && l.opt.CacheDir != "" {
-		log.Debug("writing rules to cache-dir")
-		if err := l.writeToDisk(rules); err != nil {
-			Log.Error("failed to write rules to cache", "error", err)
-		}
-	}
-	return rules, scanner.Err()
+	// Write the list to the cache as it is read rather than keeping it to
+	// write afterwards. The file is only renamed into place if the whole body
+	// arrives, so a failed download leaves the previous cache alone.
+	log.Debug("writing rules to cache-dir")
+	return writeFileAtomic(l.cacheFilename(), func(w io.Writer) error {
+		return scanRules(io.TeeReader(resp.Body, w), fn)
+	})
 }
 
-// Loads a cached version of the list from disk. The filename is made by hashing the URL with SHA256
-// and the file is expect to be in cache-dir.
-func (l *HTTPLoader) loadFromDisk() ([]string, error) {
-	f, err := os.Open(l.cacheFilename())
+func (l *HTTPLoader) readFile(name string, fn func(rule string) error) error {
+	f, err := os.Open(name)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer f.Close()
-	var rules []string
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		rules = append(rules, scanner.Text())
-	}
-	return rules, scanner.Err()
+	return scanRules(f, fn)
 }
 
-func (l *HTTPLoader) writeToDisk(rules []string) error {
-	return writeFileAtomic(l.cacheFilename(), func(w io.Writer) error {
-		for _, r := range rules {
-			if _, err := io.WriteString(w, r); err != nil {
-				return err
-			}
-			if _, err := io.WriteString(w, "\n"); err != nil {
-				return err
-			}
+// scanRules passes every line of r to fn as a rule.
+func scanRules(r io.Reader, fn func(rule string) error) error {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		if err := fn(scanner.Text()); err != nil {
+			return ruleError{err}
 		}
-		return nil
-	})
+	}
+	return scanner.Err()
 }
 
 // Returns the name of the list cache file, which is the SHA256 of url in the cache-dir.

--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -30,10 +29,7 @@ type HTTPLoaderOptions struct {
 	AllowFailure bool
 }
 
-var (
-	_ BlocklistLoader = &HTTPLoader{}
-	_ streamingLoader = &HTTPLoader{}
-)
+var _ BlocklistLoader = &HTTPLoader{}
 
 const httpTimeout = 30 * time.Minute
 
@@ -46,27 +42,15 @@ func NewHTTPLoader(url string, opt HTTPLoaderOptions) *HTTPLoader {
 	return l
 }
 
-func (l *HTTPLoader) Load() ([]string, error) {
-	var rules []string
-	err := l.loadEach(func(rule string) error {
-		rules = append(rules, rule)
-		return nil
-	})
-	if errors.Is(err, errBlocklistEmpty) {
-		return nil, nil // an incomplete list is no list, as it always was
-	}
-	return rules, err
-}
-
-// loadEach passes the rules on as they arrive over the wire, so a list of
-// millions of them is never held in memory as a whole. See FileLoader.loadEach
-// for what a failure means, which is the same here.
-func (l *HTTPLoader) loadEach(fn func(rule string) error) error {
+// Load passes the rules on as they arrive over the wire, so a list of millions
+// of them is never held in memory as a whole. See FileLoader.Load for what a
+// failure means, which is the same here.
+func (l *HTTPLoader) Load(reset func(), fn func(rule string) error) error {
 	log := Log.With("url", l.url)
 	log.Debug("loading blocklist")
 
 	start := time.Now()
-	err := l.read(log, fn)
+	err := l.read(log, reset, fn)
 	if err == nil {
 		l.loaded = true
 		log.With("load-time", time.Since(start)).Debug("completed loading blocklist")
@@ -75,19 +59,21 @@ func (l *HTTPLoader) loadEach(fn func(rule string) error) error {
 	if !l.opt.AllowFailure || !loadFailure(err) {
 		return err
 	}
-	if !l.loaded { // nothing loaded yet, carry on with an empty list
-		log.Warn("failed to load blocklist, continuing without it", "error", err)
-		return errBlocklistEmpty
+	if l.loaded {
+		log.Warn("failed to load blocklist, continuing with the previous ruleset",
+			"error", err)
+		return ErrBlocklistUnchanged
 	}
-	log.Warn("failed to load blocklist, continuing with the previous ruleset",
-		"error", err)
-	return ErrBlocklistUnchanged
+	log.Warn("failed to load blocklist, continuing without it", "error", err)
+	reset()
+	return nil
 }
 
-func (l *HTTPLoader) read(log *slog.Logger, fn func(rule string) error) error {
-	// If a cache-dir was given, try to load the list from disk on first load.
-	// Only fall back to the network if nothing was passed on yet, since the
-	// rules already handed over cannot be taken back.
+func (l *HTTPLoader) read(log *slog.Logger, reset func(), fn func(rule string) error) error {
+	// If a cache-dir was given, try to load the list from disk on first load,
+	// and fall back to the network when that fails. A cached copy that breaks
+	// off part way through has already handed some of itself over, so drop
+	// that before the list arrives again from upstream.
 	if l.fromDisk {
 		l.fromDisk = false
 		var served int
@@ -99,8 +85,11 @@ func (l *HTTPLoader) read(log *slog.Logger, fn func(rule string) error) error {
 			log.Debug("loaded blocklist from cache-dir")
 			return nil
 		}
-		if served > 0 || !loadFailure(err) {
-			return err
+		if !loadFailure(err) {
+			return err // the database refused a rule, another copy will not help
+		}
+		if served > 0 {
+			reset()
 		}
 		log.Warn("unable to load cached list from disk, loading from upstream",
 			"error", err)

--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -51,6 +52,9 @@ func (l *HTTPLoader) Load() ([]string, error) {
 		rules = append(rules, rule)
 		return nil
 	})
+	if errors.Is(err, errBlocklistEmpty) {
+		return nil, nil // an incomplete list is no list, as it always was
+	}
 	return rules, err
 }
 
@@ -75,15 +79,9 @@ func (l *HTTPLoader) loadEach(fn func(rule string) error) error {
 	if !l.opt.AllowFailure || !loadFailure(err) {
 		return err
 	}
-	if served > 0 {
-		// Part of the list is already through, so there is nothing to carry on
-		// with: the database being built holds a fragment of the rules and has
-		// to be thrown away rather than served.
-		return err
-	}
 	if !l.loaded { // nothing loaded yet, carry on with an empty list
 		log.Warn("failed to load blocklist, continuing without it", "error", err)
-		return nil
+		return errBlocklistEmpty
 	}
 	log.Warn("failed to load blocklist, continuing with the previous ruleset",
 		"error", err)

--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -68,9 +68,6 @@ func (l *HTTPLoader) read(log *slog.Logger, reset func(), fn func(rule string) e
 			log.Debug("loaded blocklist from cache-dir")
 			return nil
 		}
-		if isRuleError(err) {
-			return err // the database refused a rule, another copy will not help
-		}
 		reset()
 		log.Warn("unable to load cached list from disk, loading from upstream",
 			"error", err)

--- a/blocklistloader-http.go
+++ b/blocklistloader-http.go
@@ -81,7 +81,7 @@ func (l *HTTPLoader) loadEach(fn func(rule string) error) error {
 	}
 	log.Warn("failed to load blocklist, continuing with the previous ruleset",
 		"error", err)
-	return errBlocklistUnchanged
+	return ErrBlocklistUnchanged
 }
 
 func (l *HTTPLoader) read(log *slog.Logger, fn func(rule string) error) error {
@@ -134,8 +134,12 @@ func (l *HTTPLoader) read(log *slog.Logger, fn func(rule string) error) error {
 	var opened bool
 	err = writeFileAtomic(l.cacheFilename(), func(w io.Writer) error {
 		opened = true
-		scanErr = scanRules(io.TeeReader(resp.Body, w), fn)
-		return scanErr
+		var cacheErr error
+		scanErr, cacheErr = cacheWhileReading(resp.Body, w, fn)
+		if scanErr != nil {
+			return scanErr
+		}
+		return cacheErr
 	})
 
 	// A cache that cannot be written is worth reporting, not failing the load
@@ -165,6 +169,27 @@ func (l *HTTPLoader) readFile(name string, fn func(rule string) error) error {
 	defer f.Close()
 	return scanRules(f, fn)
 }
+
+// cacheWhileReading passes every rule read from r to fn and copies what it
+// reads into w along the way, keeping the two failures apart. A cache that
+// cannot be written must not look like a list that broke off, and it otherwise
+// would: io.TeeReader hands a write error back as a read error, and the cache
+// file is buffered, so it flushes part way through a list of any size.
+func cacheWhileReading(r io.Reader, w io.Writer, fn func(rule string) error) (scanErr, cacheErr error) {
+	cache := writerFunc(func(p []byte) (int, error) {
+		if cacheErr == nil {
+			_, cacheErr = w.Write(p)
+		}
+		return len(p), nil
+	})
+	scanErr = scanRules(io.TeeReader(r, cache), fn)
+	return scanErr, cacheErr
+}
+
+// writerFunc is an io.Writer made from a function.
+type writerFunc func(p []byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
 
 // scanRules passes every line of r to fn as a rule.
 func scanRules(r io.Reader, fn func(rule string) error) error {

--- a/blocklistloader-http_test.go
+++ b/blocklistloader-http_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
 )
 
@@ -104,8 +105,10 @@ func TestLoaderAllowFailure(t *testing.T) {
 	require.NotErrorIs(t, err, errBlocklistUnchanged)
 }
 
-// A body that stops short of what was promised is a partial list. It must not
-// be reported as a loaded one, and the cached copy must survive it.
+// A body that stops short of what was promised is a partial list. Whether that
+// fails the load or is carried on without depends on AllowFailure, exactly as
+// a list that could not be read at all does, and either way the cached copy
+// survives it and no part of the fragment is served.
 func TestHTTPLoaderTruncatedBody(t *testing.T) {
 	dir := t.TempDir()
 	truncate := false
@@ -123,17 +126,57 @@ func TestHTTPLoaderTruncatedBody(t *testing.T) {
 	require.NoError(t, err)
 
 	truncate = true
-	for _, allowFailure := range []bool{false, true} {
-		l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir, AllowFailure: allowFailure})
-		l.fromDisk = false // force it to the network
-		_, err = l.Load()
-		require.Error(t, err, "allow-failure=%v: a partial list is not a list", allowFailure)
-		require.NotErrorIs(t, err, errBlocklistUnchanged)
-	}
+	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
+	l.fromDisk = false // force it to the network
+	_, err = l.Load()
+	require.Error(t, err, "without allow-failure a partial list is an error")
+	require.NotErrorIs(t, err, errBlocklistUnchanged)
+
+	// With allow-failure and nothing loaded yet, the fragment is dropped and
+	// the list is empty, which is what an unreadable list has always done.
+	allow := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir, AllowFailure: true})
+	allow.fromDisk = false
+	rules, err := allow.Load()
+	require.NoError(t, err)
+	require.Empty(t, rules, "a fragment of a list must not be served as the list")
+
+	// Once a list has loaded, a later fragment leaves it in place instead.
+	truncate = false
+	rules, err = allow.Load()
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+	truncate = true
+	_, err = allow.Load()
+	require.ErrorIs(t, err, errBlocklistUnchanged)
 
 	cached, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
 	require.NoError(t, err)
 	require.Equal(t, []string{"a.example.com", "b.example.com"}, cached)
+}
+
+// The database built from a list that broke off must hold none of it, not the
+// part that arrived before it broke.
+func TestPartialListDiscarded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1000")
+		fmt.Fprint(w, "half.example.com\nalso.example.com\n")
+	}))
+	defer srv.Close()
+
+	loader := NewHTTPLoader(srv.URL, HTTPLoaderOptions{AllowFailure: true})
+	for _, db := range map[string]func() (BlocklistDB, error){
+		"domain":  func() (BlocklistDB, error) { return NewDomainDB("l", loader) },
+		"compact": func() (BlocklistDB, error) { return NewDomainCompactDB("l", loader) },
+	} {
+		m, err := db()
+		require.NoError(t, err)
+		for _, q := range []string{"half.example.com.", "also.example.com."} {
+			msg := new(dns.Msg)
+			msg.SetQuestion(q, dns.TypeA)
+			_, _, _, ok := m.Match(msg)
+			require.False(t, ok, "query %s came from a list that never finished loading", q)
+		}
+	}
 }
 
 // A cache-dir that cannot be written to is worth a warning, not a failed load.

--- a/blocklistloader-http_test.go
+++ b/blocklistloader-http_test.go
@@ -1,36 +1,105 @@
 package rdns
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// The disk cache round-trips through writeToDisk/loadFromDisk, and a rewrite
-// replaces the previous content rather than leaving a longer file's tail
-// behind. The cache file must be the only thing in the cache-dir, which pins
-// the temp file's location as well as its cleanup.
+// A list read from the server is cached to disk as it arrives, and the next
+// loader started against the same cache-dir reads it from there. A second
+// download replaces the previous content rather than leaving a longer file's
+// tail behind, and the cache file must be the only thing in the cache-dir,
+// which pins the temp file's location as well as its cleanup.
 func TestHTTPLoaderDiskCache(t *testing.T) {
 	dir := t.TempDir()
-	l := NewHTTPLoader("https://example.com/list.txt", HTTPLoaderOptions{CacheDir: dir})
+	var served []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, strings.Join(served, "\n"))
+	}))
+	defer srv.Close()
 
-	rules := []string{"a.example.com", "b.example.com", "c.example.com"}
-	require.NoError(t, l.writeToDisk(rules))
-
-	got, err := l.loadFromDisk()
+	served = []string{"a.example.com", "b.example.com", "c.example.com"}
+	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
+	got, err := l.Load()
 	require.NoError(t, err)
-	require.Equal(t, rules, got)
+	require.Equal(t, served, got)
+
+	// A new loader with the same cache-dir starts from the file on disk.
+	cached, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	require.NoError(t, err)
+	require.Equal(t, served, cached)
 
 	// A shorter list must not leave the tail of the previous one behind.
-	require.NoError(t, l.writeToDisk([]string{"only.example.com"}))
-	got, err = l.loadFromDisk()
+	served = []string{"only.example.com"}
+	got, err = l.Load()
 	require.NoError(t, err)
-	require.Equal(t, []string{"only.example.com"}, got)
+	require.Equal(t, served, got)
+	cached, err = NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	require.NoError(t, err)
+	require.Equal(t, served, cached)
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 	require.Len(t, entries, 1, "only the cache file should remain: %v", entries)
 	require.Equal(t, filepath.Base(l.cacheFilename()), entries[0].Name())
+}
+
+// A download that fails part way through must leave the cached copy alone.
+func TestHTTPLoaderCacheKeptOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	good := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !good {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprint(w, "a.example.com\nb.example.com")
+	}))
+	defer srv.Close()
+
+	_, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	require.NoError(t, err)
+
+	good = false
+	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
+	l.fromDisk = false // force it to the network
+	_, err = l.Load()
+	require.Error(t, err)
+
+	cached, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.example.com", "b.example.com"}, cached)
+}
+
+// With AllowFailure set, a list that has never loaded starts empty, while one
+// that has loaded before keeps what it has.
+func TestLoaderAllowFailure(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "list.txt")
+
+	l := NewFileLoader(name, FileLoaderOptions{AllowFailure: true})
+	rules, err := l.Load()
+	require.NoError(t, err, "a list that never loaded starts empty")
+	require.Empty(t, rules)
+
+	require.NoError(t, os.WriteFile(name, []byte("a.example.com\n"), 0644))
+	rules, err = l.Load()
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.example.com"}, rules)
+
+	require.NoError(t, os.Remove(name))
+	_, err = l.Load()
+	require.ErrorIs(t, err, errBlocklistUnchanged, "a loaded list keeps what it has")
+
+	// Without AllowFailure the error surfaces as it always did.
+	_, err = NewFileLoader(name, FileLoaderOptions{}).Load()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errBlocklistUnchanged)
 }

--- a/blocklistloader-http_test.go
+++ b/blocklistloader-http_test.go
@@ -14,6 +14,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// collectRules loads a list into a slice, which is how these tests read what a
+// loader hands over. Rules arrive one at a time, and a loader that gives up on
+// a list resets what it already passed on.
+func collectRules(l BlocklistLoader) ([]string, error) {
+	var rules []string
+	err := l.Load(
+		func() { rules = nil },
+		func(rule string) error {
+			rules = append(rules, rule)
+			return nil
+		})
+	return rules, err
+}
+
 // A list read from the server is cached to disk as it arrives, and the next
 // loader started against the same cache-dir reads it from there. A second
 // download replaces the previous content rather than leaving a longer file's
@@ -29,21 +43,21 @@ func TestHTTPLoaderDiskCache(t *testing.T) {
 
 	served = []string{"a.example.com", "b.example.com", "c.example.com"}
 	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
-	got, err := l.Load()
+	got, err := collectRules(l)
 	require.NoError(t, err)
 	require.Equal(t, served, got)
 
 	// A new loader with the same cache-dir starts from the file on disk.
-	cached, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	cached, err := collectRules(NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}))
 	require.NoError(t, err)
 	require.Equal(t, served, cached)
 
 	// A shorter list must not leave the tail of the previous one behind.
 	served = []string{"only.example.com"}
-	got, err = l.Load()
+	got, err = collectRules(l)
 	require.NoError(t, err)
 	require.Equal(t, served, got)
-	cached, err = NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	cached, err = collectRules(NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}))
 	require.NoError(t, err)
 	require.Equal(t, served, cached)
 
@@ -66,18 +80,38 @@ func TestHTTPLoaderCacheKeptOnFailure(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	_, err := collectRules(NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}))
 	require.NoError(t, err)
 
 	good = false
 	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
 	l.fromDisk = false // force it to the network
-	_, err = l.Load()
+	_, err = collectRules(l)
 	require.Error(t, err)
 
-	cached, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	cached, err := collectRules(NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}))
 	require.NoError(t, err)
 	require.Equal(t, []string{"a.example.com", "b.example.com"}, cached)
+}
+
+// A cached copy that breaks off part way through is dropped and the list read
+// again from upstream, rather than the fragment being served as the list.
+func TestHTTPLoaderCorruptCacheFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "a.example.com\nb.example.com")
+	}))
+	defer srv.Close()
+
+	// A cache file holding a rule and then a line longer than the scanner can
+	// take, so the read fails only after part of the list was handed over.
+	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
+	corrupt := "cached.example.com\n" + strings.Repeat("x", 100_000)
+	require.NoError(t, os.WriteFile(l.cacheFilename(), []byte(corrupt), 0644))
+
+	rules, err := collectRules(l)
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
 }
 
 // With AllowFailure set, a list that has never loaded starts empty, while one
@@ -87,21 +121,21 @@ func TestLoaderAllowFailure(t *testing.T) {
 	name := filepath.Join(dir, "list.txt")
 
 	l := NewFileLoader(name, FileLoaderOptions{AllowFailure: true})
-	rules, err := l.Load()
+	rules, err := collectRules(l)
 	require.NoError(t, err, "a list that never loaded starts empty")
 	require.Empty(t, rules)
 
 	require.NoError(t, os.WriteFile(name, []byte("a.example.com\n"), 0644))
-	rules, err = l.Load()
+	rules, err = collectRules(l)
 	require.NoError(t, err)
 	require.Equal(t, []string{"a.example.com"}, rules)
 
 	require.NoError(t, os.Remove(name))
-	_, err = l.Load()
+	_, err = collectRules(l)
 	require.ErrorIs(t, err, ErrBlocklistUnchanged, "a loaded list keeps what it has")
 
 	// Without AllowFailure the error surfaces as it always did.
-	_, err = NewFileLoader(name, FileLoaderOptions{}).Load()
+	_, err = collectRules(NewFileLoader(name, FileLoaderOptions{}))
 	require.Error(t, err)
 	require.NotErrorIs(t, err, ErrBlocklistUnchanged)
 }
@@ -123,13 +157,13 @@ func TestHTTPLoaderTruncatedBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	_, err := collectRules(NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}))
 	require.NoError(t, err)
 
 	truncate = true
 	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
 	l.fromDisk = false // force it to the network
-	_, err = l.Load()
+	_, err = collectRules(l)
 	require.Error(t, err, "without allow-failure a partial list is an error")
 	require.NotErrorIs(t, err, ErrBlocklistUnchanged)
 
@@ -137,20 +171,20 @@ func TestHTTPLoaderTruncatedBody(t *testing.T) {
 	// the list is empty, which is what an unreadable list has always done.
 	allow := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir, AllowFailure: true})
 	allow.fromDisk = false
-	rules, err := allow.Load()
+	rules, err := collectRules(allow)
 	require.NoError(t, err)
 	require.Empty(t, rules, "a fragment of a list must not be served as the list")
 
 	// Once a list has loaded, a later fragment leaves it in place instead.
 	truncate = false
-	rules, err = allow.Load()
+	rules, err = collectRules(allow)
 	require.NoError(t, err)
 	require.Len(t, rules, 2)
 	truncate = true
-	_, err = allow.Load()
+	_, err = collectRules(allow)
 	require.ErrorIs(t, err, ErrBlocklistUnchanged)
 
-	cached, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	cached, err := collectRules(NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}))
 	require.NoError(t, err)
 	require.Equal(t, []string{"a.example.com", "b.example.com"}, cached)
 }
@@ -192,7 +226,7 @@ func TestHTTPLoaderUnwritableCache(t *testing.T) {
 
 	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: notADir})
 	l.fromDisk = false
-	rules, err := l.Load()
+	rules, err := collectRules(l)
 	require.NoError(t, err, "the download worked, only the cache did not")
 	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
 }
@@ -211,7 +245,7 @@ func TestHTTPLoaderCacheWriteFails(t *testing.T) {
 	// A directory where the cache file belongs: the rename at the end fails.
 	require.NoError(t, os.Mkdir(l.cacheFilename(), 0755))
 
-	rules, err := l.Load()
+	rules, err := collectRules(l)
 	require.NoError(t, err, "the list arrived, only the cache write failed")
 	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
 }
@@ -262,7 +296,7 @@ func TestHTTPLoaderOverlongLine(t *testing.T) {
 	for _, dir := range []string{"", t.TempDir()} {
 		l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
 		l.fromDisk = false
-		rules, err := l.Load()
+		rules, err := collectRules(l)
 		require.Error(t, err, "cache-dir=%q", dir)
 		require.Empty(t, rules)
 	}

--- a/blocklistloader-http_test.go
+++ b/blocklistloader-http_test.go
@@ -103,3 +103,52 @@ func TestLoaderAllowFailure(t *testing.T) {
 	require.Error(t, err)
 	require.NotErrorIs(t, err, errBlocklistUnchanged)
 }
+
+// A body that stops short of what was promised is a partial list. It must not
+// be reported as a loaded one, and the cached copy must survive it.
+func TestHTTPLoaderTruncatedBody(t *testing.T) {
+	dir := t.TempDir()
+	truncate := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if truncate {
+			w.Header().Set("Content-Length", "1000")
+			fmt.Fprint(w, "half.example.com\n")
+			return
+		}
+		fmt.Fprint(w, "a.example.com\nb.example.com")
+	}))
+	defer srv.Close()
+
+	_, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	require.NoError(t, err)
+
+	truncate = true
+	for _, allowFailure := range []bool{false, true} {
+		l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir, AllowFailure: allowFailure})
+		l.fromDisk = false // force it to the network
+		_, err = l.Load()
+		require.Error(t, err, "allow-failure=%v: a partial list is not a list", allowFailure)
+		require.NotErrorIs(t, err, errBlocklistUnchanged)
+	}
+
+	cached, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.example.com", "b.example.com"}, cached)
+}
+
+// A cache-dir that cannot be written to is worth a warning, not a failed load.
+func TestHTTPLoaderUnwritableCache(t *testing.T) {
+	notADir := filepath.Join(t.TempDir(), "file")
+	require.NoError(t, os.WriteFile(notADir, nil, 0644))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "a.example.com\nb.example.com")
+	}))
+	defer srv.Close()
+
+	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: notADir})
+	l.fromDisk = false
+	rules, err := l.Load()
+	require.NoError(t, err, "the download worked, only the cache did not")
+	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
+}

--- a/blocklistloader-http_test.go
+++ b/blocklistloader-http_test.go
@@ -114,8 +114,35 @@ func TestHTTPLoaderCorruptCacheFallsBack(t *testing.T) {
 	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
 }
 
-// With AllowFailure set, a list that has never loaded starts empty, while one
-// that has loaded before keeps what it has.
+// A cached copy carrying a rule the database refuses is no different from one
+// that cannot be read: what it handed over is dropped and the list is taken
+// from upstream instead.
+func TestHTTPLoaderCacheRefusedRule(t *testing.T) {
+	dir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "a.example.com\nb.example.com")
+	}))
+	defer srv.Close()
+
+	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
+	cached := "cached.example.com\nrefused.example.com\n"
+	require.NoError(t, os.WriteFile(l.cacheFilename(), []byte(cached), 0644))
+
+	var rules []string
+	err := l.Load(func() { rules = nil }, func(rule string) error {
+		if rule == "refused.example.com" {
+			return errors.New("the database will not take this rule")
+		}
+		rules = append(rules, rule)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
+}
+
+// AllowFailure covers the first load: a list that has never loaded starts
+// empty. Once it has loaded, a failure is reported like any other, and the
+// database already serving its rules is what keeps them.
 func TestLoaderAllowFailure(t *testing.T) {
 	dir := t.TempDir()
 	name := filepath.Join(dir, "list.txt")
@@ -132,18 +159,17 @@ func TestLoaderAllowFailure(t *testing.T) {
 
 	require.NoError(t, os.Remove(name))
 	_, err = collectRules(l)
-	require.ErrorIs(t, err, ErrBlocklistUnchanged, "a loaded list keeps what it has")
+	require.Error(t, err, "a list that has loaded reports a failure rather than starting empty")
 
 	// Without AllowFailure the error surfaces as it always did.
 	_, err = collectRules(NewFileLoader(name, FileLoaderOptions{}))
 	require.Error(t, err)
-	require.NotErrorIs(t, err, ErrBlocklistUnchanged)
 }
 
-// A body that stops short of what was promised is a partial list. Whether that
-// fails the load or is carried on without depends on AllowFailure, exactly as
-// a list that could not be read at all does, and either way the cached copy
-// survives it and no part of the fragment is served.
+// A body that stops short of what was promised is a partial list, and counts
+// as a list that could not be read: on the first load AllowFailure carries on
+// without it, later it is an error. Either way the cached copy survives it and
+// no part of the fragment is served.
 func TestHTTPLoaderTruncatedBody(t *testing.T) {
 	dir := t.TempDir()
 	truncate := false
@@ -165,7 +191,6 @@ func TestHTTPLoaderTruncatedBody(t *testing.T) {
 	l.fromDisk = false // force it to the network
 	_, err = collectRules(l)
 	require.Error(t, err, "without allow-failure a partial list is an error")
-	require.NotErrorIs(t, err, ErrBlocklistUnchanged)
 
 	// With allow-failure and nothing loaded yet, the fragment is dropped and
 	// the list is empty, which is what an unreadable list has always done.
@@ -182,7 +207,7 @@ func TestHTTPLoaderTruncatedBody(t *testing.T) {
 	require.Len(t, rules, 2)
 	truncate = true
 	_, err = collectRules(allow)
-	require.ErrorIs(t, err, ErrBlocklistUnchanged)
+	require.Error(t, err, "a list that has loaded reports a later fragment")
 
 	cached, err := collectRules(NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}))
 	require.NoError(t, err)

--- a/blocklistloader-http_test.go
+++ b/blocklistloader-http_test.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -97,12 +98,12 @@ func TestLoaderAllowFailure(t *testing.T) {
 
 	require.NoError(t, os.Remove(name))
 	_, err = l.Load()
-	require.ErrorIs(t, err, errBlocklistUnchanged, "a loaded list keeps what it has")
+	require.ErrorIs(t, err, ErrBlocklistUnchanged, "a loaded list keeps what it has")
 
 	// Without AllowFailure the error surfaces as it always did.
 	_, err = NewFileLoader(name, FileLoaderOptions{}).Load()
 	require.Error(t, err)
-	require.NotErrorIs(t, err, errBlocklistUnchanged)
+	require.NotErrorIs(t, err, ErrBlocklistUnchanged)
 }
 
 // A body that stops short of what was promised is a partial list. Whether that
@@ -130,7 +131,7 @@ func TestHTTPLoaderTruncatedBody(t *testing.T) {
 	l.fromDisk = false // force it to the network
 	_, err = l.Load()
 	require.Error(t, err, "without allow-failure a partial list is an error")
-	require.NotErrorIs(t, err, errBlocklistUnchanged)
+	require.NotErrorIs(t, err, ErrBlocklistUnchanged)
 
 	// With allow-failure and nothing loaded yet, the fragment is dropped and
 	// the list is empty, which is what an unreadable list has always done.
@@ -147,7 +148,7 @@ func TestHTTPLoaderTruncatedBody(t *testing.T) {
 	require.Len(t, rules, 2)
 	truncate = true
 	_, err = allow.Load()
-	require.ErrorIs(t, err, errBlocklistUnchanged)
+	require.ErrorIs(t, err, ErrBlocklistUnchanged)
 
 	cached, err := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}).Load()
 	require.NoError(t, err)
@@ -213,6 +214,41 @@ func TestHTTPLoaderCacheWriteFails(t *testing.T) {
 	rules, err := l.Load()
 	require.NoError(t, err, "the list arrived, only the cache write failed")
 	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
+}
+
+// A cache write that fails part way through a download is what a cache-dir
+// filling up looks like, since the file is buffered and flushes as it fills.
+// The body still arrives in full, so every rule has to be passed on and only
+// the cache write reported as failed.
+func TestCacheWriteFailsMidList(t *testing.T) {
+	body := strings.Repeat("a.example.com\n", 5000)
+	var rules []string
+	scanErr, cacheErr := cacheWhileReading(
+		strings.NewReader(body),
+		&failingWriter{after: 100},
+		func(rule string) error {
+			rules = append(rules, rule)
+			return nil
+		})
+	require.NoError(t, scanErr, "the list read fine, only the cache did not")
+	require.Error(t, cacheErr)
+	require.Len(t, rules, 5000, "every rule of the list must still be passed on")
+}
+
+// failingWriter takes `after` bytes and then fails, as a full disk does.
+type failingWriter struct{ after int }
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	if w.after <= 0 {
+		return 0, errors.New("no space left on device")
+	}
+	if len(p) > w.after {
+		n := w.after
+		w.after = 0
+		return n, errors.New("no space left on device")
+	}
+	w.after -= len(p)
+	return len(p), nil
 }
 
 // A line longer than the scanner's buffer is a failed read of the list, not a

--- a/blocklistloader-http_test.go
+++ b/blocklistloader-http_test.go
@@ -94,50 +94,34 @@ func TestHTTPLoaderCacheKeptOnFailure(t *testing.T) {
 	require.Equal(t, []string{"a.example.com", "b.example.com"}, cached)
 }
 
-// A cached copy that breaks off part way through is dropped and the list read
-// again from upstream, rather than the fragment being served as the list.
-func TestHTTPLoaderCorruptCacheFallsBack(t *testing.T) {
-	dir := t.TempDir()
+// A cached copy that cannot be used is dropped and the list read again from
+// upstream, whether it broke off or carried a rule the database refuses.
+func TestHTTPLoaderCacheFallsBack(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "a.example.com\nb.example.com")
 	}))
 	defer srv.Close()
 
-	// A cache file holding a rule and then a line longer than the scanner can
-	// take, so the read fails only after part of the list was handed over.
-	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
-	corrupt := "cached.example.com\n" + strings.Repeat("x", 100_000)
-	require.NoError(t, os.WriteFile(l.cacheFilename(), []byte(corrupt), 0644))
+	for name, cached := range map[string]string{
+		"broke off": "cached.example.com\n" + strings.Repeat("x", 100_000),
+		"refused":   "cached.example.com\nrefused.example.com\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: t.TempDir()})
+			require.NoError(t, os.WriteFile(l.cacheFilename(), []byte(cached), 0644))
 
-	rules, err := collectRules(l)
-	require.NoError(t, err)
-	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
-}
-
-// A cached copy carrying a rule the database refuses is no different from one
-// that cannot be read: what it handed over is dropped and the list is taken
-// from upstream instead.
-func TestHTTPLoaderCacheRefusedRule(t *testing.T) {
-	dir := t.TempDir()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "a.example.com\nb.example.com")
-	}))
-	defer srv.Close()
-
-	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
-	cached := "cached.example.com\nrefused.example.com\n"
-	require.NoError(t, os.WriteFile(l.cacheFilename(), []byte(cached), 0644))
-
-	var rules []string
-	err := l.Load(func() { rules = nil }, func(rule string) error {
-		if rule == "refused.example.com" {
-			return errors.New("the database will not take this rule")
-		}
-		rules = append(rules, rule)
-		return nil
-	})
-	require.NoError(t, err)
-	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
+			var rules []string
+			err := l.Load(func() { rules = nil }, func(rule string) error {
+				if rule == "refused.example.com" {
+					return errors.New("the database will not take this rule")
+				}
+				rules = append(rules, rule)
+				return nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
+		})
+	}
 }
 
 // AllowFailure covers the first load: a list that has never loaded starts
@@ -166,10 +150,9 @@ func TestLoaderAllowFailure(t *testing.T) {
 	require.Error(t, err)
 }
 
-// A body that stops short of what was promised is a partial list, and counts
-// as a list that could not be read: on the first load AllowFailure carries on
-// without it, later it is an error. Either way the cached copy survives it and
-// no part of the fragment is served.
+// A body that stops short of what was promised is a list that could not be
+// read: an error, no part of the fragment served, and the cached copy left
+// alone.
 func TestHTTPLoaderTruncatedBody(t *testing.T) {
 	dir := t.TempDir()
 	truncate := false
@@ -200,15 +183,7 @@ func TestHTTPLoaderTruncatedBody(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, rules, "a fragment of a list must not be served as the list")
 
-	// Once a list has loaded, a later fragment leaves it in place instead.
 	truncate = false
-	rules, err = collectRules(allow)
-	require.NoError(t, err)
-	require.Len(t, rules, 2)
-	truncate = true
-	_, err = collectRules(allow)
-	require.Error(t, err, "a list that has loaded reports a later fragment")
-
 	cached, err := collectRules(NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir}))
 	require.NoError(t, err)
 	require.Equal(t, []string{"a.example.com", "b.example.com"}, cached)
@@ -239,40 +214,29 @@ func TestPartialListDiscarded(t *testing.T) {
 	}
 }
 
-// A cache-dir that cannot be written to is worth a warning, not a failed load.
-func TestHTTPLoaderUnwritableCache(t *testing.T) {
+// A cache that cannot be written is worth a warning, not a failed load: the
+// rules are in hand either way, whether the file could not be opened at all or
+// the rename at the end failed.
+func TestHTTPLoaderCacheWriteFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "a.example.com\nb.example.com")
+	}))
+	defer srv.Close()
+
 	notADir := filepath.Join(t.TempDir(), "file")
 	require.NoError(t, os.WriteFile(notADir, nil, 0644))
+	unwritable := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: notADir})
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "a.example.com\nb.example.com")
-	}))
-	defer srv.Close()
-
-	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: notADir})
-	l.fromDisk = false
-	rules, err := collectRules(l)
-	require.NoError(t, err, "the download worked, only the cache did not")
-	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
-}
-
-// Writing the cache fails after the body has been read and every rule passed
-// on, since the file is buffered and only flushed and renamed at the end. That
-// must not turn a list that arrived into a list that failed.
-func TestHTTPLoaderCacheWriteFails(t *testing.T) {
-	dir := t.TempDir()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "a.example.com\nb.example.com")
-	}))
-	defer srv.Close()
-
-	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
 	// A directory where the cache file belongs: the rename at the end fails.
-	require.NoError(t, os.Mkdir(l.cacheFilename(), 0755))
+	taken := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: t.TempDir()})
+	require.NoError(t, os.Mkdir(taken.cacheFilename(), 0755))
 
-	rules, err := collectRules(l)
-	require.NoError(t, err, "the list arrived, only the cache write failed")
-	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
+	for _, l := range []*HTTPLoader{unwritable, taken} {
+		l.fromDisk = false
+		rules, err := collectRules(l)
+		require.NoError(t, err, "the list arrived, only the cache write failed")
+		require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
+	}
 }
 
 // A cache write that fails part way through a download is what a cache-dir

--- a/blocklistloader-http_test.go
+++ b/blocklistloader-http_test.go
@@ -195,3 +195,39 @@ func TestHTTPLoaderUnwritableCache(t *testing.T) {
 	require.NoError(t, err, "the download worked, only the cache did not")
 	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
 }
+
+// Writing the cache fails after the body has been read and every rule passed
+// on, since the file is buffered and only flushed and renamed at the end. That
+// must not turn a list that arrived into a list that failed.
+func TestHTTPLoaderCacheWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "a.example.com\nb.example.com")
+	}))
+	defer srv.Close()
+
+	l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
+	// A directory where the cache file belongs: the rename at the end fails.
+	require.NoError(t, os.Mkdir(l.cacheFilename(), 0755))
+
+	rules, err := l.Load()
+	require.NoError(t, err, "the list arrived, only the cache write failed")
+	require.Equal(t, []string{"a.example.com", "b.example.com"}, rules)
+}
+
+// A line longer than the scanner's buffer is a failed read of the list, not a
+// cache problem, and must not be retried on a body already partly consumed.
+func TestHTTPLoaderOverlongLine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, strings.Repeat("x", 100_000)+"\na.example.com\nb.example.com")
+	}))
+	defer srv.Close()
+
+	for _, dir := range []string{"", t.TempDir()} {
+		l := NewHTTPLoader(srv.URL, HTTPLoaderOptions{CacheDir: dir})
+		l.fromDisk = false
+		rules, err := l.Load()
+		require.Error(t, err, "cache-dir=%q", dir)
+		require.Empty(t, rules)
+	}
+}

--- a/blocklistloader-local.go
+++ b/blocklistloader-local.go
@@ -46,7 +46,7 @@ func (l *FileLoader) Load() ([]string, error) {
 //
 // What a failure means depends on how far it got. Without AllowFailure it is
 // simply an error. With it, a list that could not be opened is no rules at all
-// when none have ever loaded, and errBlocklistUnchanged once some have, which
+// when none have ever loaded, and ErrBlocklistUnchanged once some have, which
 // leaves the database already serving queries in place. A list that broke off
 // part way through is an error either way: what has been passed on cannot be
 // taken back, so the fragment must not be built into a database and served as
@@ -70,7 +70,7 @@ func (l *FileLoader) loadEach(fn func(rule string) error) error {
 	}
 	log.Warn("failed to load blocklist, continuing with the previous ruleset",
 		"error", err)
-	return errBlocklistUnchanged
+	return ErrBlocklistUnchanged
 }
 
 func (l *FileLoader) read(fn func(rule string) error) error {

--- a/blocklistloader-local.go
+++ b/blocklistloader-local.go
@@ -2,7 +2,6 @@ package rdns
 
 import (
 	"bufio"
-	"errors"
 	"os"
 )
 
@@ -20,38 +19,22 @@ type FileLoaderOptions struct {
 	AllowFailure bool
 }
 
-var (
-	_ BlocklistLoader = &FileLoader{}
-	_ streamingLoader = &FileLoader{}
-)
+var _ BlocklistLoader = &FileLoader{}
 
 func NewFileLoader(filename string, opt FileLoaderOptions) *FileLoader {
 	return &FileLoader{filename, opt, false}
 }
 
-func (l *FileLoader) Load() ([]string, error) {
-	var rules []string
-	err := l.loadEach(func(rule string) error {
-		rules = append(rules, rule)
-		return nil
-	})
-	if errors.Is(err, errBlocklistEmpty) {
-		return nil, nil // an incomplete list is no list, as it always was
-	}
-	return rules, err
-}
-
-// loadEach reads the file a line at a time, so the whole list is never held at
+// Load reads the file a line at a time, so the whole list is never held at
 // once.
 //
-// What a failure means depends on how far it got. Without AllowFailure it is
-// simply an error. With it, a list that could not be opened is no rules at all
-// when none have ever loaded, and ErrBlocklistUnchanged once some have, which
-// leaves the database already serving queries in place. A list that broke off
-// part way through is an error either way: what has been passed on cannot be
-// taken back, so the fragment must not be built into a database and served as
-// though it were the list.
-func (l *FileLoader) loadEach(fn func(rule string) error) error {
+// What a failure means depends on AllowFailure. Without it a list that could
+// not be read is simply an error. With it, a list that has never loaded starts
+// empty, dropping whatever part of it arrived before it broke off so that a
+// fragment is not served as though it were the list, and a list that has loaded
+// before is ErrBlocklistUnchanged, which leaves the database already serving
+// queries in place and discards the one being built.
+func (l *FileLoader) Load(reset func(), fn func(rule string) error) error {
 	log := Log.With("file", l.filename)
 	log.Debug("loading blocklist")
 
@@ -64,13 +47,14 @@ func (l *FileLoader) loadEach(fn func(rule string) error) error {
 	if !l.opt.AllowFailure || !loadFailure(err) {
 		return err
 	}
-	if !l.loaded { // nothing loaded yet, carry on with an empty list
-		log.Warn("failed to load blocklist, continuing without it", "error", err)
-		return errBlocklistEmpty
+	if l.loaded {
+		log.Warn("failed to load blocklist, continuing with the previous ruleset",
+			"error", err)
+		return ErrBlocklistUnchanged
 	}
-	log.Warn("failed to load blocklist, continuing with the previous ruleset",
-		"error", err)
-	return ErrBlocklistUnchanged
+	log.Warn("failed to load blocklist, continuing without it", "error", err)
+	reset()
+	return nil
 }
 
 func (l *FileLoader) read(fn func(rule string) error) error {

--- a/blocklistloader-local.go
+++ b/blocklistloader-local.go
@@ -2,6 +2,7 @@ package rdns
 
 import (
 	"bufio"
+	"errors"
 	"os"
 )
 
@@ -34,6 +35,9 @@ func (l *FileLoader) Load() ([]string, error) {
 		rules = append(rules, rule)
 		return nil
 	})
+	if errors.Is(err, errBlocklistEmpty) {
+		return nil, nil // an incomplete list is no list, as it always was
+	}
 	return rules, err
 }
 
@@ -64,14 +68,9 @@ func (l *FileLoader) loadEach(fn func(rule string) error) error {
 	if !l.opt.AllowFailure || !loadFailure(err) {
 		return err
 	}
-	if served > 0 {
-		// Part of the list is already through, so what is being built holds a
-		// fragment of the rules and has to be thrown away rather than served.
-		return err
-	}
 	if !l.loaded { // nothing loaded yet, carry on with an empty list
 		log.Warn("failed to load blocklist, continuing without it", "error", err)
-		return nil
+		return errBlocklistEmpty
 	}
 	log.Warn("failed to load blocklist, continuing with the previous ruleset",
 		"error", err)

--- a/blocklistloader-local.go
+++ b/blocklistloader-local.go
@@ -20,8 +20,8 @@ func NewFileLoader(filename string, opt FileLoaderOptions) *FileLoader {
 	return &FileLoader{filename, opt, false}
 }
 
-// Load reads the file a line at a time, so the whole list is never held at
-// once. See listFailed for what a list that could not be read means.
+// Load reads the file a line at a time. See listFailed for a list that could
+// not be read.
 func (l *FileLoader) Load(reset func(), fn func(rule string) error) error {
 	log := Log.With("file", l.filename)
 	log.Debug("loading blocklist")

--- a/blocklistloader-local.go
+++ b/blocklistloader-local.go
@@ -8,9 +8,9 @@ import (
 // FileLoader reads blocklist rules from a local file. Used to refresh blocklists
 // from a file on the local machine.
 type FileLoader struct {
-	filename    string
-	opt         FileLoaderOptions
-	lastSuccess []string
+	filename string
+	opt      FileLoaderOptions
+	loaded   bool // a load has succeeded before, so there is a ruleset to keep
 }
 
 // FileLoaderOptions holds options for file blocklist loaders.
@@ -19,43 +19,61 @@ type FileLoaderOptions struct {
 	AllowFailure bool
 }
 
-var _ BlocklistLoader = &FileLoader{}
+var (
+	_ BlocklistLoader = &FileLoader{}
+	_ streamingLoader = &FileLoader{}
+)
 
 func NewFileLoader(filename string, opt FileLoaderOptions) *FileLoader {
-	return &FileLoader{filename, opt, nil}
+	return &FileLoader{filename, opt, false}
 }
 
-func (l *FileLoader) Load() (rules []string, err error) {
+func (l *FileLoader) Load() ([]string, error) {
+	var rules []string
+	err := l.loadEach(func(rule string) error {
+		rules = append(rules, rule)
+		return nil
+	})
+	return rules, err
+}
+
+// loadEach reads the file a line at a time, so the whole list is never held at
+// once. A failed load with AllowFailure set is reported as no rules at all
+// rather than an error, which leaves whatever database is already serving
+// queries in place.
+func (l *FileLoader) loadEach(fn func(rule string) error) error {
 	log := Log.With("file", l.filename)
 	log.Debug("loading blocklist")
 
-	// If AllowFailure is enabled, return the last successfully loaded list
-	// and nil. Without it there's nothing to fall back to, so the rules are
-	// not kept: for a large list that copy would be held for the life of the
-	// process.
-	defer func() {
-		if !l.opt.AllowFailure {
-			return
-		}
-		if err != nil {
-			log.Warn("failed to load blocklist, continuing with previous ruleset",
-				"error", err)
-			rules = l.lastSuccess
-			err = nil
-			return
-		}
-		l.lastSuccess = rules
-	}()
+	err := l.read(fn)
+	if err == nil {
+		l.loaded = true
+		log.Debug("completed loading blocklist")
+		return nil
+	}
+	if !l.opt.AllowFailure || !loadFailure(err) {
+		return err
+	}
+	if !l.loaded { // nothing loaded yet, carry on with an empty list
+		log.Warn("failed to load blocklist, continuing without it", "error", err)
+		return nil
+	}
+	log.Warn("failed to load blocklist, continuing with the previous ruleset",
+		"error", err)
+	return errBlocklistUnchanged
+}
 
+func (l *FileLoader) read(fn func(rule string) error) error {
 	f, err := os.Open(l.filename)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		rules = append(rules, scanner.Text())
+		if err := fn(scanner.Text()); err != nil {
+			return ruleError{err}
+		}
 	}
-	log.Debug("completed loading blocklist")
-	return rules, scanner.Err()
+	return scanner.Err()
 }

--- a/blocklistloader-local.go
+++ b/blocklistloader-local.go
@@ -1,10 +1,5 @@
 package rdns
 
-import (
-	"bufio"
-	"os"
-)
-
 // FileLoader reads blocklist rules from a local file. Used to refresh blocklists
 // from a file on the local machine.
 type FileLoader struct {
@@ -26,48 +21,15 @@ func NewFileLoader(filename string, opt FileLoaderOptions) *FileLoader {
 }
 
 // Load reads the file a line at a time, so the whole list is never held at
-// once.
-//
-// What a failure means depends on AllowFailure. Without it a list that could
-// not be read is simply an error. With it, a list that has never loaded starts
-// empty, dropping whatever part of it arrived before it broke off so that a
-// fragment is not served as though it were the list, and a list that has loaded
-// before is ErrBlocklistUnchanged, which leaves the database already serving
-// queries in place and discards the one being built.
+// once. See listFailed for what a list that could not be read means.
 func (l *FileLoader) Load(reset func(), fn func(rule string) error) error {
 	log := Log.With("file", l.filename)
 	log.Debug("loading blocklist")
 
-	err := l.read(fn)
-	if err == nil {
-		l.loaded = true
-		log.Debug("completed loading blocklist")
-		return nil
+	if err := readRulesFile(l.filename, fn); err != nil {
+		return listFailed(log, l.opt.AllowFailure, l.loaded, reset, err)
 	}
-	if !l.opt.AllowFailure || !loadFailure(err) {
-		return err
-	}
-	if l.loaded {
-		log.Warn("failed to load blocklist, continuing with the previous ruleset",
-			"error", err)
-		return ErrBlocklistUnchanged
-	}
-	log.Warn("failed to load blocklist, continuing without it", "error", err)
-	reset()
+	l.loaded = true
+	log.Debug("completed loading blocklist")
 	return nil
-}
-
-func (l *FileLoader) read(fn func(rule string) error) error {
-	f, err := os.Open(l.filename)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		if err := fn(scanner.Text()); err != nil {
-			return ruleError{err}
-		}
-	}
-	return scanner.Err()
 }

--- a/blocklistloader-local.go
+++ b/blocklistloader-local.go
@@ -45,13 +45,22 @@ func (l *FileLoader) loadEach(fn func(rule string) error) error {
 	log := Log.With("file", l.filename)
 	log.Debug("loading blocklist")
 
-	err := l.read(fn)
+	var served int
+	err := l.read(func(rule string) error {
+		served++
+		return fn(rule)
+	})
 	if err == nil {
 		l.loaded = true
 		log.Debug("completed loading blocklist")
 		return nil
 	}
 	if !l.opt.AllowFailure || !loadFailure(err) {
+		return err
+	}
+	if served > 0 {
+		// Part of the list is already through, so what is being built holds a
+		// fragment of the rules and has to be thrown away rather than served.
 		return err
 	}
 	if !l.loaded { // nothing loaded yet, carry on with an empty list

--- a/blocklistloader-local.go
+++ b/blocklistloader-local.go
@@ -38,9 +38,15 @@ func (l *FileLoader) Load() ([]string, error) {
 }
 
 // loadEach reads the file a line at a time, so the whole list is never held at
-// once. A failed load with AllowFailure set is reported as no rules at all
-// rather than an error, which leaves whatever database is already serving
-// queries in place.
+// once.
+//
+// What a failure means depends on how far it got. Without AllowFailure it is
+// simply an error. With it, a list that could not be opened is no rules at all
+// when none have ever loaded, and errBlocklistUnchanged once some have, which
+// leaves the database already serving queries in place. A list that broke off
+// part way through is an error either way: what has been passed on cannot be
+// taken back, so the fragment must not be built into a database and served as
+// though it were the list.
 func (l *FileLoader) loadEach(fn func(rule string) error) error {
 	log := Log.With("file", l.filename)
 	log.Debug("loading blocklist")

--- a/blocklistloader-local.go
+++ b/blocklistloader-local.go
@@ -55,11 +55,7 @@ func (l *FileLoader) loadEach(fn func(rule string) error) error {
 	log := Log.With("file", l.filename)
 	log.Debug("loading blocklist")
 
-	var served int
-	err := l.read(func(rule string) error {
-		served++
-		return fn(rule)
-	})
+	err := l.read(fn)
 	if err == nil {
 		l.loaded = true
 		log.Debug("completed loading blocklist")

--- a/blocklistloader-static.go
+++ b/blocklistloader-static.go
@@ -6,20 +6,15 @@ type StaticLoader struct {
 	rules []string
 }
 
-var (
-	_ BlocklistLoader = &StaticLoader{}
-	_ streamingLoader = &StaticLoader{}
-)
+var _ BlocklistLoader = &StaticLoader{}
 
 func NewStaticLoader(rules []string) *StaticLoader {
 	return &StaticLoader{rules}
 }
 
-func (l *StaticLoader) Load() ([]string, error) {
-	return l.rules, nil
-}
-
-func (l *StaticLoader) loadEach(fn func(rule string) error) error {
+// Load hands over the rules it was given. They are already in memory and there
+// is nothing that can fail to read, so there is never anything to reset.
+func (l *StaticLoader) Load(_ func(), fn func(rule string) error) error {
 	for _, rule := range l.rules {
 		if err := fn(rule); err != nil {
 			return err

--- a/blocklistloader-static.go
+++ b/blocklistloader-static.go
@@ -6,7 +6,10 @@ type StaticLoader struct {
 	rules []string
 }
 
-var _ BlocklistLoader = &StaticLoader{}
+var (
+	_ BlocklistLoader = &StaticLoader{}
+	_ streamingLoader = &StaticLoader{}
+)
 
 func NewStaticLoader(rules []string) *StaticLoader {
 	return &StaticLoader{rules}
@@ -14,4 +17,13 @@ func NewStaticLoader(rules []string) *StaticLoader {
 
 func (l *StaticLoader) Load() ([]string, error) {
 	return l.rules, nil
+}
+
+func (l *StaticLoader) loadEach(fn func(rule string) error) error {
+	for _, rule := range l.rules {
+		if err := fn(rule); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/blocklistloader-static.go
+++ b/blocklistloader-static.go
@@ -17,7 +17,7 @@ func NewStaticLoader(rules []string) *StaticLoader {
 func (l *StaticLoader) Load(_ func(), fn func(rule string) error) error {
 	for _, rule := range l.rules {
 		if err := fn(rule); err != nil {
-			return err
+			return ruleError{err}
 		}
 	}
 	return nil

--- a/blocklistloader-static.go
+++ b/blocklistloader-static.go
@@ -17,7 +17,7 @@ func NewStaticLoader(rules []string) *StaticLoader {
 func (l *StaticLoader) Load(_ func(), fn func(rule string) error) error {
 	for _, rule := range l.rules {
 		if err := fn(rule); err != nil {
-			return ruleError{err}
+			return err
 		}
 	}
 	return nil

--- a/blocklistloader-static.go
+++ b/blocklistloader-static.go
@@ -12,8 +12,8 @@ func NewStaticLoader(rules []string) *StaticLoader {
 	return &StaticLoader{rules}
 }
 
-// Load hands over the rules it was given. They are already in memory and there
-// is nothing that can fail to read, so there is never anything to reset.
+// Load hands over the rules it was given, which cannot fail, so there is
+// never anything to reset.
 func (l *StaticLoader) Load(_ func(), fn func(rule string) error) error {
 	for _, rule := range l.rules {
 		if err := fn(rule); err != nil {

--- a/blocklistloader.go
+++ b/blocklistloader.go
@@ -1,6 +1,60 @@
 package rdns
 
+import "errors"
+
 type BlocklistLoader interface {
 	// Returns a list of rules that can then be stored into a blocklist DB.
 	Load() ([]string, error)
+}
+
+// A loader that can hand its rules over one at a time instead of building a
+// slice of every one of them. A list of two million rules is some 80MB of
+// strings, held for as long as it takes to build a database that is a fraction
+// of that, and on a small machine that peak is what a refresh runs out of.
+//
+// The method is unexported, so a loader from outside the package keeps working
+// through the Load path in loadRules below.
+type streamingLoader interface {
+	loadEach(func(rule string) error) error
+}
+
+// errBlocklistUnchanged says a list could not be read but a previous version of
+// it is already loaded, so whatever is serving queries should stay as it is.
+// Only loaders with AllowFailure set report it, and only once they have loaded
+// something successfully.
+var errBlocklistUnchanged = errors.New("blocklist unchanged")
+
+// ruleError marks an error as coming from the database rejecting a rule rather
+// than from the list failing to load. AllowFailure is about a list being
+// unavailable, not about its contents being wrong, so the two must not be
+// confused for one another.
+type ruleError struct{ err error }
+
+func (e ruleError) Error() string { return e.err.Error() }
+func (e ruleError) Unwrap() error { return e.err }
+
+// loadFailure reports whether err is a list that could not be read, as opposed
+// to a rule the database would not take.
+func loadFailure(err error) bool {
+	var re ruleError
+	return err != nil && !errors.As(err, &re)
+}
+
+// loadRules calls fn for every rule of a list, streaming them from the loader
+// when it can do that and reading the whole list first when it cannot. An
+// error from fn stops the load and comes back unchanged.
+func loadRules(loader BlocklistLoader, fn func(rule string) error) error {
+	if s, ok := loader.(streamingLoader); ok {
+		return s.loadEach(fn)
+	}
+	rules, err := loader.Load()
+	if err != nil {
+		return err
+	}
+	for _, rule := range rules {
+		if err := fn(rule); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/blocklistloader.go
+++ b/blocklistloader.go
@@ -8,29 +8,21 @@ import (
 )
 
 type BlocklistLoader interface {
-	// Load calls rule for every rule of the list. Rules are handed over as
-	// they are read rather than collected first, so a list of millions of them
-	// is never held in memory as a whole: two million rules are some 80MB of
-	// strings, kept for as long as it takes to build a database that is a
-	// fraction of that, and on a small machine that peak is what a refresh runs
-	// out of.
+	// Load calls rule for every rule as it is read rather than collecting them
+	// first, so a list of millions is never held whole: two million rules are
+	// some 80MB of strings against a database a fraction of that size.
 	//
-	// Rules that have been passed on cannot be taken back, so a loader that
-	// abandons a list part way through, either because it broke off or because
-	// the rest of it is coming from somewhere else, calls reset first to drop
-	// what it handed over. A fragment must never be built into a database and
+	// Rules already passed on cannot be taken back, so a loader that abandons
+	// a list part way through calls reset first. A fragment must never be
 	// served as though it were the list.
 	Load(reset func(), rule func(string) error) error
 }
 
-// listFailed decides what a list that could not be read means, which is the
-// same wherever it was being read from and whether the list was unreachable or
-// its contents unusable. AllowFailure covers a single moment, the first load:
-// the list starts empty rather than keeping the process from starting, and
-// whatever part of it arrived before it broke off is dropped so that a fragment
-// is not served as though it were the list. Every later failure is an error, and
-// the database already serving the rules keeps them, which is what a failed
-// reload means everywhere.
+// listFailed decides what a list that could not be read means, whether it was
+// unreachable or its contents unusable. AllowFailure covers the first load
+// only: the list starts empty, dropping any fragment that arrived, rather than
+// keeping the process from starting. Later failures are errors, and the
+// database already serving the rules keeps them.
 func listFailed(log *slog.Logger, allowFailure, loaded bool, reset func(), err error) error {
 	if !allowFailure || loaded {
 		return err
@@ -40,7 +32,6 @@ func listFailed(log *slog.Logger, allowFailure, loaded bool, reset func(), err e
 	return nil
 }
 
-// readRulesFile passes every line of the named file to fn as a rule.
 func readRulesFile(name string, fn func(rule string) error) error {
 	f, err := os.Open(name)
 	if err != nil {
@@ -50,13 +41,12 @@ func readRulesFile(name string, fn func(rule string) error) error {
 	return scanRules(f, fn)
 }
 
-// scanRules passes every line of r to fn as a rule. A list arrives as a stream
-// of lines whatever it came from, so this is the one place one is read.
+// scanRules is the one place a list is read: a stream of lines, whatever it
+// came from.
 func scanRules(r io.Reader, fn func(rule string) error) error {
 	scanner := bufio.NewScanner(r)
-	// A list is read in one pass and the lines are short, so give the scanner
-	// a buffer worth a read rather than the 4KB it starts with. The limit on a
-	// single line stays where bufio puts it.
+	// A buffer worth a read rather than the 4KB bufio starts with. The limit
+	// on a single line stays where bufio puts it.
 	scanner.Buffer(make([]byte, 64*1024), bufio.MaxScanTokenSize)
 	for scanner.Scan() {
 		if err := fn(scanner.Text()); err != nil {

--- a/blocklistloader.go
+++ b/blocklistloader.go
@@ -18,11 +18,12 @@ type streamingLoader interface {
 	loadEach(func(rule string) error) error
 }
 
-// errBlocklistUnchanged says a list could not be read but a previous version of
+// ErrBlocklistUnchanged says a list could not be read but a previous version of
 // it is already loaded, so whatever is serving queries should stay as it is.
 // Only loaders with AllowFailure set report it, and only once they have loaded
-// something successfully.
-var errBlocklistUnchanged = errors.New("blocklist unchanged")
+// something successfully. A caller of Load that sets AllowFailure has to expect
+// it: it means there are no new rules, not that anything went wrong.
+var ErrBlocklistUnchanged = errors.New("blocklist unchanged")
 
 // ruleError marks an error as coming from the database rejecting a rule rather
 // than from the list failing to load. AllowFailure is about a list being

--- a/blocklistloader.go
+++ b/blocklistloader.go
@@ -40,10 +40,30 @@ func loadFailure(err error) bool {
 	return err != nil && !errors.As(err, &re)
 }
 
+// errBlocklistEmpty says a list broke off part way through but the loader is
+// willing to carry on without it, so whatever was handed over is a fragment
+// that has to be dropped. It never leaves loadRules.
+var errBlocklistEmpty = errors.New("blocklist incomplete")
+
 // loadRules calls fn for every rule of a list, streaming them from the loader
 // when it can do that and reading the whole list first when it cannot. An
 // error from fn stops the load and comes back unchanged.
-func loadRules(loader BlocklistLoader, fn func(rule string) error) error {
+//
+// Rules are handed over as they are read, so a list that breaks off half way
+// has already put a fragment of itself into whatever is being built. When the
+// loader is set to carry on regardless, reset is called to drop that fragment
+// and the load reports success with nothing in it, which is what a list that
+// could not be read at all has always done.
+func loadRules(loader BlocklistLoader, reset func(), fn func(rule string) error) error {
+	err := readRules(loader, fn)
+	if errors.Is(err, errBlocklistEmpty) {
+		reset()
+		return nil
+	}
+	return err
+}
+
+func readRules(loader BlocklistLoader, fn func(rule string) error) error {
 	if s, ok := loader.(streamingLoader); ok {
 		return s.loadEach(fn)
 	}

--- a/blocklistloader.go
+++ b/blocklistloader.go
@@ -3,26 +3,26 @@ package rdns
 import "errors"
 
 type BlocklistLoader interface {
-	// Returns a list of rules that can then be stored into a blocklist DB.
-	Load() ([]string, error)
-}
-
-// A loader that can hand its rules over one at a time instead of building a
-// slice of every one of them. A list of two million rules is some 80MB of
-// strings, held for as long as it takes to build a database that is a fraction
-// of that, and on a small machine that peak is what a refresh runs out of.
-//
-// The method is unexported, so a loader from outside the package keeps working
-// through the Load path in loadRules below.
-type streamingLoader interface {
-	loadEach(func(rule string) error) error
+	// Load calls rule for every rule of the list. Rules are handed over as
+	// they are read rather than collected first, so a list of millions of them
+	// is never held in memory as a whole: two million rules are some 80MB of
+	// strings, kept for as long as it takes to build a database that is a
+	// fraction of that, and on a small machine that peak is what a refresh runs
+	// out of.
+	//
+	// Rules that have been passed on cannot be taken back, so a loader that
+	// abandons a list part way through, either because it broke off or because
+	// the rest of it is coming from somewhere else, calls reset first to drop
+	// what it handed over. A fragment must never be built into a database and
+	// served as though it were the list.
+	Load(reset func(), rule func(string) error) error
 }
 
 // ErrBlocklistUnchanged says a list could not be read but a previous version of
 // it is already loaded, so whatever is serving queries should stay as it is.
 // Only loaders with AllowFailure set report it, and only once they have loaded
-// something successfully. A caller of Load that sets AllowFailure has to expect
-// it: it means there are no new rules, not that anything went wrong.
+// something successfully. A caller that sets AllowFailure has to expect it: it
+// means there are no new rules, not that anything went wrong.
 var ErrBlocklistUnchanged = errors.New("blocklist unchanged")
 
 // ruleError marks an error as coming from the database rejecting a rule rather
@@ -39,43 +39,4 @@ func (e ruleError) Unwrap() error { return e.err }
 func loadFailure(err error) bool {
 	var re ruleError
 	return err != nil && !errors.As(err, &re)
-}
-
-// errBlocklistEmpty says a list broke off part way through but the loader is
-// willing to carry on without it, so whatever was handed over is a fragment
-// that has to be dropped. It never leaves loadRules.
-var errBlocklistEmpty = errors.New("blocklist incomplete")
-
-// loadRules calls fn for every rule of a list, streaming them from the loader
-// when it can do that and reading the whole list first when it cannot. An
-// error from fn stops the load and comes back unchanged.
-//
-// Rules are handed over as they are read, so a list that breaks off half way
-// has already put a fragment of itself into whatever is being built. When the
-// loader is set to carry on regardless, reset is called to drop that fragment
-// and the load reports success with nothing in it, which is what a list that
-// could not be read at all has always done.
-func loadRules(loader BlocklistLoader, reset func(), fn func(rule string) error) error {
-	err := readRules(loader, fn)
-	if errors.Is(err, errBlocklistEmpty) {
-		reset()
-		return nil
-	}
-	return err
-}
-
-func readRules(loader BlocklistLoader, fn func(rule string) error) error {
-	if s, ok := loader.(streamingLoader); ok {
-		return s.loadEach(fn)
-	}
-	rules, err := loader.Load()
-	if err != nil {
-		return err
-	}
-	for _, rule := range rules {
-		if err := fn(rule); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/blocklistloader.go
+++ b/blocklistloader.go
@@ -1,6 +1,12 @@
 package rdns
 
-import "errors"
+import (
+	"bufio"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+)
 
 type BlocklistLoader interface {
 	// Load calls rule for every rule of the list. Rules are handed over as
@@ -25,6 +31,27 @@ type BlocklistLoader interface {
 // means there are no new rules, not that anything went wrong.
 var ErrBlocklistUnchanged = errors.New("blocklist unchanged")
 
+// listFailed decides what a list that could not be read means, which is the
+// same wherever it was being read from. Without AllowFailure it is simply an
+// error. With it, a list that has never loaded starts empty, dropping whatever
+// part of it arrived before it broke off so that a fragment is not served as
+// though it were the list, and a list that has loaded before is
+// ErrBlocklistUnchanged, which leaves the database already serving queries in
+// place and discards the one being built.
+func listFailed(log *slog.Logger, allowFailure, loaded bool, reset func(), err error) error {
+	if !allowFailure || isRuleError(err) {
+		return err
+	}
+	if loaded {
+		log.Warn("failed to load blocklist, continuing with the previous ruleset",
+			"error", err)
+		return ErrBlocklistUnchanged
+	}
+	log.Warn("failed to load blocklist, continuing without it", "error", err)
+	reset()
+	return nil
+}
+
 // ruleError marks an error as coming from the database rejecting a rule rather
 // than from the list failing to load. AllowFailure is about a list being
 // unavailable, not about its contents being wrong, so the two must not be
@@ -34,9 +61,35 @@ type ruleError struct{ err error }
 func (e ruleError) Error() string { return e.err.Error() }
 func (e ruleError) Unwrap() error { return e.err }
 
-// loadFailure reports whether err is a list that could not be read, as opposed
-// to a rule the database would not take.
-func loadFailure(err error) bool {
+// isRuleError reports whether err is a rule the database would not take, as
+// opposed to a list that could not be read.
+func isRuleError(err error) bool {
 	var re ruleError
-	return err != nil && !errors.As(err, &re)
+	return errors.As(err, &re)
+}
+
+// readRulesFile passes every line of the named file to fn as a rule.
+func readRulesFile(name string, fn func(rule string) error) error {
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return scanRules(f, fn)
+}
+
+// scanRules passes every line of r to fn as a rule. A list arrives as a stream
+// of lines whatever it came from, so this is the one place one is read.
+func scanRules(r io.Reader, fn func(rule string) error) error {
+	scanner := bufio.NewScanner(r)
+	// A list is read in one pass and the lines are short, so give the scanner
+	// a buffer worth a read rather than the 4KB it starts with. The limit on a
+	// single line stays where bufio puts it.
+	scanner.Buffer(make([]byte, 64*1024), bufio.MaxScanTokenSize)
+	for scanner.Scan() {
+		if err := fn(scanner.Text()); err != nil {
+			return ruleError{err}
+		}
+	}
+	return scanner.Err()
 }

--- a/blocklistloader.go
+++ b/blocklistloader.go
@@ -2,7 +2,6 @@ package rdns
 
 import (
 	"bufio"
-	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -24,48 +23,21 @@ type BlocklistLoader interface {
 	Load(reset func(), rule func(string) error) error
 }
 
-// ErrBlocklistUnchanged says a list could not be read but a previous version of
-// it is already loaded, so whatever is serving queries should stay as it is.
-// Only loaders with AllowFailure set report it, and only once they have loaded
-// something successfully. A caller that sets AllowFailure has to expect it: it
-// means there are no new rules, not that anything went wrong.
-var ErrBlocklistUnchanged = errors.New("blocklist unchanged")
-
 // listFailed decides what a list that could not be read means, which is the
-// same wherever it was being read from. Without AllowFailure it is simply an
-// error. With it, a list that has never loaded starts empty, dropping whatever
-// part of it arrived before it broke off so that a fragment is not served as
-// though it were the list, and a list that has loaded before is
-// ErrBlocklistUnchanged, which leaves the database already serving queries in
-// place and discards the one being built.
+// same wherever it was being read from and whether the list was unreachable or
+// its contents unusable. AllowFailure covers a single moment, the first load:
+// the list starts empty rather than keeping the process from starting, and
+// whatever part of it arrived before it broke off is dropped so that a fragment
+// is not served as though it were the list. Every later failure is an error, and
+// the database already serving the rules keeps them, which is what a failed
+// reload means everywhere.
 func listFailed(log *slog.Logger, allowFailure, loaded bool, reset func(), err error) error {
-	if !allowFailure || isRuleError(err) {
+	if !allowFailure || loaded {
 		return err
-	}
-	if loaded {
-		log.Warn("failed to load blocklist, continuing with the previous ruleset",
-			"error", err)
-		return ErrBlocklistUnchanged
 	}
 	log.Warn("failed to load blocklist, continuing without it", "error", err)
 	reset()
 	return nil
-}
-
-// ruleError marks an error as coming from the database rejecting a rule rather
-// than from the list failing to load. AllowFailure is about a list being
-// unavailable, not about its contents being wrong, so the two must not be
-// confused for one another.
-type ruleError struct{ err error }
-
-func (e ruleError) Error() string { return e.err.Error() }
-func (e ruleError) Unwrap() error { return e.err }
-
-// isRuleError reports whether err is a rule the database would not take, as
-// opposed to a list that could not be read.
-func isRuleError(err error) bool {
-	var re ruleError
-	return errors.As(err, &re)
 }
 
 // readRulesFile passes every line of the named file to fn as a rule.
@@ -88,7 +60,7 @@ func scanRules(r io.Reader, fn func(rule string) error) error {
 	scanner.Buffer(make([]byte, 64*1024), bufio.MaxScanTokenSize)
 	for scanner.Scan() {
 		if err := fn(scanner.Text()); err != nil {
-			return ruleError{err}
+			return err
 		}
 	}
 	return scanner.Err()

--- a/cidr-db.go
+++ b/cidr-db.go
@@ -74,6 +74,13 @@ func (m *CidrDB) Match(ip net.IP) (*BlocklistMatch, bool) {
 	return &BlocklistMatch{List: m.name, Rule: rule}, ok
 }
 
+// reuse hands this database to a new group while the group it came from is
+// closed. It holds no resource that closing releases, so the same instance
+// serves both.
+func (m *CidrDB) reuse() (IPBlocklistDB, error) {
+	return m, nil
+}
+
 func (m *CidrDB) Close() error {
 	return nil
 }

--- a/cidr-db.go
+++ b/cidr-db.go
@@ -24,7 +24,9 @@ func NewCidrDB(name string, loader BlocklistLoader) (*CidrDB, error) {
 		ip6:    new(ipBlocklistTrie),
 		loader: loader,
 	}
-	err := loadRules(loader, func(r string) error {
+	err := loadRules(loader, func() {
+		db.ip4, db.ip6 = new(ipBlocklistTrie), new(ipBlocklistTrie)
+	}, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
 			return nil

--- a/cidr-db.go
+++ b/cidr-db.go
@@ -24,7 +24,7 @@ func NewCidrDB(name string, loader BlocklistLoader) (*CidrDB, error) {
 		ip6:    new(ipBlocklistTrie),
 		loader: loader,
 	}
-	err := loadRules(loader, func() {
+	err := loader.Load(func() {
 		db.ip4, db.ip6 = new(ipBlocklistTrie), new(ipBlocklistTrie)
 	}, func(r string) error {
 		r = strings.TrimSpace(r)

--- a/cidr-db.go
+++ b/cidr-db.go
@@ -59,9 +59,8 @@ func NewCidrDB(name string, loader BlocklistLoader) (*CidrDB, error) {
 func (m *CidrDB) Reload() (IPBlocklistDB, error) {
 	db, err := NewCidrDB(m.name, m.loader)
 	if err != nil {
-		// The list could not be read, so the rules already loaded stand. The
-		// tries are immutable, so the instance carrying them on shares them,
-		// and it holds nothing else that closing would release.
+		// The rules already loaded stand. The tries are immutable, so the
+		// instance carrying them on shares them.
 		return &CidrDB{name: m.name, ip4: m.ip4, ip6: m.ip6, loader: m.loader}, err
 	}
 	return db, err

--- a/cidr-db.go
+++ b/cidr-db.go
@@ -1,7 +1,6 @@
 package rdns
 
 import (
-	"errors"
 	"net"
 	"strings"
 )
@@ -59,7 +58,7 @@ func NewCidrDB(name string, loader BlocklistLoader) (*CidrDB, error) {
 
 func (m *CidrDB) Reload() (IPBlocklistDB, error) {
 	db, err := NewCidrDB(m.name, m.loader)
-	if errors.Is(err, ErrBlocklistUnchanged) {
+	if err != nil {
 		// The list could not be read, so the rules already loaded stand. The
 		// tries are immutable, so the instance carrying them on shares them,
 		// and it holds nothing else that closing would release.

--- a/cidr-db.go
+++ b/cidr-db.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"errors"
 	"net"
 	"strings"
 )
@@ -57,7 +58,14 @@ func NewCidrDB(name string, loader BlocklistLoader) (*CidrDB, error) {
 }
 
 func (m *CidrDB) Reload() (IPBlocklistDB, error) {
-	return NewCidrDB(m.name, m.loader)
+	db, err := NewCidrDB(m.name, m.loader)
+	if errors.Is(err, ErrBlocklistUnchanged) {
+		// The list could not be read, so the rules already loaded stand. The
+		// tries are immutable, so the instance carrying them on shares them,
+		// and it holds nothing else that closing would release.
+		return &CidrDB{name: m.name, ip4: m.ip4, ip6: m.ip6, loader: m.loader}, err
+	}
+	return db, err
 }
 
 func (m *CidrDB) Match(ip net.IP) (*BlocklistMatch, bool) {
@@ -72,13 +80,6 @@ func (m *CidrDB) Match(ip net.IP) (*BlocklistMatch, bool) {
 	}
 	rule, ok := m.ip4.hasIP(ip)
 	return &BlocklistMatch{List: m.name, Rule: rule}, ok
-}
-
-// reuse hands this database to a new group while the group it came from is
-// closed. It holds no resource that closing releases, so the same instance
-// serves both.
-func (m *CidrDB) reuse() (IPBlocklistDB, error) {
-	return m, nil
 }
 
 func (m *CidrDB) Close() error {

--- a/cidr-db.go
+++ b/cidr-db.go
@@ -18,20 +18,16 @@ var _ IPBlocklistDB = &CidrDB{}
 
 // NewCidrDB returns a new instance of a matcher for a list of networks.
 func NewCidrDB(name string, loader BlocklistLoader) (*CidrDB, error) {
-	rules, err := loader.Load()
-	if err != nil {
-		return nil, err
-	}
 	db := &CidrDB{
 		name:   name,
 		ip4:    new(ipBlocklistTrie),
 		ip6:    new(ipBlocklistTrie),
 		loader: loader,
 	}
-	for _, r := range rules {
+	err := loadRules(loader, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
-			continue
+			return nil
 		}
 		// Append a mask suffix if there isn't one already
 		if !strings.Contains(r, "/") {
@@ -43,13 +39,17 @@ func NewCidrDB(name string, loader BlocklistLoader) (*CidrDB, error) {
 		}
 		ip, n, err := net.ParseCIDR(r)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if addr := ip.To4(); addr == nil {
 			db.ip6.add(n)
 		} else {
 			db.ip4.add(n)
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return db, nil
 }

--- a/doc/blocklists.md
+++ b/doc/blocklists.md
@@ -71,7 +71,7 @@ Options:
 
 When using the `cache-dir` option on a list that loads rules via HTTP, the results are cached into a file in the given directory. The filename is the URL of the source hashed with SHA256 so multiple blocklists can be cached in the same directory. If a cached file exists on startup, it is used instead of refreshing the list from the remote location (slowing down startup). As with the cache `filename` option, a new file is created with mode `0600` and an existing one keeps whatever mode it already has. When running under the systemd unit shipped with the packages, use a path under `/var/cache/routedns`; see [Writable Paths](overview.md#writable-paths).
 
-To avoid errors at startup when for example a remote blocklist isn't available, the `allow-failure` option can be used. Any errors encountered will be logged but not cause a failure to start. If a failure occurs during runtime, the previous ruleset will be reused.
+To avoid errors at startup when for example a remote blocklist isn't available, the `allow-failure` option can be used. Any errors encountered will be logged but not cause a failure to start, and the list is left empty. This covers a list that can't be read as well as one carrying a rule that can't be parsed. If a failure occurs during runtime, the previous ruleset will be reused.
 
 ### Examples
 

--- a/geoip-db.go
+++ b/geoip-db.go
@@ -35,7 +35,7 @@ func NewGeoIPDB(name string, loader BlocklistLoader, geoDBFile string) (*GeoIPDB
 	db := make(map[uint64]struct{})
 	// The map file is open from here on, so every way out of this function
 	// has to close it.
-	err = loadRules(loader, func() { db = make(map[uint64]struct{}) }, func(r string) error {
+	err = loader.Load(func() { db = make(map[uint64]struct{}) }, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
 			return nil

--- a/geoip-db.go
+++ b/geoip-db.go
@@ -35,7 +35,7 @@ func NewGeoIPDB(name string, loader BlocklistLoader, geoDBFile string) (*GeoIPDB
 	db := make(map[uint64]struct{})
 	// The map file is open from here on, so every way out of this function
 	// has to close it.
-	err = loadRules(loader, func(r string) error {
+	err = loadRules(loader, func() { clear(db) }, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
 			return nil

--- a/geoip-db.go
+++ b/geoip-db.go
@@ -32,24 +32,23 @@ func NewGeoIPDB(name string, loader BlocklistLoader, geoDBFile string) (*GeoIPDB
 		return nil, fmt.Errorf("failed to open geo location database file: %w", err)
 	}
 
-	rules, err := loader.Load()
-	if err != nil {
-		return nil, err
-	}
-
 	db := make(map[uint64]struct{})
-	for _, r := range rules {
+	err = loadRules(loader, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
-			continue
+			return nil
 		}
 		r = strings.Split(r, "#")[0] // possible comment at the end of the line
 		r = strings.TrimSpace(r)
 		value, err := strconv.ParseUint(r, 10, 64) // GeoNames ID
 		if err != nil {
-			return nil, fmt.Errorf("unable to parse geoname id in rule '%s': %w", r, err)
+			return fmt.Errorf("unable to parse geoname id in rule '%s': %w", r, err)
 		}
 		db[value] = struct{}{}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return &GeoIPDB{
 		name:      name,

--- a/geoip-db.go
+++ b/geoip-db.go
@@ -66,12 +66,10 @@ func NewGeoIPDB(name string, loader BlocklistLoader, geoDBFile string) (*GeoIPDB
 func (m *GeoIPDB) Reload() (IPBlocklistDB, error) {
 	db, err := NewGeoIPDB(m.name, m.loader, m.geoDBFile)
 	if err != nil {
-		// The list could not be read, so the rules already loaded stand. They
-		// are immutable and shared with the instance carrying them on, but the
-		// map file is opened again so that it has a handle of its own to close.
+		// The rules already loaded stand. They are immutable and shared, but
+		// the map file is opened again for a handle of its own to close.
 		geoDB, oerr := maxminddb.Open(m.geoDBFile)
 		if oerr != nil {
-			// Without a handle of its own there is nothing to carry them on with.
 			return nil, errors.Join(err, fmt.Errorf("failed to open geo location database file: %w", oerr))
 		}
 		return &GeoIPDB{

--- a/geoip-db.go
+++ b/geoip-db.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -63,7 +64,24 @@ func NewGeoIPDB(name string, loader BlocklistLoader, geoDBFile string) (*GeoIPDB
 }
 
 func (m *GeoIPDB) Reload() (IPBlocklistDB, error) {
-	return NewGeoIPDB(m.name, m.loader, m.geoDBFile)
+	db, err := NewGeoIPDB(m.name, m.loader, m.geoDBFile)
+	if errors.Is(err, ErrBlocklistUnchanged) {
+		// The list could not be read, so the rules already loaded stand. They
+		// are immutable and shared with the instance carrying them on, but the
+		// map file is opened again so that it has a handle of its own to close.
+		geoDB, oerr := maxminddb.Open(m.geoDBFile)
+		if oerr != nil {
+			return nil, fmt.Errorf("failed to open geo location database file: %w", oerr)
+		}
+		return &GeoIPDB{
+			name:      m.name,
+			loader:    m.loader,
+			geoDB:     geoDB,
+			geoDBFile: m.geoDBFile,
+			db:        m.db,
+		}, err
+	}
+	return db, err
 }
 
 func (m *GeoIPDB) Match(ip net.IP) (*BlocklistMatch, bool) {
@@ -102,23 +120,6 @@ func (m *GeoIPDB) Match(ip net.IP) (*BlocklistMatch, bool) {
 		}
 	}
 	return nil, false
-}
-
-// reuse hands this database to a new group while the group it came from is
-// closed. The rules are immutable and shared, but the map file is opened again
-// so the copy has a handle of its own to close.
-func (m *GeoIPDB) reuse() (IPBlocklistDB, error) {
-	geoDB, err := maxminddb.Open(m.geoDBFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open geo location database file: %w", err)
-	}
-	return &GeoIPDB{
-		name:      m.name,
-		loader:    m.loader,
-		geoDB:     geoDB,
-		geoDBFile: m.geoDBFile,
-		db:        m.db,
-	}, nil
 }
 
 func (m *GeoIPDB) Close() error {

--- a/geoip-db.go
+++ b/geoip-db.go
@@ -65,13 +65,14 @@ func NewGeoIPDB(name string, loader BlocklistLoader, geoDBFile string) (*GeoIPDB
 
 func (m *GeoIPDB) Reload() (IPBlocklistDB, error) {
 	db, err := NewGeoIPDB(m.name, m.loader, m.geoDBFile)
-	if errors.Is(err, ErrBlocklistUnchanged) {
+	if err != nil {
 		// The list could not be read, so the rules already loaded stand. They
 		// are immutable and shared with the instance carrying them on, but the
 		// map file is opened again so that it has a handle of its own to close.
 		geoDB, oerr := maxminddb.Open(m.geoDBFile)
 		if oerr != nil {
-			return nil, fmt.Errorf("failed to open geo location database file: %w", oerr)
+			// Without a handle of its own there is nothing to carry them on with.
+			return nil, errors.Join(err, fmt.Errorf("failed to open geo location database file: %w", oerr))
 		}
 		return &GeoIPDB{
 			name:      m.name,

--- a/geoip-db.go
+++ b/geoip-db.go
@@ -104,6 +104,23 @@ func (m *GeoIPDB) Match(ip net.IP) (*BlocklistMatch, bool) {
 	return nil, false
 }
 
+// reuse hands this database to a new group while the group it came from is
+// closed. The rules are immutable and shared, but the map file is opened again
+// so the copy has a handle of its own to close.
+func (m *GeoIPDB) reuse() (IPBlocklistDB, error) {
+	geoDB, err := maxminddb.Open(m.geoDBFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open geo location database file: %w", err)
+	}
+	return &GeoIPDB{
+		name:      m.name,
+		loader:    m.loader,
+		geoDB:     geoDB,
+		geoDBFile: m.geoDBFile,
+		db:        m.db,
+	}, nil
+}
+
 func (m *GeoIPDB) Close() error {
 	return m.geoDB.Close()
 }

--- a/geoip-db.go
+++ b/geoip-db.go
@@ -33,6 +33,8 @@ func NewGeoIPDB(name string, loader BlocklistLoader, geoDBFile string) (*GeoIPDB
 	}
 
 	db := make(map[uint64]struct{})
+	// The map file is open from here on, so every way out of this function
+	// has to close it.
 	err = loadRules(loader, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
@@ -48,6 +50,7 @@ func NewGeoIPDB(name string, loader BlocklistLoader, geoDBFile string) (*GeoIPDB
 		return nil
 	})
 	if err != nil {
+		geoDB.Close()
 		return nil, err
 	}
 	return &GeoIPDB{

--- a/geoip-db.go
+++ b/geoip-db.go
@@ -35,7 +35,7 @@ func NewGeoIPDB(name string, loader BlocklistLoader, geoDBFile string) (*GeoIPDB
 	db := make(map[uint64]struct{})
 	// The map file is open from here on, so every way out of this function
 	// has to close it.
-	err = loadRules(loader, func() { clear(db) }, func(r string) error {
+	err = loadRules(loader, func() { db = make(map[uint64]struct{}) }, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
 			return nil

--- a/ip-db-multi.go
+++ b/ip-db-multi.go
@@ -34,7 +34,7 @@ func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
 		n, err := db.Reload()
 		if err != nil {
 			if n == nil { // nothing to put in its place, so the group stays as it is
-				return MultiIPDB{}, err
+				return nil, err
 			}
 			Log.Warn("failed to load rules, continuing with the ones already loaded",
 				"error", err)
@@ -43,7 +43,7 @@ func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
 	}
 	group, err := NewMultiIPDB(newDBs...)
 	if err != nil {
-		return MultiIPDB{}, err
+		return nil, err
 	}
 	keep = true
 	return group, nil

--- a/ip-db-multi.go
+++ b/ip-db-multi.go
@@ -32,7 +32,7 @@ func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
 	unchanged := 0
 	for _, db := range m.dbs {
 		n, err := db.Reload()
-		if errors.Is(err, errBlocklistUnchanged) {
+		if errors.Is(err, ErrBlocklistUnchanged) {
 			r, ok := db.(reusableIPDB)
 			if !ok {
 				closeAll()
@@ -51,7 +51,7 @@ func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
 	}
 	if unchanged == len(m.dbs) { // nothing moved, so there is nothing to swap in
 		closeAll()
-		return MultiIPDB{}, errBlocklistUnchanged
+		return MultiIPDB{}, ErrBlocklistUnchanged
 	}
 	return NewMultiIPDB(newDBs...)
 }

--- a/ip-db-multi.go
+++ b/ip-db-multi.go
@@ -1,7 +1,6 @@
 package rdns
 
 import (
-	"errors"
 	"net"
 )
 
@@ -20,6 +19,7 @@ func NewMultiIPDB(dbs ...IPBlocklistDB) (MultiIPDB, error) {
 func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
 	// A list that could not be read hands back the rules it already has while
 	// the lists beside it refresh, so the group is rebuilt whole either way.
+	// A database that cannot even do that leaves the group as it is.
 	// The databases it is rebuilt from are new instances, which is what lets
 	// the group they came from be closed once this one is in place.
 	newDBs := make([]IPBlocklistDB, 0, len(m.dbs))
@@ -33,15 +33,14 @@ func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
 			}
 		}
 	}()
-	changed := false
 	for _, db := range m.dbs {
 		n, err := db.Reload()
-		switch {
-		case errors.Is(err, ErrBlocklistUnchanged): // n holds the rules it had
-		case err != nil:
-			return MultiIPDB{}, err
-		default:
-			changed = true
+		if err != nil {
+			if n == nil { // nothing to put in its place, so the group stays as it is
+				return MultiIPDB{}, err
+			}
+			Log.Warn("failed to load rules, continuing with the ones already loaded",
+				"error", err)
 		}
 		newDBs = append(newDBs, n)
 	}
@@ -50,9 +49,6 @@ func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
 		return MultiIPDB{}, err
 	}
 	keep = true
-	if !changed { // nothing moved, so the group says so as its databases did
-		return group, ErrBlocklistUnchanged
-	}
 	return group, nil
 }
 

--- a/ip-db-multi.go
+++ b/ip-db-multi.go
@@ -18,13 +18,10 @@ func NewMultiIPDB(dbs ...IPBlocklistDB) (MultiIPDB, error) {
 
 func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
 	// A list that could not be read hands back the rules it already has while
-	// the lists beside it refresh, so the group is rebuilt whole either way.
-	// A database that cannot even do that leaves the group as it is.
-	// The databases it is rebuilt from are new instances, which is what lets
+	// the lists beside it refresh. Those are new instances, which is what lets
 	// the group they came from be closed once this one is in place.
 	newDBs := make([]IPBlocklistDB, 0, len(m.dbs))
-	// Every way out of here but the last one leaves the group unbuilt, and the
-	// databases gathered for it are then nobody's to close but ours.
+	// Until the group is built, what was gathered for it is ours to close.
 	keep := false
 	defer func() {
 		if !keep {

--- a/ip-db-multi.go
+++ b/ip-db-multi.go
@@ -18,11 +18,10 @@ func NewMultiIPDB(dbs ...IPBlocklistDB) (MultiIPDB, error) {
 }
 
 func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
-	// A list that could not be read keeps the rules it already has while the
-	// lists beside it still refresh. Unlike the name-based group, this one
-	// closes its databases when it is replaced, so a database that reported
-	// nothing to change is carried across as a copy that owns whatever it
-	// holds rather than as the instance the old group is about to close.
+	// A list that could not be read hands back the rules it already has while
+	// the lists beside it refresh, so the group is rebuilt whole either way.
+	// The databases it is rebuilt from are new instances, which is what lets
+	// the group they came from be closed once this one is in place.
 	newDBs := make([]IPBlocklistDB, 0, len(m.dbs))
 	// Every way out of here but the last one leaves the group unbuilt, and the
 	// databases gathered for it are then nobody's to close but ours.
@@ -38,14 +37,7 @@ func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
 	for _, db := range m.dbs {
 		n, err := db.Reload()
 		switch {
-		case errors.Is(err, ErrBlocklistUnchanged):
-			r, ok := db.(reusableIPDB)
-			if !ok {
-				return MultiIPDB{}, err
-			}
-			if n, err = r.reuse(); err != nil {
-				return MultiIPDB{}, err
-			}
+		case errors.Is(err, ErrBlocklistUnchanged): // n holds the rules it had
 		case err != nil:
 			return MultiIPDB{}, err
 		default:
@@ -53,22 +45,15 @@ func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
 		}
 		newDBs = append(newDBs, n)
 	}
-	if !changed { // nothing moved, so there is nothing to swap in
-		return MultiIPDB{}, ErrBlocklistUnchanged
-	}
 	group, err := NewMultiIPDB(newDBs...)
 	if err != nil {
 		return MultiIPDB{}, err
 	}
 	keep = true
+	if !changed { // nothing moved, so the group says so as its databases did
+		return group, ErrBlocklistUnchanged
+	}
 	return group, nil
-}
-
-// An IP database that can produce an equivalent of itself, holding the same
-// rules but owning whatever needs closing, so that it can be carried into a
-// new group while the group it came from is closed.
-type reusableIPDB interface {
-	reuse() (IPBlocklistDB, error)
 }
 
 func (m MultiIPDB) Match(ip net.IP) (*BlocklistMatch, bool) {

--- a/ip-db-multi.go
+++ b/ip-db-multi.go
@@ -17,10 +17,22 @@ func NewMultiIPDB(dbs ...IPBlocklistDB) (MultiIPDB, error) {
 }
 
 func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
-	var newDBs []IPBlocklistDB
+	// Unlike the name-based group, this one owns its databases and closes them
+	// when it is replaced, so a database that reported nothing to change
+	// cannot be carried into the new group: the old group would close it out
+	// from under the new one. The whole group therefore keeps what it has
+	// until every list in it can be read again, and the ones already rebuilt
+	// are closed rather than dropped on the floor.
+	newDBs := make([]IPBlocklistDB, 0, len(m.dbs))
+	closeAll := func() {
+		for _, db := range newDBs {
+			db.Close()
+		}
+	}
 	for _, db := range m.dbs {
 		n, err := db.Reload()
 		if err != nil {
+			closeAll()
 			return MultiIPDB{}, err
 		}
 		newDBs = append(newDBs, n)

--- a/ip-db-multi.go
+++ b/ip-db-multi.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"errors"
 	"net"
 )
 
@@ -17,27 +18,49 @@ func NewMultiIPDB(dbs ...IPBlocklistDB) (MultiIPDB, error) {
 }
 
 func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
-	// Unlike the name-based group, this one owns its databases and closes them
-	// when it is replaced, so a database that reported nothing to change
-	// cannot be carried into the new group: the old group would close it out
-	// from under the new one. The whole group therefore keeps what it has
-	// until every list in it can be read again, and the ones already rebuilt
-	// are closed rather than dropped on the floor.
+	// A list that could not be read keeps the rules it already has while the
+	// lists beside it still refresh. Unlike the name-based group, this one
+	// closes its databases when it is replaced, so a database that reported
+	// nothing to change is carried across as a copy that owns whatever it
+	// holds rather than as the instance the old group is about to close.
 	newDBs := make([]IPBlocklistDB, 0, len(m.dbs))
 	closeAll := func() {
 		for _, db := range newDBs {
 			db.Close()
 		}
 	}
+	unchanged := 0
 	for _, db := range m.dbs {
 		n, err := db.Reload()
-		if err != nil {
+		if errors.Is(err, errBlocklistUnchanged) {
+			r, ok := db.(reusableIPDB)
+			if !ok {
+				closeAll()
+				return MultiIPDB{}, err
+			}
+			if n, err = r.reuse(); err != nil {
+				closeAll()
+				return MultiIPDB{}, err
+			}
+			unchanged++
+		} else if err != nil {
 			closeAll()
 			return MultiIPDB{}, err
 		}
 		newDBs = append(newDBs, n)
 	}
+	if unchanged == len(m.dbs) { // nothing moved, so there is nothing to swap in
+		closeAll()
+		return MultiIPDB{}, errBlocklistUnchanged
+	}
 	return NewMultiIPDB(newDBs...)
+}
+
+// An IP database that can produce an equivalent of itself, holding the same
+// rules but owning whatever needs closing, so that it can be carried into a
+// new group while the group it came from is closed.
+type reusableIPDB interface {
+	reuse() (IPBlocklistDB, error)
 }
 
 func (m MultiIPDB) Match(ip net.IP) (*BlocklistMatch, bool) {

--- a/ip-db-multi.go
+++ b/ip-db-multi.go
@@ -24,36 +24,44 @@ func (m MultiIPDB) Reload() (IPBlocklistDB, error) {
 	// nothing to change is carried across as a copy that owns whatever it
 	// holds rather than as the instance the old group is about to close.
 	newDBs := make([]IPBlocklistDB, 0, len(m.dbs))
-	closeAll := func() {
-		for _, db := range newDBs {
-			db.Close()
+	// Every way out of here but the last one leaves the group unbuilt, and the
+	// databases gathered for it are then nobody's to close but ours.
+	keep := false
+	defer func() {
+		if !keep {
+			for _, db := range newDBs {
+				db.Close()
+			}
 		}
-	}
-	unchanged := 0
+	}()
+	changed := false
 	for _, db := range m.dbs {
 		n, err := db.Reload()
-		if errors.Is(err, ErrBlocklistUnchanged) {
+		switch {
+		case errors.Is(err, ErrBlocklistUnchanged):
 			r, ok := db.(reusableIPDB)
 			if !ok {
-				closeAll()
 				return MultiIPDB{}, err
 			}
 			if n, err = r.reuse(); err != nil {
-				closeAll()
 				return MultiIPDB{}, err
 			}
-			unchanged++
-		} else if err != nil {
-			closeAll()
+		case err != nil:
 			return MultiIPDB{}, err
+		default:
+			changed = true
 		}
 		newDBs = append(newDBs, n)
 	}
-	if unchanged == len(m.dbs) { // nothing moved, so there is nothing to swap in
-		closeAll()
+	if !changed { // nothing moved, so there is nothing to swap in
 		return MultiIPDB{}, ErrBlocklistUnchanged
 	}
-	return NewMultiIPDB(newDBs...)
+	group, err := NewMultiIPDB(newDBs...)
+	if err != nil {
+		return MultiIPDB{}, err
+	}
+	keep = true
+	return group, nil
 }
 
 // An IP database that can produce an equivalent of itself, holding the same

--- a/mac-db.go
+++ b/mac-db.go
@@ -26,7 +26,7 @@ func NewMACDB(name string, loader BlocklistLoader) (*MACDB, error) {
 		name:   name,
 		loader: loader,
 	}
-	err := loadRules(loader, func() { db.macs = nil }, func(r string) error {
+	err := loader.Load(func() { db.macs = nil }, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
 			return nil

--- a/mac-db.go
+++ b/mac-db.go
@@ -22,25 +22,24 @@ var _ BlocklistDB = &MACDB{}
 
 // NewMACDB returns a new instance of a matcher for a list of MAC addresses.
 func NewMACDB(name string, loader BlocklistLoader) (*MACDB, error) {
-	rules, err := loader.Load()
-	if err != nil {
-		return nil, err
-	}
 	db := &MACDB{
 		name:   name,
-		macs:   make([][]byte, 0, len(rules)),
 		loader: loader,
 	}
-	for _, r := range rules {
+	err := loadRules(loader, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
-			continue
+			return nil
 		}
 		mac, err := parseMAC(r)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		db.macs = append(db.macs, mac)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return db, nil
 }

--- a/mac-db.go
+++ b/mac-db.go
@@ -88,10 +88,6 @@ func (m *MACDB) Match(msg *dns.Msg) ([]net.IP, []string, *BlocklistMatch, bool) 
 	return nil, nil, nil, false
 }
 
-func (m *MACDB) Close() error {
-	return nil
-}
-
 func (m *MACDB) String() string {
 	return "MAC-blocklist"
 }

--- a/mac-db.go
+++ b/mac-db.go
@@ -26,7 +26,7 @@ func NewMACDB(name string, loader BlocklistLoader) (*MACDB, error) {
 		name:   name,
 		loader: loader,
 	}
-	err := loadRules(loader, func(r string) error {
+	err := loadRules(loader, func() { db.macs = nil }, func(r string) error {
 		r = strings.TrimSpace(r)
 		if strings.HasPrefix(r, "#") || r == "" {
 			return nil

--- a/response-blocklist-ip.go
+++ b/response-blocklist-ip.go
@@ -13,6 +13,11 @@ import (
 
 // IPBlocklistDB is a database containing IPs used in blocklists.
 type IPBlocklistDB interface {
+	// Reload builds a new instance of the same database with a freshly loaded
+	// ruleset. It hands one back even when it reports ErrBlocklistUnchanged,
+	// holding the rules already loaded, so that a caller always has a database
+	// to put where this one was. Whichever it gets is a new instance owning
+	// whatever it holds, so closing the one it replaces never disturbs it.
 	Reload() (IPBlocklistDB, error)
 	Match(ip net.IP) (*BlocklistMatch, bool)
 	Close() error

--- a/response-blocklist-ip.go
+++ b/response-blocklist-ip.go
@@ -15,8 +15,9 @@ import (
 type IPBlocklistDB interface {
 	// Reload builds a new instance with a freshly loaded ruleset. A list that
 	// could not be read is an error, and the database handed back with it
-	// holds the rules already loaded. Either way it is a new instance owning
-	// what it holds, so closing the one it replaces never disturbs it.
+	// holds the rules already loaded, or is nil when it cannot hold them at
+	// all. Either way it is a new instance owning what it holds, so closing
+	// the one it replaces never disturbs it.
 	Reload() (IPBlocklistDB, error)
 	Match(ip net.IP) (*BlocklistMatch, bool)
 	Close() error

--- a/response-blocklist-ip.go
+++ b/response-blocklist-ip.go
@@ -13,12 +13,10 @@ import (
 
 // IPBlocklistDB is a database containing IPs used in blocklists.
 type IPBlocklistDB interface {
-	// Reload builds a new instance of the same database with a freshly loaded
-	// ruleset. A list that could not be read is an error, and the database
-	// handed back with it holds the rules already loaded, so that a caller
-	// always has one to put where this one was. Whichever it gets is a new
-	// instance owning whatever it holds, so closing the one it replaces never
-	// disturbs it.
+	// Reload builds a new instance with a freshly loaded ruleset. A list that
+	// could not be read is an error, and the database handed back with it
+	// holds the rules already loaded. Either way it is a new instance owning
+	// what it holds, so closing the one it replaces never disturbs it.
 	Reload() (IPBlocklistDB, error)
 	Match(ip net.IP) (*BlocklistMatch, bool)
 	Close() error

--- a/response-blocklist-ip.go
+++ b/response-blocklist-ip.go
@@ -14,10 +14,11 @@ import (
 // IPBlocklistDB is a database containing IPs used in blocklists.
 type IPBlocklistDB interface {
 	// Reload builds a new instance of the same database with a freshly loaded
-	// ruleset. It hands one back even when it reports ErrBlocklistUnchanged,
-	// holding the rules already loaded, so that a caller always has a database
-	// to put where this one was. Whichever it gets is a new instance owning
-	// whatever it holds, so closing the one it replaces never disturbs it.
+	// ruleset. A list that could not be read is an error, and the database
+	// handed back with it holds the rules already loaded, so that a caller
+	// always has one to put where this one was. Whichever it gets is a new
+	// instance owning whatever it holds, so closing the one it replaces never
+	// disturbs it.
 	Reload() (IPBlocklistDB, error)
 	Match(ip net.IP) (*BlocklistMatch, bool)
 	Close() error


### PR DESCRIPTION
A loader reads its whole list into a slice of strings and hands that over. For
a two million rule list that is 82 MB of strings, and 110 MB at the moment the
slice itself grows, all to build a database of 17 MB. On the machines these
lists are aimed at, the peak during a refresh is what runs the process out of
memory, not the database it produces.

Loaders that can pass their rules on one at a time now do so, and every
database in the tree reads through one helper:

```go
func loadRules(loader BlocklistLoader, fn func(rule string) error) error
```

`BlocklistLoader` itself is unchanged. The streaming method sits on an
unexported interface, and `loadRules` falls back to `Load()` for anything that
does not implement it, so a loader written outside the package keeps working
exactly as it did.

### Measured

A 2 million rule list, loading and building together:

| | peak | retained |
| --- | --- | --- |
| compact domain list | 164 -> 55 MB | 16.7 MB, unchanged |
| exact domain list | 249 -> 167 MB | 72.3 MB, unchanged |

Builds are about a fifth slower. That is the garbage a line at a time makes
rather than the loss of a rule count to size the buffers by: pre-sizing them as
before, with the count supplied by hand, recovers none of it, so there is no
size hint to add.

### A callback rather than an iterator

The databases already push rules into a builder, so a callback is the shape
they want. An iterator would also mean each of the eight consumers holding the
error from its own loop body in a captured variable, since a `range` body
cannot return one to the producer, and then checking a second error afterwards
for the read itself. A `Seq2[string, error]` avoids the captured variable at
the cost of a nil check on every rule for an error that is only ever terminal.

### Cache and failure handling

The HTTP loader writes its cache file as the body arrives rather than keeping
the rules to write afterwards. A download that fails part way through still
leaves the previous cache in place, through the temporary file that is only
renamed on success. It falls back from a cached copy to the network only while
no rule has been passed on yet, since the ones already handed over cannot be
taken back.

`AllowFailure` no longer keeps a copy of the rules to replay. A list that has
never loaded starts empty, as it did, and one that has loaded before reports
`errBlocklistUnchanged`, which the refresh loop takes as leave the database
alone. That is the same outcome as rebuilding an identical database from a kept
copy, without the copy or the rebuild. A rule the database rejects is kept
distinct from a list that cannot be read, so a malformed rule still fails the
load rather than being taken for an unavailable list.

### Tests

The loader tests now go through a real HTTP server and the public entry points
rather than calling the cache helpers directly: a list cached as it downloads,
a second loader picking it up from disk, a shorter list not leaving the tail of
a longer one behind, a failed download leaving the cache intact, and both
AllowFailure paths.