### PR TITLE
Tighten readiness synchronization

### DIFF
--- a/adminlistener.go
+++ b/adminlistener.go
@@ -98,6 +98,7 @@ func (s *AdminListener) startTCP() error {
 		return err
 	}
 	defer ln.Close()
+	s.opt.notifyStarted()
 	return httpServer.ServeTLS(ln, "", "")
 }
 

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	syslog "github.com/RackSec/srslog"
+	"github.com/coreos/go-systemd/v22/daemon"
 	rdns "github.com/folbricht/routedns"
 	"github.com/heimdalr/dag"
 	"github.com/redis/go-redis/v9"
@@ -549,6 +550,14 @@ func run(opt options, args []string) error {
 			continue
 		}
 		go superviseNetNSListener(pl.id, pl.nsName, pl.build)
+	}
+
+	// Notify Systemd that we are done starting, i.e. the listeners are up.
+	// This is a no-op unless $NOTIFY_SOCKET is set.
+	_, err = daemon.SdNotify(false, daemon.SdNotifyReady)
+	if err != nil {
+		rdns.Log.Error("daemon notification failed", "error", err)
+		// carry on
 	}
 
 	// Graceful shutdown

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"slices"
 	"strconv"
+	"sync"
 	"syscall"
 	"time"
 
@@ -358,6 +359,7 @@ func run(opt options, args []string) error {
 
 	// Build the Listeners last as they can point to routers, groups or resolvers directly.
 	var listeners []pendingListener
+	var wg sync.WaitGroup
 	for id, l := range config.Listeners {
 		resolver, ok := resolvers[l.Resolver]
 		// All Listeners should route queries (except the admin service).
@@ -384,9 +386,10 @@ func run(opt options, args []string) error {
 		}
 
 		opt := rdns.ListenOptions{
-			AllowedNet:    allowedNet,
-			NetNS:         netns,
-			SocketOptions: rdns.SocketOptions{FWMark: l.FWMark, BindInterface: l.BindInterface},
+			AllowedNet:        allowedNet,
+			NetNS:             netns,
+			SocketOptions:     rdns.SocketOptions{FWMark: l.FWMark, BindInterface: l.BindInterface},
+			NotifyStartedFunc: wg.Done,
 		}
 
 		var build func() (rdns.Listener, error)
@@ -507,6 +510,7 @@ func run(opt options, args []string) error {
 		}
 		pl := pendingListener{id: id, nsName: nsName, build: build}
 		if pl.nsName == "" {
+			wg.Add(1)
 			pl.ln, err = build()
 			if err != nil {
 				return err
@@ -554,6 +558,7 @@ func run(opt options, args []string) error {
 
 	// Notify Systemd that we are done starting, i.e. the listeners are up.
 	// This is a no-op unless $NOTIFY_SOCKET is set.
+	wg.Wait()
 	_, err = daemon.SdNotify(false, daemon.SdNotifyReady)
 	if err != nil {
 		rdns.Log.Error("daemon notification failed", "error", err)

--- a/cmd/routedns/routedns.service
+++ b/cmd/routedns/routedns.service
@@ -3,7 +3,7 @@ Description=RouteDNS - DNS stub resolver and router
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
 DynamicUser=true
 NoNewPrivileges=true
 WorkingDirectory=/opt/routedns

--- a/dnslistener.go
+++ b/dnslistener.go
@@ -28,6 +28,8 @@ type ListenOptions struct {
 
 	// Linux socket options for fwmark and interface binding.
 	SocketOptions SocketOptions
+
+	NotifyStartedFunc func()
 }
 
 // NewDNSListener returns an instance of either a UDP or TCP DNS listener.
@@ -35,9 +37,10 @@ func NewDNSListener(id, addr, net string, opt ListenOptions, resolver Resolver) 
 	return &DNSListener{
 		id: id,
 		Server: &dns.Server{
-			Addr:    addr,
-			Net:     net,
-			Handler: listenHandler(id, net, addr, resolver, opt.AllowedNet),
+			Addr:              addr,
+			Net:               net,
+			Handler:           listenHandler(id, net, addr, resolver, opt.AllowedNet),
+			NotifyStartedFunc: opt.NotifyStartedFunc,
 		},
 		opt: opt,
 	}
@@ -78,6 +81,12 @@ func (s DNSListener) Stop() error {
 
 func (s DNSListener) String() string {
 	return s.id
+}
+
+func (opt *ListenOptions) notifyStarted() {
+	if opt.NotifyStartedFunc != nil {
+		opt.NotifyStartedFunc()
+	}
 }
 
 // DNS handler to forward all incoming requests to a given resolver.

--- a/dnslistener_test.go
+++ b/dnslistener_test.go
@@ -1,0 +1,155 @@
+package rdns
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockNotifier struct {
+	mock.Mock
+}
+
+// Used to mock  a NotifyStartedFunc
+func (m *mockNotifier) NotifyStarted() {
+	m.Called()
+}
+
+// NotifyStartedFunc is invoked once the ODoH listener is up, which is used by
+// the router to wait for all listeners before starting to serve.
+func testNotifyStartedFunc(t *testing.T, makeListener func(*testing.T, func()) Listener) {
+	started := make(chan struct{})
+	notifier := &mockNotifier{}
+	notifier.On("NotifyStarted").Once().Return().Run(func(mock.Arguments) {
+		close(started)
+	})
+
+	l := makeListener(t, notifier.NotifyStarted)
+
+	go l.Start()
+	defer l.Stop()
+	select {
+	case <-started:
+	case <-time.After(1 * time.Minute):
+		t.Fatal("timeout")
+	}
+
+	mock.AssertExpectationsForObjects(t, notifier)
+}
+
+func TestDNSListenerNotifyStartedFunc(t *testing.T) {
+	testNotifyStartedFunc(t,
+		func(t *testing.T, f func()) Listener {
+			addr, err := getLnAddress()
+			require.NoError(t, err)
+
+			return NewDNSListener("test-dns-notify-started-func", addr, "udp",
+				ListenOptions{NotifyStartedFunc: f},
+				new(TestResolver))
+		})
+}
+
+func TestAdminListenerNotifyStartedFunc(t *testing.T) {
+	testNotifyStartedFunc(t,
+		func(t *testing.T, f func()) Listener {
+			addr, err := getLnAddress()
+			require.NoError(t, err)
+
+			tlsServerConfig, err := TLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+			require.NoError(t, err)
+
+			l, err := NewAdminListener("test-admin-notify-started-func", addr, AdminListenerOptions{
+				ListenOptions: ListenOptions{NotifyStartedFunc: f},
+				TLSConfig:     tlsServerConfig,
+				Transport:     "tcp",
+			})
+			require.NoError(t, err)
+			return l
+		})
+}
+
+func TestDoHListenerNotifyStartedFunc(t *testing.T) {
+	testNotifyStartedFunc(t,
+		func(t *testing.T, f func()) Listener {
+			addr, err := getLnAddress()
+			require.NoError(t, err)
+
+			tlsServerConfig, err := TLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+			require.NoError(t, err)
+
+			l, err := NewDoHListener("test-doh-notify-started-func", addr, DoHListenerOptions{
+				ListenOptions: ListenOptions{NotifyStartedFunc: f},
+				TLSConfig:     tlsServerConfig,
+			}, new(TestResolver))
+			require.NoError(t, err)
+			return l
+		})
+}
+
+func TestDoQListenerNotifyStartedFunc(t *testing.T) {
+	testNotifyStartedFunc(t,
+		func(t *testing.T, f func()) Listener {
+			addr, err := getLnAddress()
+			require.NoError(t, err)
+
+			tlsServerConfig, err := TLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+			require.NoError(t, err)
+
+			return NewQUICListener("test-doq-notify-started-func", addr, DoQListenerOptions{
+				ListenOptions: ListenOptions{NotifyStartedFunc: f},
+				TLSConfig:     tlsServerConfig,
+			}, new(TestResolver))
+		})
+}
+
+func TestDoTListenerNotifyStartedFunc(t *testing.T) {
+	testNotifyStartedFunc(t,
+		func(t *testing.T, f func()) Listener {
+			addr, err := getLnAddress()
+			require.NoError(t, err)
+
+			tlsServerConfig, err := TLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+			require.NoError(t, err)
+
+			return NewDoTListener("test-dot-notify-started-func", addr, "tcp", DoTListenerOptions{
+				ListenOptions: ListenOptions{NotifyStartedFunc: f},
+				TLSConfig:     tlsServerConfig,
+			}, new(TestResolver))
+		})
+}
+
+func TestDTLSListenerNotifyStartedFunc(t *testing.T) {
+	testNotifyStartedFunc(t,
+		func(t *testing.T, f func()) Listener {
+			addr, err := getLnAddress()
+			require.NoError(t, err)
+
+			dtlsConfig, err := DTLSServerConfig("", "testdata/server.crt", "testdata/server.key", false, nil)
+			require.NoError(t, err)
+
+			return NewDTLSListener("test-dtls-notify-started-func", addr, DTLSListenerOptions{
+				ListenOptions: ListenOptions{NotifyStartedFunc: f},
+				DTLSConfig:    dtlsConfig,
+			}, new(TestResolver))
+		})
+}
+
+func TestODoHListenerNotifyStartedFunc(t *testing.T) {
+	testNotifyStartedFunc(t,
+		func(t *testing.T, f func()) Listener {
+			addr, err := getLnAddress()
+			require.NoError(t, err)
+
+			tlsServerConfig, err := TLSServerConfig("", "testdata/server.crt", "testdata/server.key", false)
+			require.NoError(t, err)
+
+			l, err := NewODoHListener("test-odoh-notify-started-func", addr, ODoHListenerOptions{
+				ListenOptions: ListenOptions{NotifyStartedFunc: f},
+				TLSConfig:     tlsServerConfig,
+			}, new(TestResolver))
+			require.NoError(t, err)
+			return l
+		})
+}

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -141,6 +141,7 @@ func (s *DoHListener) startTCP() error {
 		return err
 	}
 	defer ln.Close()
+	s.opt.notifyStarted()
 	if s.opt.NoTLS {
 		return httpServer.Serve(ln)
 	}

--- a/doqlistener.go
+++ b/doqlistener.go
@@ -106,6 +106,7 @@ func (s *DoQListener) Start() error {
 	s.ln = ln
 	s.mu.Unlock()
 	s.log.Info("starting listener")
+	s.opt.notifyStarted()
 
 	for {
 		connection, err := ln.Accept(context.Background())

--- a/dotlistener.go
+++ b/dotlistener.go
@@ -36,10 +36,11 @@ func NewDoTListener(id, addr, network string, opt DoTListenerOptions, resolver R
 	return &DoTListener{
 		id: id,
 		Server: &dns.Server{
-			Addr:      addr,
-			Net:       network,
-			TLSConfig: opt.TLSConfig,
-			Handler:   listenHandler(id, "dot", addr, resolver, opt.AllowedNet),
+			Addr:              addr,
+			Net:               network,
+			TLSConfig:         opt.TLSConfig,
+			Handler:           listenHandler(id, "dot", addr, resolver, opt.AllowedNet),
+			NotifyStartedFunc: opt.NotifyStartedFunc,
 		},
 		opt: opt,
 	}

--- a/dtlslistener.go
+++ b/dtlslistener.go
@@ -70,6 +70,7 @@ func (s *DTLSListener) Start() error {
 		return err
 	}
 	s.Server.Listener = dtlsListener{listener}
+	s.opt.notifyStarted()
 	return s.Server.ActivateAndServe()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/txthinking/runnergroup v0.0.0-20250224021307-5864ffeb65ae // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91
 	github.com/cisco/go-hpke v0.0.0-20230407100446-246075f83609
 	github.com/cloudflare/odoh-go v1.0.1-0.20230926114050-f39fa019b017
+	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/heimdalr/dag v1.5.1
 	github.com/jtacoma/uritemplates v1.0.0
 	github.com/miekg/dns v1.1.72

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64
 github.com/cloudflare/circl v1.6.4/go.mod h1:YxarevkLlbaHuWsxG6vmYNWBEsSp4pnp7j+4VljMavY=
 github.com/cloudflare/odoh-go v1.0.1-0.20230926114050-f39fa019b017 h1:KRDWKVEQ1mNK3BbNeZDNEQQ81ifDmHRrPSXN0yg+aY8=
 github.com/cloudflare/odoh-go v1.0.1-0.20230926114050-f39fa019b017/go.mod h1:Gmzq8ufk4mojTuM6miLvqYryFQO9wf96bv67HpkZrZo=
+github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
+github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/packaging/routedns.service
+++ b/packaging/routedns.service
@@ -3,7 +3,7 @@ Description=RouteDNS - DNS stub resolver and router
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
 DynamicUser=true
 NoNewPrivileges=true
 


### PR DESCRIPTION
followup to #651

This needs to be tested a bit more. I believe that ODOH listener works without modification because the option is picked up by the underlying DOH listener.