### PR TITLE
Hold the CIDR blocklist in one flat array

### DIFF
--- a/cidr-db.go
+++ b/cidr-db.go
@@ -53,6 +53,8 @@ func NewCidrDB(name string, loader BlocklistLoader) (*CidrDB, error) {
 	if err != nil {
 		return nil, err
 	}
+	db.ip4.compact()
+	db.ip6.compact()
 	return db, nil
 }
 

--- a/ip-blocklist-trie.go
+++ b/ip-blocklist-trie.go
@@ -59,15 +59,20 @@ func (t *ipBlocklistTrie) add(n *net.IPNet) {
 	t.nodes[p].child = [2]uint32{ipBlocklistLeaf, 0}
 }
 
-// compact returns the trie holding only the nodes still reachable from the
-// root, in the order a lookup walks them. A network added after one that
-// already covers it leaves whatever was built below it unreachable, and a
-// build that grew by doubling holds an array up to twice the size it needs.
+// compact rebuilds the trie with only the nodes still reachable from the root,
+// in the order a lookup walks them. A network added after one that already
+// covers it leaves whatever was built below it unreachable, and a build that
+// grew by doubling holds an array up to twice the size it needs.
+//
+// The nodes are counted before they are copied so that the array is exactly
+// the size of what it holds. Sizing it from the trie being replaced would keep
+// that array alive behind the shorter slice, which is the memory this exists to
+// give back, and would hold both in full while it ran.
 func (t *ipBlocklistTrie) compact() {
 	if len(t.nodes) == 0 {
 		return
 	}
-	nodes := make([]ipBlocklistNode, 1, len(t.nodes))
+	nodes := make([]ipBlocklistNode, 1, t.reachable(0))
 	var walk func(from, to uint32)
 	walk = func(from, to uint32) {
 		if t.nodes[from].leaf() {
@@ -86,6 +91,21 @@ func (t *ipBlocklistTrie) compact() {
 	}
 	walk(0, 0)
 	t.nodes = nodes
+}
+
+// reachable counts the nodes a lookup can still arrive at from the given one,
+// itself included. Every node has one parent, so nothing is counted twice.
+func (t *ipBlocklistTrie) reachable(from uint32) int {
+	if t.nodes[from].leaf() {
+		return 1
+	}
+	n := 1
+	for _, c := range t.nodes[from].child {
+		if c != 0 {
+			n += t.reachable(c)
+		}
+	}
+	return n
 }
 
 // Returns true and the string representation of the network covering

--- a/ip-blocklist-trie.go
+++ b/ip-blocklist-trie.go
@@ -7,76 +7,108 @@ import "net"
 // ideas from routing table implementations as described in
 // https://vincent.bernat.ch/en/blog/2017-ipv4-route-lookup-linux, it differs
 // in that it looks for the shortest prefix (biggest network match) since
-// it's sufficient to know if an IP is covered by one of the networks
+// it's sufficient to know if an IP is covered by one of the networks.
+//
+// The tree sits in one flat array, a node naming its children by index rather
+// than by pointer, so a list of any size costs the collector one object to mark
+// rather than one per node.
 type ipBlocklistTrie struct {
-	root *ipBlocklistNode
+	nodes []ipBlocklistNode
 }
 
+// A node holds the node under each of the two values the bit at its depth can
+// take. Index 0 is the root, which is nobody's child, so a zero means there is
+// nothing under that bit.
+//
+// A leaf is the end of a network on the list. Nothing below it can matter,
+// since a longer prefix inside a network already covered adds nothing, so a
+// leaf has no children and says so in the slot a child index would have used.
 type ipBlocklistNode struct {
-	left, right *ipBlocklistNode
-	leaf        bool
+	child [2]uint32
 }
+
+// Marks a node as the end of a network. Reserved as a child index, which costs
+// the last of the four billion nodes a trie could otherwise hold.
+const ipBlocklistLeaf = ^uint32(0)
+
+func (n ipBlocklistNode) leaf() bool { return n.child[0] == ipBlocklistLeaf }
 
 // Add a network to the trie.
 func (t *ipBlocklistTrie) add(n *net.IPNet) {
-	if t.root == nil {
-		t.root = new(ipBlocklistNode)
+	if len(t.nodes) == 0 {
+		t.nodes = make([]ipBlocklistNode, 1) // node 0 is the root
 	}
 	prefix, _ := n.Mask.Size()
-	p := t.root
+	p := uint32(0)
 	for i := range prefix {
-		if p.leaf { // stop if we already have a shorter prefix than this
+		if t.nodes[p].leaf() { // stop if we already have a shorter prefix than this
 			break
 		}
 		b := bit(n.IP, i)
-		if b == 1 {
-			if p.right == nil {
-				p.right = new(ipBlocklistNode)
-			}
-			p = p.right
-		} else {
-			if p.left == nil {
-				p.left = new(ipBlocklistNode)
-			}
-			p = p.left
+		if t.nodes[p].child[b] == 0 {
+			t.nodes = append(t.nodes, ipBlocklistNode{})
+			t.nodes[p].child[b] = uint32(len(t.nodes) - 1)
 		}
+		p = t.nodes[p].child[b]
 	}
 
-	// Mark this as the leaf-node. We care about the shortest prefix
-	// so nothing should go past this when building the trie
-	p.left = nil
-	p.right = nil
-	p.leaf = true
+	// Mark this as the leaf-node. We care about the shortest prefix so nothing
+	// should go past this when building the trie. Anything already below it is
+	// let go of here rather than removed, and compact() drops it at the end of
+	// the build.
+	t.nodes[p].child = [2]uint32{ipBlocklistLeaf, 0}
+}
+
+// compact returns the trie holding only the nodes still reachable from the
+// root, in the order a lookup walks them. A network added after one that
+// already covers it leaves whatever was built below it unreachable, and a
+// build that grew by doubling holds an array up to twice the size it needs.
+func (t *ipBlocklistTrie) compact() {
+	if len(t.nodes) == 0 {
+		return
+	}
+	nodes := make([]ipBlocklistNode, 1, len(t.nodes))
+	var walk func(from, to uint32)
+	walk = func(from, to uint32) {
+		if t.nodes[from].leaf() {
+			nodes[to].child = [2]uint32{ipBlocklistLeaf, 0}
+			return
+		}
+		for b, c := range t.nodes[from].child {
+			if c == 0 {
+				continue
+			}
+			nodes = append(nodes, ipBlocklistNode{})
+			id := uint32(len(nodes) - 1)
+			nodes[to].child[b] = id
+			walk(c, id)
+		}
+	}
+	walk(0, 0)
+	t.nodes = nodes
 }
 
 // Returns true and the string representation of the network covering
 // the IP.
 func (t *ipBlocklistTrie) hasIP(ip net.IP) (string, bool) {
-	if t.root == nil {
+	if len(t.nodes) == 0 {
 		return "", false
 	}
-	p := t.root
 	size := 32
 	if addr := ip.To4(); addr == nil {
 		size = 128
 	} else {
 		ip = addr // make sure we use the 4-byte representation of an IPv4
 	}
+	p := uint32(0)
 	for i := 0; i < size; i++ {
-		if p.leaf {
+		n := t.nodes[p]
+		if n.leaf() {
 			return ruleString(ip, i), true
 		}
-		b := bit(ip, i)
-		if b == 1 {
-			if p.right == nil {
-				return "", false
-			}
-			p = p.right
-		} else {
-			if p.left == nil {
-				return "", false
-			}
-			p = p.left
+		p = n.child[bit(ip, i)]
+		if p == 0 {
+			return "", false
 		}
 	}
 	return ruleString(ip, size), true
@@ -95,23 +127,7 @@ func ruleString(ip net.IP, maskBits int) string {
 	return ipNet.String()
 }
 
-var bitMask = []byte{
-	128,
-	64,
-	32,
-	16,
-	8,
-	4,
-	2,
-	1,
-}
-
 // Returns n'th bit from an IP address from the left.
 func bit(ip net.IP, n int) int {
-	byteIndex := n / 8
-	bitIndex := n % 8
-	if (ip[byteIndex] & bitMask[bitIndex]) == 0 {
-		return 0
-	}
-	return 1
+	return int(ip[n/8]>>(7-n%8)) & 1
 }

--- a/ip-blocklist-trie_test.go
+++ b/ip-blocklist-trie_test.go
@@ -1,0 +1,110 @@
+package rdns
+
+import (
+	"math/rand"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func mustCIDR(t *testing.T, s string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(s)
+	require.NoError(t, err)
+	return n
+}
+
+// The biggest network covering an address is the one reported, whichever order
+// the networks arrived in. A longer prefix inside one already on the list adds
+// nothing, so it never becomes a rule of its own.
+func TestIPBlocklistTrieShortestPrefix(t *testing.T) {
+	for _, order := range [][]string{
+		{"1.2.3.0/24", "1.2.0.0/16"},
+		{"1.2.0.0/16", "1.2.3.0/24"},
+	} {
+		var tr ipBlocklistTrie
+		for _, s := range order {
+			tr.add(mustCIDR(t, s))
+		}
+		rule, ok := tr.hasIP(net.ParseIP("1.2.3.4"))
+		require.True(t, ok, "order: %v", order)
+		require.Equal(t, "1.2.0.0/16", rule, "order: %v", order)
+
+		rule, ok = tr.hasIP(net.ParseIP("1.3.0.1"))
+		require.False(t, ok, "order: %v", order)
+		require.Empty(t, rule, "order: %v", order)
+	}
+}
+
+// A default route covers everything, and is the one case where the root itself
+// carries the rule.
+func TestIPBlocklistTrieDefaultRoute(t *testing.T) {
+	var v4, v6 ipBlocklistTrie
+	v4.add(mustCIDR(t, "0.0.0.0/0"))
+	v6.add(mustCIDR(t, "::/0"))
+
+	rule, ok := v4.hasIP(net.ParseIP("8.8.8.8"))
+	require.True(t, ok)
+	require.Equal(t, "0.0.0.0/0", rule)
+
+	rule, ok = v6.hasIP(net.ParseIP("2001:db8::1"))
+	require.True(t, ok)
+	require.Equal(t, "::/0", rule)
+}
+
+func TestIPBlocklistTrieEmpty(t *testing.T) {
+	var tr ipBlocklistTrie
+	tr.compact() // nothing to walk
+	_, ok := tr.hasIP(net.ParseIP("1.2.3.4"))
+	require.False(t, ok)
+}
+
+// compact drops what a network added over one already covering it left behind,
+// and answers every address exactly as the trie did before it ran.
+func TestIPBlocklistTrieCompact(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	randomIP := func() net.IP {
+		return net.IPv4(byte(rng.Intn(256)), byte(rng.Intn(256)), byte(rng.Intn(256)), byte(rng.Intn(256)))
+	}
+
+	var tr ipBlocklistTrie
+	var nets []*net.IPNet
+	for range 2000 {
+		ip := randomIP().To4()
+		mask := net.CIDRMask(16+rng.Intn(17), 32)
+		n := &net.IPNet{IP: ip.Mask(mask), Mask: mask}
+		nets = append(nets, n)
+		tr.add(n)
+	}
+	// Supernets of a tenth of them, added last, so the nodes below each one are
+	// left unreachable.
+	for _, n := range nets[:200] {
+		mask := net.CIDRMask(8, 32)
+		tr.add(&net.IPNet{IP: n.IP.Mask(mask), Mask: mask})
+	}
+
+	probes := make([]net.IP, 0, 20000)
+	for range 20000 {
+		probes = append(probes, randomIP())
+	}
+	type verdict struct {
+		rule string
+		ok   bool
+	}
+	before := make([]verdict, 0, len(probes))
+	for _, ip := range probes {
+		rule, ok := tr.hasIP(ip)
+		before = append(before, verdict{rule, ok})
+	}
+
+	nodesBefore := len(tr.nodes)
+	tr.compact()
+	require.Less(t, len(tr.nodes), nodesBefore, "compact dropped nothing")
+
+	for i, ip := range probes {
+		rule, ok := tr.hasIP(ip)
+		require.Equal(t, before[i].ok, ok, "ip: %v", ip)
+		require.Equal(t, before[i].rule, rule, "ip: %v", ip)
+	}
+}

--- a/ip-blocklist-trie_test.go
+++ b/ip-blocklist-trie_test.go
@@ -101,6 +101,9 @@ func TestIPBlocklistTrieCompact(t *testing.T) {
 	nodesBefore := len(tr.nodes)
 	tr.compact()
 	require.Less(t, len(tr.nodes), nodesBefore, "compact dropped nothing")
+	// The array is the memory, not the length: sizing it from the trie being
+	// replaced would keep every dropped node resident behind the shorter slice.
+	require.Equal(t, len(tr.nodes), cap(tr.nodes), "compact kept the array it dropped nodes from")
 
 	for i, ip := range probes {
 		rule, ok := tr.hasIP(ip)


### PR DESCRIPTION
The IP blocklist keeps a binary trie of address bits, and every node of it was a pair of pointers and a bool: 24 bytes, of which 16 are pointers the collector follows on every cycle. A hundred thousand networks come to about two hundred thousand nodes, since a trie with n leaves carries roughly 2n nodes, so the structure cost 4.8 MB and made a collection ten times more expensive than an empty heap.

A node is now a pair of child indices into one array, 8 bytes with nothing in it to follow, which is the shape the domain blocklist moved to in #646. The walk is unchanged, bit by bit from the most significant, and index 0 is the root, which is nobody's child, so a zero index still means there is nothing under that bit. A leaf says so in the slot a child index would have used.

Measured on a hundred thousand `/24` networks:

| | before | after |
| --- | ---: | ---: |
| held | 4.80 MB (48.0 B/rule) | 1.61 MB (16.1 B/rule) |
| GC CPU per cycle | 13.8 ms | 3.1 ms |
| lookup, miss | 13.5 ns | 11.6 ns |
| lookup, hit | 230 ns | unchanged within noise |

3.1 ms is the empty-heap baseline on the same machine, so a list of this size now costs the collector nothing. A hit is dominated by building the rule string, which is three allocations either way and unchanged here.

Adding a network over one already on the list leaves what was built below it unreachable. The pointer trie let the collector take those nodes back; an array cannot, so `compact()` rebuilds it from the root once the list is read, keeping the nodes a lookup can still reach and laying them out in the order it walks them. It matters more than it sounds: a list where a twentieth of the entries are covered by a later supernet built 464,634 nodes and kept 46,274, which is 4.32 MB down to 0.38 MB.

The nodes are counted before they are copied so that the array is the size of what it holds. Sizing it from the trie being replaced, as the first commit here did, leaves every dropped node resident behind the shorter slice: the length shrinks and the allocation does not, so that same list held 3.72 MB for its 46,274 live nodes. It was worst exactly where compaction has most to do.

Every verdict was compared against the pointer trie over 2.4 million lookups drawn from three lists, random addresses and addresses taken from the networks themselves, agreeing on the rule string as well as on the match. The bit accessor loses its lookup table for a shift, checked over all 256 byte values at all 128 positions.

The tests that ship encode the behaviour rather than carrying a second implementation: that the biggest covering network is the one reported whichever order the networks arrived in, that a default route is answered from the root, and that `compact` drops nodes while answering every address exactly as it did before it ran.
