### PR TITLE
Notify readiness to systemd

### DIFF
--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	syslog "github.com/RackSec/srslog"
+	"github.com/coreos/go-systemd/v22/daemon"
 	rdns "github.com/folbricht/routedns"
 	"github.com/heimdalr/dag"
 	"github.com/redis/go-redis/v9"
@@ -549,6 +550,14 @@ func run(opt options, args []string) error {
 			continue
 		}
 		go superviseNetNSListener(pl.id, pl.nsName, pl.build)
+	}
+
+	// Notify Systemd that we are done starting, i.e. the listeners are up.
+	// This is a no-op unless $NOTIFY_SOCKET is set.
+	_, err = daemon.SdNotify(false, daemon.SdNotifyReady)
+	if err != nil {
+		rdns.Log.Error("daemon notification failed", "error", err)
+		// carry on
 	}
 
 	// Graceful shutdown

--- a/cmd/routedns/routedns.service
+++ b/cmd/routedns/routedns.service
@@ -3,7 +3,7 @@ Description=RouteDNS - DNS stub resolver and router
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
 DynamicUser=true
 NoNewPrivileges=true
 WorkingDirectory=/opt/routedns

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91
 	github.com/cisco/go-hpke v0.0.0-20230407100446-246075f83609
 	github.com/cloudflare/odoh-go v1.0.1-0.20230926114050-f39fa019b017
+	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/heimdalr/dag v1.5.1
 	github.com/jtacoma/uritemplates v1.0.0
 	github.com/miekg/dns v1.1.72

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64
 github.com/cloudflare/circl v1.6.4/go.mod h1:YxarevkLlbaHuWsxG6vmYNWBEsSp4pnp7j+4VljMavY=
 github.com/cloudflare/odoh-go v1.0.1-0.20230926114050-f39fa019b017 h1:KRDWKVEQ1mNK3BbNeZDNEQQ81ifDmHRrPSXN0yg+aY8=
 github.com/cloudflare/odoh-go v1.0.1-0.20230926114050-f39fa019b017/go.mod h1:Gmzq8ufk4mojTuM6miLvqYryFQO9wf96bv67HpkZrZo=
+github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
+github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/packaging/routedns.service
+++ b/packaging/routedns.service
@@ -3,7 +3,7 @@ Description=RouteDNS - DNS stub resolver and router
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
 DynamicUser=true
 NoNewPrivileges=true
 


### PR DESCRIPTION
On Linux, systemd supports an IPC protocol that allows daemons to signal to PID 1 that they have finished starting up. (See [`sd_notify(3)`](https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html)) This PR uses a pure-Go implementation to bring this functionality to routedns.

This is useful because this way, systemd units that specify `After=routedns.service` will be guaranteed that routedns is listening on its sockets. Otherwise there is a race condition which I ran into. (In a slightly unusual set up, i.e. I run a NixOS deployment and many systemd units including routedns and wireguard setup units that need DNS resolution restart in the same transaction)

The code is no-op in existing setups that don't explicitly enable the feature.